### PR TITLE
Event-driven wheel identity: enable-once + listen + settle

### DIFF
--- a/FanaBridge.Tests/ConnectionMonitorTests.cs
+++ b/FanaBridge.Tests/ConnectionMonitorTests.cs
@@ -10,22 +10,22 @@ namespace FanaBridge.Tests
 
         // The wheelbase now owns its transport, so a single stub stands in for
         // both connection state (IsConnected / IsDevicePresent) and identity
-        // polling.
+        // servicing.
         private class StubWheelbase : IWheelbaseConnection
         {
             public bool IsConnected { get; set; } = true;
             public bool IsDevicePresent { get; set; } = true;
             public int DisconnectCalls { get; private set; }
-            public int PollCalls { get; private set; }
-            public bool PollThrows { get; set; }
+            public int UpdateCalls { get; private set; }
+            public bool UpdateThrows { get; set; }
 
             public void Disconnect() => DisconnectCalls++;
 
-            public bool PollWheelIdentity()
+            public bool UpdateIdentity()
             {
-                if (PollThrows)
-                    throw new InvalidOperationException("wheel poll failed");
-                PollCalls++;
+                if (UpdateThrows)
+                    throw new InvalidOperationException("identity update failed");
+                UpdateCalls++;
                 return true;
             }
         }
@@ -183,10 +183,10 @@ namespace FanaBridge.Tests
             Assert.Equal(1, wheelbase.DisconnectCalls);
         }
 
-        // ── Wheel poll failure ───────────────────────────────────────────
+        // ── Identity update failure ──────────────────────────────────────
 
         [Fact]
-        public void Update_PollThrows_DisconnectsWithShortCooldown()
+        public void Update_IdentityThrows_DisconnectsWithShortCooldown()
         {
             var wheelbase = new StubWheelbase();
             int connectAttempts = 0;
@@ -198,16 +198,15 @@ namespace FanaBridge.Tests
             });
             monitor.TryInitialConnect(); // attempt 1
 
-            // Poll happens on the very first frame when cooldown is 0.
-            // Make it throw to trigger disconnect.
-            wheelbase.PollThrows = true;
+            // Identity is serviced every frame; make it throw to trigger disconnect.
+            wheelbase.UpdateThrows = true;
             bool result = monitor.Update();
 
             Assert.False(result);
             Assert.False(monitor.IsConnected);
 
             // Short cooldown = 60 frames. Pump through cooldown, then reconnect.
-            wheelbase.PollThrows = false;
+            wheelbase.UpdateThrows = false;
             PumpFrames(monitor, 60);
             Assert.False(monitor.IsConnected);
 
@@ -218,14 +217,13 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void Update_PollThrows_TearsDownWheelbase()
+        public void Update_IdentityThrows_TearsDownWheelbase()
         {
             var wheelbase = new StubWheelbase();
             var monitor = Create(wheelbase, () => true);
             monitor.TryInitialConnect();
 
-            // Poll happens on the first frame when cooldown is 0.
-            wheelbase.PollThrows = true;
+            wheelbase.UpdateThrows = true;
             monitor.Update();
 
             Assert.Equal(1, wheelbase.DisconnectCalls);
@@ -299,17 +297,17 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void Update_SteadyState_PollsWheelIdentity()
+        public void Update_SteadyState_ServicesIdentityEveryFrame()
         {
             var wheelbase = new StubWheelbase();
             var monitor = Create(wheelbase, () => true);
             monitor.TryInitialConnect();
 
-            // Poll happens immediately on first frame, then every 30 frames
+            // Identity is serviced on every frame (cheap non-blocking drain),
+            // not on a poll interval.
             PumpFrames(monitor, 120);
 
-            // Expect polls at frames: 1, 31, 61, 91 = 4 polls
-            Assert.True(wheelbase.PollCalls >= 4);
+            Assert.True(wheelbase.UpdateCalls >= 100);
         }
     }
 }

--- a/FanaBridge.Tests/IdentitySettlerTests.cs
+++ b/FanaBridge.Tests/IdentitySettlerTests.cs
@@ -1,0 +1,123 @@
+using FanaBridge.Transport;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class IdentitySettlerTests
+    {
+        private const int Settle = 200;
+        private const byte HubWire = 0x0C;
+        private const byte NoWire  = 0x00;
+        private const byte BmwWire = 0x0F;
+        private const byte PBMR    = 0x02;
+        private const byte NoMod   = 0x00;
+
+        // Commit an initial identity at t=0 and return a settler positioned in steady state.
+        private static IdentitySettler Seeded(byte wire, byte module)
+        {
+            var s = new IdentitySettler(Settle);
+            s.Offer(wire, module, 0);
+            Assert.True(s.Tick(Settle, out _, out _)); // first commit is a change
+            Assert.True(s.IsStable);
+            return s;
+        }
+
+        [Fact]
+        public void InitialReading_CommitsAfterSettleWindow()
+        {
+            var s = new IdentitySettler(Settle);
+            s.Offer(HubWire, PBMR, 0);
+
+            Assert.False(s.IsStable);
+            Assert.False(s.Tick(199, out _, out _)); // still within the window
+            Assert.True(s.Tick(200, out var w, out var m)); // committed
+            Assert.Equal(HubWire, w);
+            Assert.Equal(PBMR, m);
+            Assert.True(s.IsStable);
+        }
+
+        [Fact]
+        public void SteadyState_NeverSettlesOrCommits()
+        {
+            var s = Seeded(HubWire, PBMR);
+            for (long t = 200; t < 2000; t += 50)
+            {
+                s.Offer(HubWire, PBMR, t);            // same reading every tick
+                Assert.True(s.IsStable);
+                Assert.False(s.Tick(t, out _, out _));
+            }
+        }
+
+        [Fact]
+        public void CleanChange_CommitsOneWindowLater()
+        {
+            var s = Seeded(HubWire, PBMR);
+
+            s.Offer(HubWire, NoMod, 1000);            // module removed
+            Assert.False(s.IsStable);                 // suppressed while settling
+            Assert.False(s.Tick(1100, out _, out _)); // < deadline
+            Assert.True(s.Tick(1200, out var w, out var m));
+            Assert.Equal(HubWire, w);
+            Assert.Equal(NoMod, m);
+        }
+
+        [Fact]
+        public void Flap_RidesOut_AndCommitsWhatItSettlesTo()
+        {
+            var s = Seeded(HubWire, NoMod); // hub present, no module yet
+
+            // A reconnect storm: wire flaps 0x0C <-> 0x00 every 15 ms for ~2 s,
+            // ending settled on the hub with the module now present.
+            long t = 1000;
+            for (; t < 3000; t += 15)
+                s.Offer((t / 15) % 2 == 0 ? NoWire : HubWire, NoMod, t);
+            s.Offer(HubWire, PBMR, t); // final settled reading
+
+            // Never commits mid-storm (deadline keeps moving), and stays unstable.
+            Assert.False(s.IsStable);
+            Assert.False(s.Tick(t + 199, out _, out _));
+
+            // Commits the settled value one window after the last push.
+            Assert.True(s.Tick(t + 200, out var w, out var m));
+            Assert.Equal(HubWire, w);
+            Assert.Equal(PBMR, m);
+            Assert.True(s.IsStable);
+        }
+
+        [Fact]
+        public void SettlesBackToCommitted_NoChangeEvent()
+        {
+            var s = Seeded(HubWire, PBMR);
+
+            s.Offer(NoWire, NoMod, 1000);  // a blip away...
+            s.Offer(HubWire, PBMR, 1030);  // ...then back to the committed value
+            Assert.False(s.Tick(1100, out _, out _)); // settling
+            // Window expires having settled back to what was already committed: no event.
+            Assert.False(s.Tick(1230, out _, out _));
+            Assert.True(s.IsStable);
+        }
+
+        [Fact]
+        public void WheelSwap_CommitsNewWheel()
+        {
+            var s = Seeded(HubWire, NoMod);
+            s.Offer(BmwWire, NoMod, 500);
+            Assert.True(s.Tick(700, out var w, out _));
+            Assert.Equal(BmwWire, w);
+        }
+
+        [Fact]
+        public void Reset_ClearsCommittedAndSettling()
+        {
+            var s = Seeded(HubWire, PBMR);
+            s.Offer(NoWire, NoMod, 1000); // mid-settle
+            s.Reset();
+
+            Assert.True(s.IsStable);
+            // After reset the same reading must re-earn its settle window from scratch.
+            s.Offer(HubWire, PBMR, 2000);
+            Assert.False(s.Tick(2199, out _, out _));
+            Assert.True(s.Tick(2200, out _, out _));
+        }
+    }
+}

--- a/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -128,8 +128,18 @@ namespace FanaBridge.Adapters
             if (plugin == null)
                 return DeviceState.Disabled;
 
+            // ARCHITECTURE: this reaches directly into wheelbase identity fields.
+            // When the peripheral model lands, bind to a peripheral snapshot (class
+            // + code + capabilities) instead, so a DeviceInstance can represent
+            // pedals/shifter (hosted or standalone), not just a base attachment.
             var wheelbase = plugin.Wheelbase;
             if (wheelbase == null || !wheelbase.IsConnected)
+                return DeviceState.Scanning;
+
+            // While the attachment identity is settling (mid-transition), treat the
+            // device as not-yet-connected so no LED/display output is driven at a
+            // half-(re)connected wheel.
+            if (!wheelbase.IdentityStable)
                 return DeviceState.Scanning;
 
             if (!_config.MatchesAttachment(

--- a/FanaBridge/FanatecPlugin.cs
+++ b/FanaBridge/FanatecPlugin.cs
@@ -82,6 +82,10 @@ namespace FanaBridge
         }
 
         /// <summary>The connected wheelbase — used by DeviceInstance wrappers to query wheel identity.</summary>
+        // ARCHITECTURE: single-device assumption. When multi-device support lands
+        // (pedals/shifter/SRM), this becomes a DeviceManager owning a collection;
+        // don't add callers that bake in "exactly one base". See the device-
+        // architecture direction note (Connection / IIdentitySource / Device).
         public FanatecWheelbase Wheelbase => _wheelbase;
 
         /// <summary>Shared HID transport — used by DeviceInstance wrappers for hardware I/O.</summary>

--- a/FanaBridge/Protocol/SystemReportReader.cs
+++ b/FanaBridge/Protocol/SystemReportReader.cs
@@ -1,0 +1,163 @@
+using System;
+using FanaBridge.Transport;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// Reads the col03 <c>FF 08</c> system report — the wire-level side of identity.
+    /// Owns the enable/trigger byte patterns, the report offsets, and the signature
+    /// scan, leaving <see cref="FanatecWheelbase"/> to own identity STATE.
+    ///
+    /// After a single <see cref="Enable"/> the base PUSHES this report on every
+    /// attachment change and is otherwise silent, so steady-state reads are a
+    /// non-blocking drain — no triggering.
+    /// </summary>
+    internal sealed class SystemReportReader
+    {
+        /// <summary>The raw bytes an identity is built from (one system report).</summary>
+        public struct Reading
+        {
+            public byte BaseType;
+            public byte Wire;
+            public byte ModRaw;
+        }
+
+        private const int ReportLength = 64;
+        private const int InitialReadTimeoutMs = 60;
+        private const int InitialMaxReadAttempts = 8; // axis reports interleave; skip past them
+        private const int DrainTimeoutMs = 0;         // non-blocking
+        private const int DrainMaxReports = 16;       // bound per drain
+
+        private byte[] _readBuf;
+
+        /// <summary>Enable the firmware's push-on-change for the system report.</summary>
+        public void Enable(IDeviceTransport io)
+        {
+            io.SendCol03(BuildEnable());
+        }
+
+        /// <summary>
+        /// Enable + trigger + read once, returning the current identity. The base
+        /// only pushes on change, so this seeds the initial state on connect.
+        /// </summary>
+        public bool ReadInitial(IDeviceTransport io, out Reading reading)
+        {
+            reading = default;
+
+            // Hold the transport for the enable→trigger→read sequence so an
+            // interleaved LED write can't land between trigger and read.
+            using (io.BeginBatch())
+            {
+                io.SendCol03(BuildEnable());
+                io.SendCol03(BuildTrigger());
+
+                byte[] buf = Buffer(io);
+                for (int attempt = 0; attempt < InitialMaxReadAttempts; attempt++)
+                {
+                    int n = io.ReadCol03(buf, InitialReadTimeoutMs);
+                    if (n <= 0) break;
+
+                    int sig = FindSignature(buf, n);
+                    if (sig < 0) continue; // axis/other report — read again
+
+                    reading = Decode(buf, sig);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Non-blocking drain of pushed reports; every FF 08 report found is passed
+        /// to <paramref name="onReading"/>. Returns the number delivered.
+        /// </summary>
+        public int DrainPushes(IDeviceTransport io, Action<Reading> onReading)
+        {
+            int count = 0;
+            using (io.BeginBatch())
+            {
+                byte[] buf = Buffer(io);
+                for (int i = 0; i < DrainMaxReports; i++)
+                {
+                    int n = io.ReadCol03(buf, DrainTimeoutMs);
+                    if (n <= 0) break;
+
+                    int sig = FindSignature(buf, n);
+                    if (sig < 0) continue; // axis/other report — not FF 08
+
+                    onReading(Decode(buf, sig));
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Times a few empty (idle) drains to confirm <c>ReadCol03(buf, 0)</c> is
+        /// non-blocking — the per-frame drain depends on it; a blocking read would
+        /// stall the frame thread. Returns the slowest sample in milliseconds.
+        /// Call once after the initial read (when the input is quiet).
+        /// </summary>
+        public double ProbeDrainLatencyMs(IDeviceTransport io, int samples)
+        {
+            double worst = 0;
+            var sw = new System.Diagnostics.Stopwatch();
+            using (io.BeginBatch())
+            {
+                byte[] buf = Buffer(io);
+                for (int i = 0; i < samples; i++)
+                {
+                    sw.Restart();
+                    io.ReadCol03(buf, DrainTimeoutMs); // expected empty → must return immediately
+                    sw.Stop();
+                    double ms = sw.Elapsed.TotalMilliseconds;
+                    if (ms > worst) worst = ms;
+                }
+            }
+            return worst;
+        }
+
+        // Reusable read buffer, sized to the col03 input report length. Safe to
+        // reuse because each match is decoded into a Reading before the next read.
+        private byte[] Buffer(IDeviceTransport io)
+        {
+            int len = io.Col03MaxInputReportLength;
+            if (len < ReportLength) len = ReportLength;
+            if (_readBuf == null || _readBuf.Length < len)
+                _readBuf = new byte[len];
+            return _readBuf;
+        }
+
+        private static Reading Decode(byte[] buf, int sig) => new Reading
+        {
+            BaseType = buf[sig + FanatecIdentity.OffBaseType],
+            Wire     = buf[sig + FanatecIdentity.OffWireCode],
+            ModRaw   = buf[sig + FanatecIdentity.OffModule],
+        };
+
+        // Locate the "FF 08" signature; tolerates a leading report-ID byte by
+        // scanning the first few positions.
+        private static int FindSignature(byte[] buf, int len)
+        {
+            int limit = len - (FanatecIdentity.OffModule + 1);
+            for (int i = 0; i <= limit && i <= 2; i++)
+                if (buf[i] == 0xFF && buf[i + 1] == 0x08)
+                    return i;
+            return -1;
+        }
+
+        private static byte[] BuildEnable()
+        {
+            var b = new byte[ReportLength];
+            b[0] = 0xFF; b[1] = 0x08; b[2] = 0x01; b[3] = 0xFF;
+            return b;
+        }
+
+        private static byte[] BuildTrigger()
+        {
+            var b = new byte[ReportLength];
+            b[0] = 0xFF; b[1] = 0x08; b[2] = 0x02;
+            return b;
+        }
+    }
+}

--- a/FanaBridge/Transport/ConnectionMonitor.cs
+++ b/FanaBridge/Transport/ConnectionMonitor.cs
@@ -20,12 +20,10 @@ namespace FanaBridge.Transport
         private bool _connected;
         private int _frameCounter;
         private int _reconnectCooldown;
-        private int _wheelPollCooldown;
 
         // ── Heartbeat intervals (in frames) ────────────────────────────
         private const int HID_BUS_CHECK_INTERVAL = 120;
         private const int STREAM_CHECK_INTERVAL = 60;
-        private const int WHEEL_POLL_INTERVAL = 30;
 
         // ── Reconnect cooldowns (in frames) ────────────────────────────
         private const int COOLDOWN_LONG = 300;
@@ -130,28 +128,22 @@ namespace FanaBridge.Transport
                 }
             }
 
-            // Poll wheel identity (~every 0.5 s at 60 fps)
-            if (_wheelPollCooldown <= 0)
+            // Service identity every frame: drain pushed FF 08 reports and advance
+            // the settle timer. The base pushes on change, so this is cheap (a
+            // non-blocking drain) and only commits once a change has settled.
+            try
             {
-                try
-                {
-                    _wheelbase.PollWheelIdentity();
-                }
-                catch (Exception ex)
-                {
-                    _logWarn(
-                        $"FanaBridge: Wheel identity poll failed, triggering reconnect: {ex.Message}");
-                    _wheelbase.Disconnect();
-                    _connected = false;
-                    _reconnectCooldown = COOLDOWN_SHORT;
-                    Disconnected?.Invoke();
-                    return false;
-                }
-                _wheelPollCooldown = WHEEL_POLL_INTERVAL;
+                _wheelbase.UpdateIdentity();
             }
-            else
+            catch (Exception ex)
             {
-                _wheelPollCooldown--;
+                _logWarn(
+                    $"FanaBridge: Identity update failed, triggering reconnect: {ex.Message}");
+                _wheelbase.Disconnect();
+                _connected = false;
+                _reconnectCooldown = COOLDOWN_SHORT;
+                Disconnected?.Invoke();
+                return false;
             }
 
             return true;

--- a/FanaBridge/Transport/FanatecWheelbase.cs
+++ b/FanaBridge/Transport/FanatecWheelbase.cs
@@ -23,6 +23,11 @@ namespace FanaBridge.Transport
     /// It is also instantiable per base, so supporting multiple wheelbases later
     /// is a matter of holding a collection rather than unwinding singletons.
     /// </summary>
+    // ARCHITECTURE: this class is base-specific — it directly owns the FF 08
+    // exchange + the base/wheel/module model. The future device model SPLITS it
+    // (a generic Device/manager holding a transport + a bound per-class driver
+    // carrying the FF 08 logic), it does not simply rename. See the device-
+    // architecture direction note (Connection / IIdentitySource / Device).
     public class FanatecWheelbase : IDisposable, IWheelbaseConnection
     {
         public const ushort FANATEC_VENDOR_ID = 0x0EB7;
@@ -32,15 +37,34 @@ namespace FanaBridge.Transport
         private readonly FanatecTransport _transport = new FanatecTransport();
         private bool _disposed;
 
-        public FanatecWheelbase() { }
+        public FanatecWheelbase()
+        {
+            _ingest = OnDrainReading;
+        }
 
         /// <summary>The wheelbase's HID transport — used by LED/display/tuning encoders.</summary>
         public IDeviceTransport Transport => _transport;
 
-        // FF 08 system-report exchange parameters.
-        private const int Ff08ReportLength = 64;
-        private const int Ff08ReadTimeoutMs = 60;
-        private const int Ff08MaxReadAttempts = 8; // axis reports interleave; skip past them
+        // ── Identity acquisition (enable-once, then listen) ────────────────
+        // The base PUSHES the FF 08 system report on every attachment change after
+        // a single enable, and is silent otherwise. We enable + read once on
+        // connect, then UpdateIdentity drains pushed reports via the reader — no
+        // polling. A changed reading is held by the settler until it goes quiet
+        // (riding out the firmware's transient reconnect flap), then committed.
+        private const int IdentitySettleMs = 200;
+        private const int IdentityReEnableMs = 10000;   // keep the push subscription alive
+
+        private readonly SystemReportReader _reportReader = new SystemReportReader();
+        private readonly IdentitySettler _settler = new IdentitySettler(IdentitySettleMs);
+        private readonly System.Diagnostics.Stopwatch _clock = System.Diagnostics.Stopwatch.StartNew();
+        private readonly Action<SystemReportReader.Reading> _ingest;
+        private long _lastEnableMs;
+        private long _drainNow;
+
+        // Most recent drained reading; decoded into the public properties on commit.
+        private SystemReportReader.Reading _lastReading;
+
+        private volatile bool _identityStable = true;
 
         // ── Connection state ─────────────────────────────────────────────
 
@@ -101,6 +125,13 @@ namespace FanaBridge.Transport
         /// </summary>
         public bool WheelIdentified =>
             WheelDetected && !string.IsNullOrEmpty(WheelCode);
+
+        /// <summary>
+        /// Whether the attachment identity is settled (not mid-transition). False
+        /// while a changed reading is still settling — consumers should treat the
+        /// device as not-yet-connected and suppress output during that window.
+        /// </summary>
+        public bool IdentityStable => _identityStable;
 
         /// <summary>
         /// Display name for the current wheel/hub: the matched profile's name, else
@@ -229,10 +260,29 @@ namespace FanaBridge.Transport
             SimHub.Logging.Current.Info(string.Format(
                 "FanatecWheelbase: {0} (PID 0x{1:X4})", ProductName, productId));
 
-            try { PollWheelIdentity(); }
+            // Enable the system report (turns on the firmware's push-on-change) and
+            // read the initial identity once. From here on UpdateIdentity only
+            // listens for pushes — no triggering.
+            try
+            {
+                _lastEnableMs = _clock.ElapsedMilliseconds;
+                if (_reportReader.ReadInitial(_transport, out var reading))
+                    IngestReading(reading, _clock.ElapsedMilliseconds);
+
+                // Confirm the per-frame drain is non-blocking on this hardware — a
+                // blocking ReadCol03(buf, 0) would stall the frame thread. Done once
+                // now that the input is quiet; leaves a permanent regression guard.
+                double drainMs = _reportReader.ProbeDrainLatencyMs(_transport, 5);
+                if (drainMs > 1.0)
+                    SimHub.Logging.Current.Warn(string.Format(
+                        "FanatecWheelbase: idle identity drain took {0:F2} ms — expected non-blocking (<1 ms); per-frame identity polling may stutter.", drainMs));
+                else
+                    SimHub.Logging.Current.Info(string.Format(
+                        "FanatecWheelbase: identity drain is non-blocking ({0:F2} ms idle)", drainMs));
+            }
             catch (Exception ex)
             {
-                SimHub.Logging.Current.Warn("FanatecWheelbase: Initial poll failed: " + ex.Message);
+                SimHub.Logging.Current.Warn("FanatecWheelbase: Initial identity read failed: " + ex.Message);
             }
             return true;
         }
@@ -259,112 +309,66 @@ namespace FanaBridge.Transport
             catch { return "Fanatec Device"; }
         }
 
-        // ── Polling ──────────────────────────────────────────────────────
+        // ── Identity ──────────────────────────────────────────────────────
 
         /// <summary>
-        /// Reads the FF 08 system report and updates wheelbase + attachment identity.
-        /// Call periodically (not every frame). Returns true if identity changed.
+        /// Drains pushed FF 08 system reports and advances the settle timer. Called
+        /// each frame by <see cref="ConnectionMonitor"/>. The base pushes on every
+        /// attachment change (no polling); a changed reading is committed only once
+        /// it has settled. Returns true when a new identity was committed this call.
         /// </summary>
-        public bool PollWheelIdentity()
+        public bool UpdateIdentity()
         {
             if (!IsConnected)
                 return false;
 
-            if (!ReadFf08Report(out var buf, out int sig))
-                return false; // no FF 08 report this round
+            long now = _clock.ElapsedMilliseconds;
 
-            byte baseType = buf[sig + FanatecIdentity.OffBaseType];
-            byte wireCode = buf[sig + FanatecIdentity.OffWireCode];
-            byte modRaw   = buf[sig + FanatecIdentity.OffModule];
-
-            bool isHub = FanatecIdentity.IsHub(wireCode);
-            // A module is only meaningful on a hub; ignore stray bytes on a wheel.
-            string moduleCode = isHub ? FanatecIdentity.DecodeModule(modRaw) : null;
-
-            var prevCode = WheelCode;
-            var prevModule = ModuleCode;
-            var prevDetected = WheelDetected;
-
-            WheelDetected = wireCode != 0;
-            WheelCode = FanatecIdentity.DecodeCode(wireCode);
-            WheelWireCode = wireCode;
-            IsHub = isHub;
-            ModuleCode = moduleCode;
-            BaseType = baseType;
-            BaseCode = FanatecIdentity.DecodeBaseCode(baseType);
-
-            bool changed = prevCode != WheelCode
-                || prevModule != ModuleCode
-                || prevDetected != WheelDetected;
-
-            if (changed)
+            // Keep the push-on-change subscription alive (the enable can lapse).
+            if (now - _lastEnableMs >= IdentityReEnableMs)
             {
-                ResolveCapabilities("Wheel changed");
-                WheelChanged?.Invoke(this);
+                _lastEnableMs = now;
+                try { _reportReader.Enable(_transport); }
+                catch { /* transient; the next tick retries */ }
             }
 
+            _drainNow = now;
+            _reportReader.DrainPushes(_transport, _ingest);
+
+            bool changed = _settler.Tick(now, out _, out _);
+            _identityStable = _settler.IsStable;
+            if (changed)
+                CommitIdentity();
             return changed;
         }
 
-        // Triggers and reads the col03 FF 08 system report (enable → trigger → read,
-        // skipping interleaved axis reports). Returns the buffer + signature offset.
-        // TODO: This is low-level wire I/O (enable/trigger byte patterns, signature
-        // scanning) living in the connection-root class. Consider extracting the
-        // FF 08 exchange into a Protocol-level reader alongside FanatecIdentity's
-        // decode, leaving the wheelbase to own only identity STATE and call into it
-        // — symmetric with how the LED/display/tuning encoders are layered.
-        private bool ReadFf08Report(out byte[] report, out int sig)
+        // Drain callback: record the reading and offer it to the settler. _drainNow
+        // carries the current clock so the cached delegate needs no per-frame closure.
+        private void OnDrainReading(SystemReportReader.Reading r) => IngestReading(r, _drainNow);
+
+        private void IngestReading(SystemReportReader.Reading r, long now)
         {
-            report = null; sig = -1;
-
-            var enable = new byte[Ff08ReportLength];
-            enable[0] = 0xFF; enable[1] = 0x08; enable[2] = 0x01; enable[3] = 0xFF;
-
-            var trigger = new byte[Ff08ReportLength];
-            trigger[0] = 0xFF; trigger[1] = 0x08; trigger[2] = 0x02;
-
-            // The col03 send/read surface is the IDeviceTransport interface
-            // (explicitly implemented on FanatecTransport).
-            IDeviceTransport io = _transport;
-
-            // Hold the transport for the enable→trigger→read sequence so an
-            // interleaved LED write can't land between trigger and read.
-            using (io.BeginBatch())
-            {
-                io.SendCol03(enable);
-                io.SendCol03(trigger);
-
-                int bufLen = io.Col03MaxInputReportLength;
-                if (bufLen < Ff08ReportLength) bufLen = Ff08ReportLength;
-
-                for (int attempt = 0; attempt < Ff08MaxReadAttempts; attempt++)
-                {
-                    var buf = new byte[bufLen];
-                    int n = io.ReadCol03(buf, Ff08ReadTimeoutMs);
-                    if (n <= 0) break;
-
-                    int s = FindFf08Signature(buf, n);
-                    if (s < 0) continue; // not the FF08 report (axis/other) — read again
-
-                    report = buf; sig = s;
-                    return true;
-                }
-            }
-
-            return false;
+            _lastReading = r;
+            byte effModule = FanatecIdentity.IsHub(r.Wire) ? r.ModRaw : (byte)0;
+            _settler.Offer(r.Wire, effModule, now);
         }
 
-        // Locate the "FF 08" system-report signature; tolerates a leading
-        // report-ID byte by scanning the first few positions.
-        private static int FindFf08Signature(byte[] buf, int len)
+        // Commit the latest (settled) reading into the public identity properties.
+        private void CommitIdentity()
         {
-            int limit = len - (FanatecIdentity.OffModule + 1);
-            for (int i = 0; i <= limit && i <= 2; i++)
-            {
-                if (buf[i] == 0xFF && buf[i + 1] == 0x08)
-                    return i;
-            }
-            return -1;
+            byte wire = _lastReading.Wire;
+            bool isHub = FanatecIdentity.IsHub(wire);
+
+            WheelDetected = wire != 0;
+            WheelCode = FanatecIdentity.DecodeCode(wire);
+            WheelWireCode = wire;
+            IsHub = isHub;
+            ModuleCode = isHub ? FanatecIdentity.DecodeModule(_lastReading.ModRaw) : null;
+            BaseType = _lastReading.BaseType;
+            BaseCode = FanatecIdentity.DecodeBaseCode(_lastReading.BaseType);
+
+            ResolveCapabilities("Wheel changed");
+            WheelChanged?.Invoke(this);
         }
 
         /// <summary>
@@ -433,6 +437,9 @@ namespace FanaBridge.Transport
         public void Disconnect()
         {
             _transport.Disconnect();
+            _settler.Reset();
+            _identityStable = true;
+            _lastReading = default;
 
             ConnectedProductId = 0;
             ProductName = null;

--- a/FanaBridge/Transport/IWheelbaseConnection.cs
+++ b/FanaBridge/Transport/IWheelbaseConnection.cs
@@ -2,7 +2,7 @@ namespace FanaBridge.Transport
 {
     /// <summary>
     /// Connection-check surface of a <see cref="FanatecWheelbase"/>, used by
-    /// <see cref="ConnectionMonitor"/> for heartbeat and identity polling.
+    /// <see cref="ConnectionMonitor"/> for heartbeat and identity servicing.
     /// </summary>
     public interface IWheelbaseConnection
     {
@@ -15,7 +15,10 @@ namespace FanaBridge.Transport
         /// <summary>Release the wheelbase connection and reset identity state.</summary>
         void Disconnect();
 
-        /// <summary>Poll the FF 08 system report for the current wheel/hub identity.</summary>
-        bool PollWheelIdentity();
+        /// <summary>
+        /// Service identity: drain any pushed FF 08 reports and advance the settle
+        /// timer. Called every frame. Returns true when a new identity was committed.
+        /// </summary>
+        bool UpdateIdentity();
     }
 }

--- a/FanaBridge/Transport/IdentitySettler.cs
+++ b/FanaBridge/Transport/IdentitySettler.cs
@@ -1,0 +1,90 @@
+namespace FanaBridge.Transport
+{
+    /// <summary>
+    /// Settles raw wheel/hub + module identity readings before they are committed.
+    ///
+    /// The wheelbase firmware pushes a burst of transient "in transition" FF 08
+    /// reports while an attachment is (dis)connecting — e.g. a ~2 s storm of the
+    /// wire byte flapping between a hub code and zero during a hub/module reconnect.
+    /// Committing those raw makes the detected identity oscillate. Mirroring the
+    /// Fanatec service (which sleeps after a settings-change push, then reads),
+    /// this holds a changed reading until it has been quiet for a settle window,
+    /// then commits whatever the burst settled to.
+    ///
+    /// Pure and time-injected (the caller passes a millisecond clock) so it can be
+    /// unit-tested without timing.
+    /// </summary>
+    internal sealed class IdentitySettler
+    {
+        private readonly long _settleMs;
+
+        private bool _hasCommitted;
+        private byte _committedWire, _committedModule;
+
+        private byte _pendingWire, _pendingModule;
+        private bool _settling;
+        private long _deadline;
+
+        public IdentitySettler(int settleMs)
+        {
+            _settleMs = settleMs < 0 ? 0 : settleMs;
+        }
+
+        /// <summary>True when no change is in flight — the committed identity is trustworthy.</summary>
+        public bool IsStable => !_settling;
+
+        /// <summary>
+        /// Offer a fresh reading. If it differs from the committed identity it
+        /// (re)starts the settle window; every further differing reading pushes the
+        /// window out, so a flapping burst only commits once it goes quiet.
+        /// </summary>
+        public void Offer(byte wire, byte module, long nowMs)
+        {
+            if (!_settling && _hasCommitted && wire == _committedWire && module == _committedModule)
+                return; // unchanged steady state
+
+            _settling = true;
+            _pendingWire = wire;
+            _pendingModule = module;
+            _deadline = nowMs + _settleMs;
+        }
+
+        /// <summary>
+        /// Advance the settle timer. Returns true — with the newly committed
+        /// (wire, module) — only when a settled reading is committed AND it differs
+        /// from the previously committed one. Returns false while still settling, or
+        /// when the burst settled back to the existing identity.
+        /// </summary>
+        public bool Tick(long nowMs, out byte wire, out byte module)
+        {
+            wire = _committedWire;
+            module = _committedModule;
+
+            if (!_settling || nowMs < _deadline)
+                return false;
+
+            _settling = false;
+            bool changed = !_hasCommitted
+                || _pendingWire != _committedWire
+                || _pendingModule != _committedModule;
+
+            _committedWire = _pendingWire;
+            _committedModule = _pendingModule;
+            _hasCommitted = true;
+
+            wire = _committedWire;
+            module = _committedModule;
+            return changed;
+        }
+
+        /// <summary>Clear all state (e.g. on disconnect).</summary>
+        public void Reset()
+        {
+            _hasCommitted = false;
+            _settling = false;
+            _committedWire = _committedModule = 0;
+            _pendingWire = _pendingModule = 0;
+            _deadline = 0;
+        }
+    }
+}


### PR DESCRIPTION
Replace the short-poll-and-commit identity flow with the firmware's own push model, fixing the reconnect oscillation at the root.

The base PUSHES the col03 FF 08 system report on every attachment change after a single enable, and is silent otherwise (confirmed by hardware probe; it's also how the Fanatec service works — event-driven, no timer). The old flow triggered+read every 30 frames and committed each raw read, so it latched the firmware's transient reconnect flap (a ~2 s wire-byte storm) into a visible Connected/Scanning oscillation with pulsed LED output. That flap is inherent firmware behaviour, not caused by our traffic — so the fix is to stop committing raw reads.

- FanatecWheelbase: enable + read once on connect, then UpdateIdentity (called every frame) does a non-blocking drain of pushed reports — no triggering. A periodic re-enable keeps the push subscription alive.
- IdentitySettler (new, pure, unit-tested): holds a changed (wire, module) reading until it has been quiet for a settle window (200 ms, mirroring the Fanatec service's settle), then commits whatever it settled to. Rides out the flap; never latches an intermediate value.
- SystemReportReader (new): owns the FF 08 wire I/O — enable/trigger patterns, offsets, signature scan, non-blocking drain — leaving the wheelbase to own identity STATE. Resolves the standing TODO.
- IdentityStable gate: GetDeviceState returns Scanning while settling, so no LED/display output is driven at a half-(re)connected device.
- Self-check: ProbeDrainLatencyMs confirms the non-blocking drain on connect (warns if a read blocks), as a permanent regression guard.
- ConnectionMonitor services identity every frame (drops the 30-frame poll); IWheelbaseConnection.PollWheelIdentity -> UpdateIdentity.

Also marks the two single-device seams (FanatecPlugin.Wheelbase, FanatecWheelDeviceInstance) for the future multi-device/peripheral model.

100/100 tests pass; build clean. Hardware-validated (wheel swap, module unplug/replug, base reconnect).