### PR TITLE
Use SpeedLocal for speed display (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.1 - 2026-06-18
+
+### Fixed
+- Speed display now follows the km/h vs mph unit set in SimHub instead of always showing km/h, by reading `SpeedLocal` rather than `SpeedKmh` ([#27](https://github.com/kelchm/FanaBridge/issues/27))
+
 ## v0.3.0 - 2026-03-28
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Single source of truth for product versioning. -->
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
 

--- a/FanaBridge.Tests/FanaBridge.Tests.csproj
+++ b/FanaBridge.Tests/FanaBridge.Tests.csproj
@@ -13,6 +13,9 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(SimHubDir)Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="GameReaderCommon">
+      <HintPath>$(SimHubDir)GameReaderCommon.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/FanaBridge.Tests/FanatecDisplayDriverTests.cs
+++ b/FanaBridge.Tests/FanatecDisplayDriverTests.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Generic;
+using FanaBridge.Adapters;
+using FanaBridge.Protocol;
+using FanaBridge.Transport;
+using GameReaderCommon;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class FanatecDisplayDriverTests
+    {
+        // ── Test stub ────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Records every col01 report the driver emits through DisplayEncoder.
+        /// Only SendCol01 is exercised by the display path.
+        /// </summary>
+        private class RecordingTransport : IDeviceTransport
+        {
+            public bool IsConnected { get; set; } = true;
+            public int Col03MaxInputReportLength { get; set; } = 64;
+
+            public List<byte[]> SentCol01Reports { get; } = new List<byte[]>();
+
+            public bool SendCol01(byte[] data)
+            {
+                var copy = new byte[data.Length];
+                Array.Copy(data, copy, data.Length);
+                SentCol01Reports.Add(copy);
+                return true;
+            }
+
+            public bool SendCol03(byte[] data) => true;
+            public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public IDisposable BeginBatch() => new NoOpDisposable();
+
+            private sealed class NoOpDisposable : IDisposable
+            {
+                public void Dispose() { }
+            }
+
+            /// <summary>The 3 segment bytes (positions 5-7) of the most recent report.</summary>
+            public (byte, byte, byte) LastSegments
+            {
+                get
+                {
+                    var r = SentCol01Reports[SentCol01Reports.Count - 1];
+                    return (r[5], r[6], r[7]);
+                }
+            }
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────
+
+        private static FanatecDisplayDriver MakeDriver(RecordingTransport transport, string mode)
+        {
+            var encoder = new DisplayEncoder(transport);
+            var settings = new DisplaySettings { DisplayMode = mode };
+            return new FanatecDisplayDriver(encoder, settings);
+        }
+
+        // StatusDataBase is abstract with internal setters, so it can't be
+        // constructed or populated directly from the test assembly. Its only
+        // concrete subclass is the generic StatusData<T>; we close it over
+        // object, create an instance, and drive the internal setters via
+        // reflection.
+        private static readonly Type StatusDataType =
+            typeof(GameData).Assembly
+                .GetType("GameReaderCommon.StatusData`1")
+                .MakeGenericType(typeof(object));
+
+        private static void Set(object statusData, string property, object value)
+        {
+            statusData.GetType().GetProperty(property).GetSetMethod(true)
+                .Invoke(statusData, new[] { value });
+        }
+
+        private static GameData MakeData(
+            string gear = "1",
+            double speedLocal = 0,
+            double speedKmh = 0,
+            double rpms = 0,
+            double redLineReached = 0)
+        {
+            var status = System.Runtime.Serialization.FormatterServices
+                .GetUninitializedObject(StatusDataType);
+            Set(status, "Gear", gear);
+            Set(status, "SpeedLocal", speedLocal);
+            Set(status, "SpeedKmh", speedKmh);
+            Set(status, "Rpms", rpms);
+            Set(status, "CarSettings_RPMRedLineReached", redLineReached);
+
+            return new GameData { NewData = (StatusDataBase)status };
+        }
+
+        // ── DisplayMode / construction ───────────────────────────────────
+
+        [Fact]
+        public void DisplayMode_DefaultsToGear_WhenSettingsNull()
+        {
+            var driver = new FanatecDisplayDriver(new DisplayEncoder(new RecordingTransport()), null);
+            Assert.Equal("Gear", driver.DisplayMode);
+        }
+
+        [Fact]
+        public void DisplayMode_ReflectsSettings()
+        {
+            var driver = MakeDriver(new RecordingTransport(), "Speed");
+            Assert.Equal("Speed", driver.DisplayMode);
+        }
+
+        [Fact]
+        public void UpdateSettings_NullResetsToDefault()
+        {
+            var driver = MakeDriver(new RecordingTransport(), "Speed");
+            driver.UpdateSettings(null);
+            Assert.Equal("Gear", driver.DisplayMode);
+        }
+
+        // ── Update guards ────────────────────────────────────────────────
+
+        [Fact]
+        public void Update_NullNewData_DoesNothing()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Speed");
+
+            driver.Update(new GameData()); // NewData is null by default
+
+            Assert.Empty(transport.SentCol01Reports);
+        }
+
+        [Fact]
+        public void Update_UnknownMode_FallsBackToGear()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "TotallyBogusMode");
+
+            driver.Update(MakeData(gear: "4"));
+
+            // Gear 4 rendered as blank / digit-4 / blank
+            Assert.Equal((SevenSegment.Blank, SevenSegment.Digit4, SevenSegment.Blank), transport.LastSegments);
+            Assert.Equal("4", driver.CurrentGear);
+        }
+
+        // ── Gear mode ────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData("R", -1, SevenSegment.R)]
+        [InlineData("N", 0, SevenSegment.N)]
+        [InlineData("3", 3, SevenSegment.Digit3)]
+        [InlineData("reverse", -1, SevenSegment.R)]
+        [InlineData("", 0, SevenSegment.N)]      // empty -> neutral
+        [InlineData("garbage", 0, SevenSegment.N)] // unparseable -> neutral
+        public void Gear_RendersExpectedSegment(string gearStr, int _, byte expectedMiddle)
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Gear");
+
+            driver.Update(MakeData(gear: gearStr));
+
+            Assert.Equal((SevenSegment.Blank, expectedMiddle, SevenSegment.Blank), transport.LastSegments);
+        }
+
+        [Fact]
+        public void Gear_SetsCurrentTextAndGear()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Gear");
+
+            driver.Update(MakeData(gear: "R"));
+
+            Assert.Equal("R", driver.CurrentGear);
+            Assert.Equal("R", driver.CurrentText);
+        }
+
+        [Fact]
+        public void Gear_RateLimits_UnchangedValue()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Gear");
+
+            driver.Update(MakeData(gear: "2"));
+            driver.Update(MakeData(gear: "2"));
+            driver.Update(MakeData(gear: "2"));
+
+            Assert.Single(transport.SentCol01Reports);
+        }
+
+        [Fact]
+        public void Gear_WritesAgain_WhenValueChanges()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Gear");
+
+            driver.Update(MakeData(gear: "2"));
+            driver.Update(MakeData(gear: "3"));
+
+            Assert.Equal(2, transport.SentCol01Reports.Count);
+        }
+
+        // ── Speed mode (the SpeedLocal fix, issue #27) ───────────────────
+
+        [Fact]
+        public void Speed_UsesSpeedLocal_NotSpeedKmh()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Speed");
+
+            // 88 mph would read as 141 km/h; the display must follow SpeedLocal.
+            driver.Update(MakeData(speedLocal: 88, speedKmh: 141));
+
+            Assert.Equal("88", driver.CurrentText);
+            Assert.Equal(
+                (SevenSegment.Digit0, SevenSegment.Digit8, SevenSegment.Digit8),
+                transport.LastSegments);
+        }
+
+        [Fact]
+        public void Speed_RoundsToNearestInt()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Speed");
+
+            driver.Update(MakeData(speedLocal: 99.6));
+
+            Assert.Equal("100", driver.CurrentText);
+        }
+
+        [Theory]
+        [InlineData(-5, "0")]
+        [InlineData(1234, "999")]
+        public void Speed_ClampsToRange(double speedLocal, string expected)
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Speed");
+
+            driver.Update(MakeData(speedLocal: speedLocal));
+
+            Assert.Equal(expected, driver.CurrentText);
+        }
+
+        [Fact]
+        public void Speed_RateLimits_UnchangedValue()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Speed");
+
+            driver.Update(MakeData(speedLocal: 120));
+            driver.Update(MakeData(speedLocal: 120.2)); // rounds to same int
+
+            Assert.Single(transport.SentCol01Reports);
+        }
+
+        // ── GearAndSpeed mode ────────────────────────────────────────────
+        // NOTE: the gear/speed switch is gated on DateTime.UtcNow (a 2s overlay
+        // after each gear change) which isn't injectable, so only the gear-
+        // overlay branch is deterministically reachable. A fresh driver always
+        // starts inside the overlay window on the first gear it sees.
+
+        [Fact]
+        public void GearAndSpeed_ShowsGearOverlay_OnFirstFrame()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "GearAndSpeed");
+
+            driver.Update(MakeData(gear: "5", speedLocal: 200));
+
+            Assert.Equal("5", driver.CurrentText);
+            Assert.Equal((SevenSegment.Blank, SevenSegment.Digit5, SevenSegment.Blank), transport.LastSegments);
+        }
+
+        // ── GearUpshiftBrackets mode ─────────────────────────────────────
+
+        [Fact]
+        public void UpshiftBrackets_NoBrackets_BelowRedline()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "GearUpshiftBrackets");
+
+            driver.Update(MakeData(gear: "3", rpms: 6000, redLineReached: 0));
+
+            Assert.Equal((SevenSegment.Blank, SevenSegment.Digit3, SevenSegment.Blank), transport.LastSegments);
+            Assert.Equal("3", driver.CurrentText);
+        }
+
+        [Fact]
+        public void UpshiftBrackets_ShowsBrackets_AtRedline()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "GearUpshiftBrackets");
+
+            driver.Update(MakeData(gear: "3", rpms: 8000, redLineReached: 1));
+
+            Assert.Equal((SevenSegment.BracketLeft, SevenSegment.Digit3, SevenSegment.BracketRight), transport.LastSegments);
+            Assert.Equal("[3]", driver.CurrentText);
+        }
+
+        [Fact]
+        public void UpshiftBrackets_NoBrackets_WhenRpmsZero()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "GearUpshiftBrackets");
+
+            // redline flag set but no rpms -> brackets require both
+            driver.Update(MakeData(gear: "3", rpms: 0, redLineReached: 1));
+
+            Assert.Equal("3", driver.CurrentText);
+        }
+
+        [Fact]
+        public void UpshiftBrackets_RewritesWhenBracketStateChanges()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "GearUpshiftBrackets");
+
+            driver.Update(MakeData(gear: "3", rpms: 8000, redLineReached: 0)); // no brackets
+            driver.Update(MakeData(gear: "3", rpms: 8000, redLineReached: 1)); // brackets on
+
+            Assert.Equal(2, transport.SentCol01Reports.Count);
+        }
+
+        [Fact]
+        public void UpshiftBrackets_RateLimits_UnchangedState()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "GearUpshiftBrackets");
+
+            driver.Update(MakeData(gear: "3", rpms: 8000, redLineReached: 1));
+            driver.Update(MakeData(gear: "3", rpms: 8100, redLineReached: 1));
+
+            Assert.Single(transport.SentCol01Reports);
+        }
+
+        // ── Clear ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Clear_BlanksDisplayAndResetsState()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Gear");
+
+            driver.Update(MakeData(gear: "4"));
+            driver.Clear();
+
+            Assert.Equal((SevenSegment.Blank, SevenSegment.Blank, SevenSegment.Blank), transport.LastSegments);
+            Assert.Equal("", driver.CurrentText);
+            Assert.Equal("", driver.CurrentGear);
+        }
+
+        [Fact]
+        public void Clear_ResetsRateLimiter_SoSameValueWritesAgain()
+        {
+            var transport = new RecordingTransport();
+            var driver = MakeDriver(transport, "Gear");
+
+            driver.Update(MakeData(gear: "4"));
+            int afterFirst = transport.SentCol01Reports.Count;
+
+            driver.Clear();
+            driver.Update(MakeData(gear: "4")); // same gear, but cache was reset
+
+            // first write + clear write + second write
+            Assert.Equal(afterFirst + 2, transport.SentCol01Reports.Count);
+        }
+    }
+}

--- a/FanaBridge/Adapters/FanatecDisplayDriver.cs
+++ b/FanaBridge/Adapters/FanatecDisplayDriver.cs
@@ -110,41 +110,28 @@ namespace FanaBridge.Adapters
 
         private void UpdateGear(GameData data)
         {
-            string gearStr = data.NewData.Gear;
-            int gear = ParseGear(gearStr);
+            int gear = ParseGear(data.NewData.Gear);
 
             if (gear == _lastSentGear && _lastDisplayMode == "Gear")
                 return;
 
-            _display.DisplayGear(gear);
-            _lastSentGear = gear;
-            _lastDisplayMode = "Gear";
-            _currentGear = GearToString(gear);
-            _currentText = _currentGear;
+            ShowGear(gear, "Gear");
         }
 
         private void UpdateSpeed(GameData data)
         {
-            int speed = (int)Math.Round(data.NewData.SpeedKmh);
-            if (speed < 0) speed = 0;
-            if (speed > 999) speed = 999;
+            int speed = ReadSpeed(data);
 
             if (speed == _lastSentSpeed && _lastDisplayMode == "Speed")
                 return;
 
-            _display.DisplaySpeed(speed);
-            _lastSentSpeed = speed;
-            _lastDisplayMode = "Speed";
-            _currentText = speed.ToString();
+            ShowSpeed(speed, "Speed");
         }
 
         private void UpdateGearAndSpeed(GameData data)
         {
-            string gearStr = data.NewData.Gear;
-            int gear = ParseGear(gearStr);
-            int speed = (int)Math.Round(data.NewData.SpeedKmh);
-            if (speed < 0) speed = 0;
-            if (speed > 999) speed = 999;
+            int gear = ParseGear(data.NewData.Gear);
+            int speed = ReadSpeed(data);
 
             // Trigger the gear overlay whenever the gear changes
             if (gear != _lastKnownGear)
@@ -157,31 +144,19 @@ namespace FanaBridge.Adapters
             {
                 // Show gear as a temporary overlay after a gear change
                 if (gear != _lastSentGear || _lastDisplayMode != "GearSpeed_Gear")
-                {
-                    _display.DisplayGear(gear);
-                    _lastSentGear = gear;
-                    _lastDisplayMode = "GearSpeed_Gear";
-                    _currentGear = GearToString(gear);
-                    _currentText = _currentGear;
-                }
+                    ShowGear(gear, "GearSpeed_Gear");
             }
             else
             {
                 // Default: show speed
                 if (speed != _lastSentSpeed || _lastDisplayMode != "GearSpeed_Speed")
-                {
-                    _display.DisplaySpeed(speed);
-                    _lastSentSpeed = speed;
-                    _lastDisplayMode = "GearSpeed_Speed";
-                    _currentText = speed.ToString();
-                }
+                    ShowSpeed(speed, "GearSpeed_Speed");
             }
         }
 
         private void UpdateGearUpshiftBrackets(GameData data)
         {
-            string gearStr = data.NewData.Gear;
-            int gear = ParseGear(gearStr);
+            int gear = ParseGear(data.NewData.Gear);
 
             bool showBrackets = data.NewData.Rpms > 0
                 && data.NewData.CarSettings_RPMRedLineReached > 0;
@@ -201,6 +176,43 @@ namespace FanaBridge.Adapters
         // =====================================================================
         // HELPERS
         // =====================================================================
+
+        /// <summary>
+        /// Reads the speed from telemetry (SpeedLocal honours the user's km/h
+        /// vs mph choice in SimHub) and clamps it to the 3-digit range.
+        /// </summary>
+        private static int ReadSpeed(GameData data)
+        {
+            int speed = (int)Math.Round(data.NewData.SpeedLocal);
+            if (speed < 0) speed = 0;
+            if (speed > 999) speed = 999;
+            return speed;
+        }
+
+        /// <summary>
+        /// Writes a gear to the display and updates the cached state under the
+        /// given display-mode tag.
+        /// </summary>
+        private void ShowGear(int gear, string mode)
+        {
+            _display.DisplayGear(gear);
+            _lastSentGear = gear;
+            _lastDisplayMode = mode;
+            _currentGear = GearToString(gear);
+            _currentText = _currentGear;
+        }
+
+        /// <summary>
+        /// Writes a speed to the display and updates the cached state under the
+        /// given display-mode tag.
+        /// </summary>
+        private void ShowSpeed(int speed, string mode)
+        {
+            _display.DisplaySpeed(speed);
+            _lastSentSpeed = speed;
+            _lastDisplayMode = mode;
+            _currentText = speed.ToString();
+        }
 
         /// <summary>
         /// Parses SimHub gear string to an integer: "R"=-1, "N"=0, "1"-"9"=1-9.


### PR DESCRIPTION
Resolves #27.

## What

Speed on the 3-digit display now follows the **km/h vs mph** unit chosen in SimHub, instead of always showing km/h. This is a one-field swap — `SpeedKmh` → `SpeedLocal` — in the two places `FanatecDisplayDriver` reads speed (`Speed` and `GearAndSpeed` modes).

Suggested and verified in-game (Forza Horizon 6) by the issue author; swapping units in SimHub settings now updates the display between km/h and mph.

## Also in this PR

- **Tests:** new `FanatecDisplayDriverTests` (27 tests) covering gear/speed/brackets rendering, rate-limiting, clamping, `Clear()`, and a regression test asserting the display follows `SpeedLocal` rather than `SpeedKmh`. Full suite: 117 passing.
  - The test project now references `GameReaderCommon` (resolved via the existing `$(SimHubDir)` HintPath — same source CI already stages).
- **Refactor:** DRY'd the duplicated speed read+clamp and the gear/speed display-write blocks into shared private helpers. No behavior change.
- **Release prep:** bumped version to `0.3.1` and added a `CHANGELOG` entry.

## Not addressed (noted for later)

The `GearAndSpeed` gear-overlay timer still uses `DateTime.UtcNow`, which leaves its speed branch deterministically untestable. Switching it to telemetry's `PacketTime` would fix that and make timing testable, but needs more research before changing — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.3.1

* **Bug Fixes**
  * Speed display now correctly respects the km/h versus mph unit preference configured in SimHub instead of always using the default unit.

* **Tests**
  * Added comprehensive test coverage for display driver functionality to validate behavior across multiple display modes and scenarios.

* **Chores**
  * Version updated to 0.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->