### PR TITLE
Add Upshift Brackets

### DIFF
--- a/FanaBridge/Adapters/DisplaySettings.cs
+++ b/FanaBridge/Adapters/DisplaySettings.cs
@@ -9,7 +9,7 @@ namespace FanaBridge.Adapters
         public const string DefaultMode = "Gear";
 
         /// <summary>
-        /// Display mode: "Gear", "Speed", or "GearAndSpeed".
+        /// Display mode: "Gear", "Speed", "GearAndSpeed", or "GearUpshiftBrackets".
         /// </summary>
         public string DisplayMode { get; set; } = DefaultMode;
     }

--- a/FanaBridge/Adapters/FanatecDisplayDriver.cs
+++ b/FanaBridge/Adapters/FanatecDisplayDriver.cs
@@ -30,11 +30,8 @@ namespace FanaBridge.Adapters
         private int _lastKnownGear = int.MinValue;
         private DateTime _gearOverlayUntil = DateTime.MinValue;
 
-        // GearUpshiftBrackets: flicker state
-        private static readonly TimeSpan FlickerInterval = TimeSpan.FromMilliseconds(250);
+        // GearUpshiftBrackets: bracket state
         private bool _lastBracketsShown;
-        private bool _flickerBracketsOn;
-        private DateTime _flickerToggleAt = DateTime.MinValue;
 
         public FanatecDisplayDriver(DisplayEncoder display, DisplaySettings settings)
         {
@@ -105,8 +102,6 @@ namespace FanaBridge.Adapters
             _lastKnownGear = int.MinValue;
             _gearOverlayUntil = DateTime.MinValue;
             _lastBracketsShown = false;
-            _flickerBracketsOn = false;
-            _flickerToggleAt = DateTime.MinValue;
         }
 
         // =====================================================================
@@ -188,29 +183,8 @@ namespace FanaBridge.Adapters
             string gearStr = data.NewData.Gear;
             int gear = ParseGear(gearStr);
 
-            // SimHub computes the shift-point percentage via its own RPM config.
-            // 1.0 = redline reached; values approaching 1.0 are used for the flicker zone.
-            double rpmPct = data.NewData.CarSettings_CurrentDisplayedRPMPercent;
-
-            bool showBrackets;
-
-            if (rpmPct >= 1.0)
-            {
-                // Redline reached: flicker brackets to signal upshift
-                DateTime now = DateTime.UtcNow;
-                if (now >= _flickerToggleAt)
-                {
-                    _flickerBracketsOn = !_flickerBracketsOn;
-                    _flickerToggleAt   = now + FlickerInterval;
-                }
-                showBrackets = _flickerBracketsOn;
-            }
-            else
-            {
-                // Below redline: no brackets, reset flicker state
-                showBrackets       = false;
-                _flickerBracketsOn = false;
-            }
+            bool showBrackets = data.NewData.Rpms > 0
+                && data.NewData.CarSettings_RPMRedLineReached > 0;
 
             // Rate-limit: only write to the display when something changed
             if (gear == _lastSentGear && showBrackets == _lastBracketsShown && _lastDisplayMode == "GearUpshift")

--- a/FanaBridge/Adapters/FanatecDisplayDriver.cs
+++ b/FanaBridge/Adapters/FanatecDisplayDriver.cs
@@ -47,7 +47,7 @@ namespace FanaBridge.Adapters
             _settings = settings ?? new DisplaySettings();
         }
 
-        /// <summary>The current display mode string ("Gear", "Speed", "GearAndSpeed").</summary>
+        /// <summary>The current display mode string ("Gear", "Speed", "GearAndSpeed", "GearUpshiftBrackets").</summary>
         public string DisplayMode
         {
             get { return _settings.DisplayMode ?? DisplaySettings.DefaultMode; }
@@ -187,13 +187,13 @@ namespace FanaBridge.Adapters
                 && data.NewData.CarSettings_RPMRedLineReached > 0;
 
             // Rate-limit: only write to the display when something changed
-            if (gear == _lastSentGear && showBrackets == _lastBracketsShown && _lastDisplayMode == "GearUpshift")
+            if (gear == _lastSentGear && showBrackets == _lastBracketsShown && _lastDisplayMode == "GearUpshiftBrackets")
                 return;
 
             _display.DisplayGearBracketed(gear, showBrackets);
             _lastSentGear      = gear;
             _lastBracketsShown = showBrackets;
-            _lastDisplayMode   = "GearUpshift";
+            _lastDisplayMode   = "GearUpshiftBrackets";
             _currentGear       = GearToString(gear);
             _currentText       = showBrackets ? "[" + _currentGear + "]" : _currentGear;
         }

--- a/FanaBridge/Adapters/FanatecDisplayDriver.cs
+++ b/FanaBridge/Adapters/FanatecDisplayDriver.cs
@@ -30,6 +30,12 @@ namespace FanaBridge.Adapters
         private int _lastKnownGear = int.MinValue;
         private DateTime _gearOverlayUntil = DateTime.MinValue;
 
+        // GearUpshiftBrackets: flicker state
+        private static readonly TimeSpan FlickerInterval = TimeSpan.FromMilliseconds(250);
+        private bool _lastBracketsShown;
+        private bool _flickerBracketsOn;
+        private DateTime _flickerToggleAt = DateTime.MinValue;
+
         public FanatecDisplayDriver(DisplayEncoder display, DisplaySettings settings)
         {
             _display = display;
@@ -75,6 +81,10 @@ namespace FanaBridge.Adapters
                     UpdateGearAndSpeed(data);
                     break;
 
+                case "GearUpshiftBrackets":
+                    UpdateGearUpshiftBrackets(data);
+                    break;
+
                 case "Gear":
                 default:
                     UpdateGear(data);
@@ -94,6 +104,9 @@ namespace FanaBridge.Adapters
             _lastSentSpeed = int.MinValue;
             _lastKnownGear = int.MinValue;
             _gearOverlayUntil = DateTime.MinValue;
+            _lastBracketsShown = false;
+            _flickerBracketsOn = false;
+            _flickerToggleAt = DateTime.MinValue;
         }
 
         // =====================================================================
@@ -168,6 +181,47 @@ namespace FanaBridge.Adapters
                     _currentText = speed.ToString();
                 }
             }
+        }
+
+        private void UpdateGearUpshiftBrackets(GameData data)
+        {
+            string gearStr = data.NewData.Gear;
+            int gear = ParseGear(gearStr);
+
+            // SimHub computes the shift-point percentage via its own RPM config.
+            // 1.0 = redline reached; values approaching 1.0 are used for the flicker zone.
+            double rpmPct = data.NewData.CarSettings_CurrentDisplayedRPMPercent;
+
+            bool showBrackets;
+
+            if (rpmPct >= 1.0)
+            {
+                // Redline reached: flicker brackets to signal upshift
+                DateTime now = DateTime.UtcNow;
+                if (now >= _flickerToggleAt)
+                {
+                    _flickerBracketsOn = !_flickerBracketsOn;
+                    _flickerToggleAt   = now + FlickerInterval;
+                }
+                showBrackets = _flickerBracketsOn;
+            }
+            else
+            {
+                // Below redline: no brackets, reset flicker state
+                showBrackets       = false;
+                _flickerBracketsOn = false;
+            }
+
+            // Rate-limit: only write to the display when something changed
+            if (gear == _lastSentGear && showBrackets == _lastBracketsShown && _lastDisplayMode == "GearUpshift")
+                return;
+
+            _display.DisplayGearBracketed(gear, showBrackets);
+            _lastSentGear      = gear;
+            _lastBracketsShown = showBrackets;
+            _lastDisplayMode   = "GearUpshift";
+            _currentGear       = GearToString(gear);
+            _currentText       = showBrackets ? "[" + _currentGear + "]" : _currentGear;
         }
 
         // =====================================================================

--- a/FanaBridge/Adapters/FanatecDisplayDriver.cs
+++ b/FanaBridge/Adapters/FanatecDisplayDriver.cs
@@ -190,7 +190,7 @@ namespace FanaBridge.Adapters
             if (gear == _lastSentGear && showBrackets == _lastBracketsShown && _lastDisplayMode == "GearUpshiftBrackets")
                 return;
 
-            _display.DisplayGearBracketed(gear, showBrackets);
+            _display.DisplayGear(gear, showBrackets);
             _lastSentGear      = gear;
             _lastBracketsShown = showBrackets;
             _lastDisplayMode   = "GearUpshiftBrackets";

--- a/FanaBridge/Protocol/DisplayEncoder.cs
+++ b/FanaBridge/Protocol/DisplayEncoder.cs
@@ -53,24 +53,7 @@ namespace FanaBridge.Protocol
         /// </summary>
         public bool DisplayGear(int gear)
         {
-            byte seg;
-            switch (gear)
-            {
-                case -1: seg = SevenSegment.R; break;
-                case 0:  seg = SevenSegment.N; break;
-                case 1:  seg = SevenSegment.Digit1; break;
-                case 2:  seg = SevenSegment.Digit2; break;
-                case 3:  seg = SevenSegment.Digit3; break;
-                case 4:  seg = SevenSegment.Digit4; break;
-                case 5:  seg = SevenSegment.Digit5; break;
-                case 6:  seg = SevenSegment.Digit6; break;
-                case 7:  seg = SevenSegment.Digit7; break;
-                case 8:  seg = SevenSegment.Digit8; break;
-                case 9:  seg = SevenSegment.Digit9; break;
-                default: seg = SevenSegment.N; break;
-            }
-
-            return SetDisplay(SevenSegment.Blank, seg, SevenSegment.Blank);
+            return SetDisplay(SevenSegment.Blank, GearToSegment(gear), SevenSegment.Blank);
         }
 
         /// <summary>
@@ -79,26 +62,28 @@ namespace FanaBridge.Protocol
         /// </summary>
         public bool DisplayGearBracketed(int gear, bool showBrackets)
         {
-            byte seg;
-            switch (gear)
-            {
-                case -1: seg = SevenSegment.R; break;
-                case 0:  seg = SevenSegment.N; break;
-                case 1:  seg = SevenSegment.Digit1; break;
-                case 2:  seg = SevenSegment.Digit2; break;
-                case 3:  seg = SevenSegment.Digit3; break;
-                case 4:  seg = SevenSegment.Digit4; break;
-                case 5:  seg = SevenSegment.Digit5; break;
-                case 6:  seg = SevenSegment.Digit6; break;
-                case 7:  seg = SevenSegment.Digit7; break;
-                case 8:  seg = SevenSegment.Digit8; break;
-                case 9:  seg = SevenSegment.Digit9; break;
-                default: seg = SevenSegment.N; break;
-            }
-
             byte left  = showBrackets ? SevenSegment.BracketLeft  : SevenSegment.Blank;
             byte right = showBrackets ? SevenSegment.BracketRight : SevenSegment.Blank;
-            return SetDisplay(left, seg, right);
+            return SetDisplay(left, GearToSegment(gear), right);
+        }
+
+        private static byte GearToSegment(int gear)
+        {
+            switch (gear)
+            {
+                case -1: return SevenSegment.R;
+                case 0:  return SevenSegment.N;
+                case 1:  return SevenSegment.Digit1;
+                case 2:  return SevenSegment.Digit2;
+                case 3:  return SevenSegment.Digit3;
+                case 4:  return SevenSegment.Digit4;
+                case 5:  return SevenSegment.Digit5;
+                case 6:  return SevenSegment.Digit6;
+                case 7:  return SevenSegment.Digit7;
+                case 8:  return SevenSegment.Digit8;
+                case 9:  return SevenSegment.Digit9;
+                default: return SevenSegment.N;
+            }
         }
 
         /// <summary>

--- a/FanaBridge/Protocol/DisplayEncoder.cs
+++ b/FanaBridge/Protocol/DisplayEncoder.cs
@@ -74,6 +74,34 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
+        /// Display a gear number with optional upshift brackets: -1=R, 0=N, 1-9.
+        /// When <paramref name="showBrackets"/> is true, renders [n] using the outer digit positions.
+        /// </summary>
+        public bool DisplayGearBracketed(int gear, bool showBrackets)
+        {
+            byte seg;
+            switch (gear)
+            {
+                case -1: seg = SevenSegment.R; break;
+                case 0:  seg = SevenSegment.N; break;
+                case 1:  seg = SevenSegment.Digit1; break;
+                case 2:  seg = SevenSegment.Digit2; break;
+                case 3:  seg = SevenSegment.Digit3; break;
+                case 4:  seg = SevenSegment.Digit4; break;
+                case 5:  seg = SevenSegment.Digit5; break;
+                case 6:  seg = SevenSegment.Digit6; break;
+                case 7:  seg = SevenSegment.Digit7; break;
+                case 8:  seg = SevenSegment.Digit8; break;
+                case 9:  seg = SevenSegment.Digit9; break;
+                default: seg = SevenSegment.N; break;
+            }
+
+            byte left  = showBrackets ? SevenSegment.BracketLeft  : SevenSegment.Blank;
+            byte right = showBrackets ? SevenSegment.BracketRight : SevenSegment.Blank;
+            return SetDisplay(left, seg, right);
+        }
+
+        /// <summary>
         /// Display a speed value (0-999) on the 3-digit display.
         /// </summary>
         public bool DisplaySpeed(int speed)

--- a/FanaBridge/Protocol/DisplayEncoder.cs
+++ b/FanaBridge/Protocol/DisplayEncoder.cs
@@ -50,17 +50,9 @@ namespace FanaBridge.Protocol
 
         /// <summary>
         /// Display a gear number: -1=R, 0=N, 1-9.
-        /// </summary>
-        public bool DisplayGear(int gear)
-        {
-            return SetDisplay(SevenSegment.Blank, GearToSegment(gear), SevenSegment.Blank);
-        }
-
-        /// <summary>
-        /// Display a gear number with optional upshift brackets: -1=R, 0=N, 1-9.
         /// When <paramref name="showBrackets"/> is true, renders [n] using the outer digit positions.
         /// </summary>
-        public bool DisplayGearBracketed(int gear, bool showBrackets)
+        public bool DisplayGear(int gear, bool showBrackets = false)
         {
             byte left  = showBrackets ? SevenSegment.BracketLeft  : SevenSegment.Blank;
             byte right = showBrackets ? SevenSegment.BracketRight : SevenSegment.Blank;

--- a/FanaBridge/Protocol/SevenSegment.cs
+++ b/FanaBridge/Protocol/SevenSegment.cs
@@ -32,10 +32,12 @@ namespace FanaBridge.Protocol
         public const byte Digit9 = 0x6F;
 
         // Symbols
-        public const byte Dot    = 0x80;
-        public const byte Blank  = 0x00;
-        public const byte Dash   = 0x40;
-        public const byte Under  = 0x08;
+        public const byte Dot          = 0x80;
+        public const byte Blank        = 0x00;
+        public const byte Dash         = 0x40;
+        public const byte Under        = 0x08;
+        public const byte BracketLeft  = 0x39;  // [ top + top-left + bottom-left + bottom
+        public const byte BracketRight = 0x0F;  // ] top + top-right + bottom-right + bottom
 
         // Letters (7-segment approximations)
         public const byte A = 0x77;

--- a/FanaBridge/UI/ScreenSettingsPanel.xaml
+++ b/FanaBridge/UI/ScreenSettingsPanel.xaml
@@ -21,6 +21,7 @@
                     <ComboBoxItem Content="Gear" Tag="Gear" />
                     <ComboBoxItem Content="Speed" Tag="Speed" />
                     <ComboBoxItem Content="Gear + Speed" Tag="GearAndSpeed" />
+                    <ComboBoxItem Content="Gear + Upshift Brackets" Tag="GearUpshiftBrackets" />
                 </ComboBox>
             </styles:SHSubSection>
 


### PR DESCRIPTION
Added Upshift when readline is reached (configurable through Simhub). 

(The ghosting of the left digit in this video is my 7 segment display. Is not as bright in reality)

https://github.com/user-attachments/assets/4e305929-3640-491d-a126-9f548ca46c98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Gear + Upshift Brackets" display mode that shows gear with optional bracket symbols.
  * New Display Mode option added to settings to select this mode.

* **Bug Fixes & Improvements**
  * Reduced unnecessary display updates for the new mode via mode-specific rate limiting.
  * Clearing the display now resets bracket state to avoid stale visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->