### PR TITLE
Fix GTSWX button LEDs in grouped mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.3.2 - 2026-06-22
+
+### Fixed
+- Button LEDs on the GT Steering Wheel Extreme (GTSWX) now work when "Individual LEDs profiles" is disabled. The button LED region was mapped with the wrong offset, so button lighting only worked in individual-LEDs mode ([#29](https://github.com/kelchm/FanaBridge/issues/29))
+
+### Changed
+- GT Steering Wheel Extreme (GTSWX) profile marked as verified
+
 ## v0.3.1 - 2026-06-18
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Single source of truth for product versioning. -->
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <VersionPrefix>0.3.2</VersionPrefix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
 

--- a/FanaBridge.Tests/FanaBridge.Tests.csproj
+++ b/FanaBridge.Tests/FanaBridge.Tests.csproj
@@ -16,6 +16,9 @@
     <Reference Include="GameReaderCommon">
       <HintPath>$(SimHubDir)GameReaderCommon.dll</HintPath>
     </Reference>
+    <Reference Include="BA63Driver">
+      <HintPath>$(SimHubDir)BA63Driver.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/FanaBridge.Tests/FanatecLedDriverTests.cs
+++ b/FanaBridge.Tests/FanatecLedDriverTests.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using BA63Driver.Mapper;
+using FanaBridge.Adapters;
+using FanaBridge.Profiles;
+using FanaBridge.Protocol;
+using FanaBridge.Transport;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="FanatecLedDriver"/> — the physical mapper it builds
+    /// and the per-channel command dispatch in <c>SendLeds</c>.
+    /// </summary>
+    public class FanatecLedDriverTests
+    {
+        // ── Transport stub ───────────────────────────────────────────────
+
+        private sealed class RecordingTransport : IDeviceTransport
+        {
+            private readonly object _lock = new object();
+            private readonly List<byte[]> _col01 = new List<byte[]>();
+            private readonly List<byte[]> _col03 = new List<byte[]>();
+
+            public bool IsConnected { get; set; } = true;
+            public int Col03MaxInputReportLength => 64;
+
+            public bool SendCol01(byte[] data) { lock (_lock) { _col01.Add((byte[])data.Clone()); } return true; }
+            public bool SendCol03(byte[] data) { lock (_lock) { _col03.Add((byte[])data.Clone()); } return true; }
+            public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public IDisposable BeginBatch() => new NoOp();
+            private sealed class NoOp : IDisposable { public void Dispose() { } }
+
+            public byte[][] Col01 { get { lock (_lock) { return _col01.ToArray(); } } }
+            public byte[][] Col03 { get { lock (_lock) { return _col03.ToArray(); } } }
+        }
+
+        // ── Fixtures ─────────────────────────────────────────────────────
+
+        // Builds caps from (channel, count) groups. hwIndex restarts per channel,
+        // except buttonAuxIntensity continues after buttonRgb (they share the
+        // single col03 0x03 intensity payload), matching the real profiles.
+        private static WheelCapabilities Caps(params (string channel, int count)[] groups)
+        {
+            int buttonRgbCount = groups.Where(g => g.channel == "buttonRgb").Sum(g => g.count);
+            var leds = new List<object>();
+            foreach (var (channel, count) in groups)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    int hw = channel == "buttonAuxIntensity" ? buttonRgbCount + i : i;
+                    string role = channel == "buttonAuxIntensity" ? "encoder"
+                                : channel.StartsWith("button") ? "button"
+                                : "rev";
+                    leds.Add(new { channel, hwIndex = hw, role, label = channel + i });
+                }
+            }
+            var json = JsonConvert.SerializeObject(new { id = "TEST", name = "Test", leds });
+            return new WheelCapabilities(JsonConvert.DeserializeObject<WheelProfile>(json));
+        }
+
+        private static FanatecLedDriver BuildDriver(WheelCapabilities caps, IDeviceTransport transport)
+            => new FanatecLedDriver(caps, new LedEncoder(transport), new LegacyLedEncoder(transport), transport);
+
+        // Lights every LED white via raw/individual state, runs one frame, and
+        // returns the recorded reports. Dispose() blocks until the async write
+        // task finishes, so all reports are present when this returns.
+        private static RecordingTransport RunAllWhite(WheelCapabilities caps)
+        {
+            var transport = new RecordingTransport();
+            var driver = BuildDriver(caps, transport);
+            var raw = new Color[caps.AllLedCount];
+            for (int i = 0; i < raw.Length; i++) raw[i] = Color.FromArgb(255, 255, 255, 255);
+            var state = new LedDeviceState(new Color[0], new Color[0], new Color[0], new Color[0], raw);
+
+            Assert.True(driver.SendLeds(state, forceRefresh: true));
+            driver.Dispose();
+            return transport;
+        }
+
+        private static bool Col03Has(RecordingTransport t, byte subcmd) => t.Col03.Any(r => r[2] == subcmd);
+        private static bool Col01Has(RecordingTransport t, byte subcmd) => t.Col01.Any(r => r[3] == subcmd);
+        private static byte[] Col03Last(RecordingTransport t, byte subcmd) => t.Col03.Last(r => r[2] == subcmd);
+
+        // ── Mapper regression tests (the GTSWX button-LED bug) ───────────
+        //
+        // ButtonRangeMap's first arg indexes the BUTTONS section array, not the
+        // combined layout; it must be 0 or grouped ("Individual LEDs: Disabled")
+        // mode reads ButtonsState out of bounds and button LEDs stay black.
+
+        [Fact]
+        public void Mapper_GroupedMode_ButtonLedsReadFromButtonsState()
+        {
+            var caps = Caps(("revRgb", 9), ("flagRgb", 6), ("buttonRgb", 4)); // GTSWX shape
+            var mapper = BuildDriver(caps, new RecordingTransport()).GetPhysicalMapper();
+
+            int revFlagCount = caps.RevFlagCount;   // 15
+            int buttonCount = caps.ButtonLedCount;  // 4
+
+            // Grouped mode: sections populated, RawState empty. Gray values keep
+            // the assertion independent of any ColorOrder channel remapping.
+            var buttonsState = new Color[buttonCount];
+            for (int i = 0; i < buttonCount; i++)
+                buttonsState[i] = Color.FromArgb(255, 40 + i * 20, 40 + i * 20, 40 + i * 20);
+
+            var state = new LedDeviceState(new Color[revFlagCount], buttonsState,
+                new Color[0], new Color[0], new Color[0]);
+
+            for (int i = 0; i < buttonCount; i++)
+            {
+                Color c = mapper.GetColor(revFlagCount + i, state, ignoreBrightness: true);
+                Assert.False(c.R == 0 && c.G == 0 && c.B == 0,
+                    $"Button {i} resolved to black — ButtonsState not reached.");
+                Assert.Equal(40 + i * 20, c.R);
+            }
+        }
+
+        [Fact]
+        public void Mapper_GroupedMode_TelemetryLedsReadFromLedsState()
+        {
+            var caps = Caps(("revRgb", 9), ("flagRgb", 6), ("buttonRgb", 4));
+            var mapper = BuildDriver(caps, new RecordingTransport()).GetPhysicalMapper();
+
+            int revFlagCount = caps.RevFlagCount;
+            var ledsState = new Color[revFlagCount];
+            for (int i = 0; i < revFlagCount; i++)
+                ledsState[i] = Color.FromArgb(255, 10 + i, 10 + i, 10 + i);
+
+            var state = new LedDeviceState(ledsState, new Color[caps.ButtonLedCount],
+                new Color[0], new Color[0], new Color[0]);
+
+            for (int i = 0; i < revFlagCount; i++)
+                Assert.Equal(10 + i, mapper.GetColor(i, state, ignoreBrightness: true).R);
+        }
+
+        [Fact]
+        public void Mapper_IndividualMode_ButtonLedsReadFromRawState()
+        {
+            // Individual mode: RawState carries the full contiguous layout indexed
+            // by physical position. This path worked even with the original bug.
+            var caps = Caps(("revRgb", 9), ("flagRgb", 6), ("buttonRgb", 4));
+            var mapper = BuildDriver(caps, new RecordingTransport()).GetPhysicalMapper();
+
+            var rawState = new Color[caps.AllLedCount];
+            int firstButton = caps.RevFlagCount;
+            rawState[firstButton] = Color.FromArgb(255, 70, 70, 70);
+
+            var state = new LedDeviceState(new Color[0], new Color[0], new Color[0], new Color[0], rawState);
+            Assert.Equal(70, mapper.GetColor(firstButton, state, ignoreBrightness: true).R);
+        }
+
+        // ── Per-combo dispatch tests ─────────────────────────────────────
+        //
+        // One representative example per wheel-lighting combo, asserting which
+        // hardware command (col03 subcmd / col01 subcmd) a lit LED produces.
+        // col03 subcmd is byte[2]; col01 subcmd is byte[3].
+
+        [Fact] // CSSWFORMV2 etc.
+        public void Dispatch_RevFlagRgb_SendsRevAndFlagColorReports()
+        {
+            var t = RunAllWhite(Caps(("revRgb", 9), ("flagRgb", 6)));
+
+            Assert.True(Col03Has(t, 0x00), "rev colors (0x00) missing");
+            Assert.True(Col03Has(t, 0x01), "flag colors (0x01) missing");
+            Assert.False(Col03Has(t, 0x02), "unexpected button colors (0x02)");
+            Assert.False(Col03Has(t, 0x03), "unexpected button intensities (0x03)");
+            Assert.Empty(t.Col01);
+
+            var rev = Col03Last(t, 0x00); // RGB565 of white, big-endian at offset 3
+            Assert.True(rev[3] != 0 || rev[4] != 0, "rev LED 0 color is zero");
+        }
+
+        [Fact] // GTSWX
+        public void Dispatch_RevFlagButtonRgb_SendsAllCol03Channels()
+        {
+            var t = RunAllWhite(Caps(("revRgb", 9), ("flagRgb", 6), ("buttonRgb", 4)));
+
+            Assert.True(Col03Has(t, 0x00), "rev colors (0x00) missing");
+            Assert.True(Col03Has(t, 0x01), "flag colors (0x01) missing");
+            Assert.True(Col03Has(t, 0x02), "button colors (0x02) missing");
+            Assert.True(Col03Has(t, 0x03), "button intensities (0x03) missing");
+            Assert.Empty(t.Col01);
+
+            var btn = Col03Last(t, 0x02);
+            Assert.True(btn[3] != 0 || btn[4] != 0, "button LED 0 color is zero");
+        }
+
+        [Fact] // PBMR
+        public void Dispatch_ButtonRgbOnly_SendsButtonColorAndIntensity()
+        {
+            var t = RunAllWhite(Caps(("buttonRgb", 12)));
+
+            Assert.False(Col03Has(t, 0x00), "unexpected rev colors (0x00)");
+            Assert.False(Col03Has(t, 0x01), "unexpected flag colors (0x01)");
+            Assert.True(Col03Has(t, 0x02), "button colors (0x02) missing");
+            Assert.True(Col03Has(t, 0x03), "button intensities (0x03) missing");
+            Assert.Empty(t.Col01);
+        }
+
+        [Fact] // PSWBMW
+        public void Dispatch_ButtonRgbWithAuxIntensity_SetsAuxSlotsInIntensityReport()
+        {
+            var t = RunAllWhite(Caps(("buttonRgb", 12), ("buttonAuxIntensity", 3)));
+
+            Assert.True(Col03Has(t, 0x02), "button colors (0x02) missing");
+            Assert.True(Col03Has(t, 0x03), "button intensities (0x03) missing");
+
+            // Aux LEDs occupy intensity slots 12..14 (after the 12 buttonRgb).
+            // Payload starts at byte 3, so slot 12 lands at byte 15.
+            var intensity = Col03Last(t, 0x03);
+            Assert.NotEqual(0, intensity[3]);       // buttonRgb 0 intensity
+            Assert.NotEqual(0, intensity[3 + 12]);  // aux 0 intensity
+        }
+
+        [Fact] // CSL P1 / WRC
+        public void Dispatch_LegacyRevStripe_SendsEnableSequenceAndData()
+        {
+            var t = RunAllWhite(Caps(("legacyRevStripe", 1)));
+
+            Assert.Empty(t.Col03);
+            Assert.True(Col01Has(t, 0x06), "RevStripe enable (0x06) missing");
+            Assert.True(Col01Has(t, 0x02), "global enable (0x02) missing");
+            Assert.True(Col01Has(t, 0x08), "LED data (0x08) missing");
+        }
+
+        [Fact] // CSSWBMW etc.
+        public void Dispatch_LegacyRevOnOff_SendsGlobalEnableAndBitmask()
+        {
+            var t = RunAllWhite(Caps(("legacyRevOnOff", 9)));
+
+            Assert.Empty(t.Col03);
+            Assert.True(Col01Has(t, 0x02), "global enable (0x02) missing");
+            Assert.True(Col01Has(t, 0x08), "bitmask LED data (0x08) missing");
+        }
+
+        [Fact] // GTSWPRO
+        public void Dispatch_LegacyRev3Bit_SendsGlobalEnableAndRgbData()
+        {
+            var t = RunAllWhite(Caps(("legacyRev3Bit", 9)));
+
+            Assert.Empty(t.Col03);
+            Assert.True(Col01Has(t, 0x02), "global enable (0x02) missing");
+            Assert.True(Col01Has(t, 0x0A), "3-bit rev data (0x0A) missing");
+        }
+
+        [Fact] // supported channel, no shipped profile yet
+        public void Dispatch_LegacyFlag3Bit_SendsGlobalEnableAndFlagData()
+        {
+            var t = RunAllWhite(Caps(("legacyFlag3Bit", 6)));
+
+            Assert.Empty(t.Col03);
+            Assert.True(Col01Has(t, 0x02), "global enable (0x02) missing");
+            Assert.True(Col01Has(t, 0x0B), "3-bit flag data (0x0B) missing");
+        }
+    }
+}

--- a/FanaBridge/Adapters/FanatecLedDriver.cs
+++ b/FanaBridge/Adapters/FanatecLedDriver.cs
@@ -358,7 +358,10 @@ namespace FanaBridge.Adapters
 
             int buttonCount = caps.ButtonLedCount;
             if (buttonCount > 0)
-                maps.Add(new ButtonRangeMap(revFlagCount, buttonCount));
+                // First arg is the offset into the buttons section array, not the
+                // combined layout — physical placement comes from map order. Must be
+                // 0 or grouped mode reads out of bounds. See FanatecLedDriverTests.
+                maps.Add(new ButtonRangeMap(0, buttonCount));
 
             return new PhysicalMapper(maps.ToArray());
         }

--- a/FanaBridge/Resources/Profiles/GTSWX.json
+++ b/FanaBridge/Resources/Profiles/GTSWX.json
@@ -8,7 +8,7 @@
     "wheelType": "GTSWX"
   },
   "display": "itm",
-  "verified": false,
+  "verified": true,
   "leds": [
     { "channel": "revRgb",  "hwIndex": 0, "role": "rev",  "label": "Rev LED 1" },
     { "channel": "revRgb",  "hwIndex": 1, "role": "rev",  "label": "Rev LED 2" },

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -12,6 +12,7 @@ These profiles have been verified on hardware.
 |--------|:---:|:---:|:---:|:---:|
 | ClubSport BMW M3 GT2 V2 | On/Off | — | — | 3-digit |
 | ClubSport Formula V2.5 | Full color | Full color | — | 3-digit |
+| GT Extreme | Full color | Full color | Full color | 3-digit (ITM planned) |
 | Podium BMW M4 GT3 | — | — | Full color | 3-digit |
 | Podium Hub + Button Module Endurance | Full color | Full color | — | 3-digit (ITM planned) |
 | Podium Hub + Button Module Rally | — | — | Full color | 3-digit |
@@ -36,7 +37,6 @@ These profiles are based on SDK data and should work, but have not been tested o
 | CSL Elite WRC | 512 colors (RevStripe) | — | — | 3-digit |
 | CSL GT3 | — | — | — | 3-digit |
 | GT PRO | 8 colors | — | — | 3-digit |
-| GT Extreme | Full color | Full color | Full color | 3-digit (ITM planned) |
 | Podium Bentley GT3 | Full color | Full color | — | 3-digit (ITM planned) |
 
 > **Other hubs:** The ClubSport Universal Hub, CSL Universal Hub, and ClubSport Universal Hub V2 are recognized by FanaBridge but do not yet have built-in profiles. Use the Wheel Profile Wizard to create one.


### PR DESCRIPTION
Fixes #29

## Problem

Button LED control on the GTSWX only worked while "Individual LEDs profiles" was **enabled**. With it **disabled** (grouped mode), the button LEDs stayed dark — telemetry rev/flag LEDs were unaffected.

## Root cause

`FanatecLedDriver.BuildMapper()` built the button region with:

```csharp
maps.Add(new ButtonRangeMap(revFlagCount, buttonCount));
```

Decompiling `BA63Driver.dll` confirms `RangeMap`'s first argument is the **index into that section's own color array** (`state.ButtonsState`), not a global offset into the combined layout. Physical placement is determined purely by the *order* maps are added, so the offset must be `0`.

In grouped mode `PhysicalMapper.GetColor` reads `ButtonsState[logicalIdx]`. With the offset set to `revFlagCount` (15 for GTSWX), the button maps read `ButtonsState[15..]`, which is out of bounds for the 4-entry buttons array → `Color.Black` → dead button LEDs. In individual mode the raw overlay (`RawState`) is indexed by *physical* position instead, so it worked — exactly the reported symptom.

## Why only GTSWX

GTSWX (9 rev + 6 flag + 4 buttons) is the only shipped wheel that combines telemetry and button LEDs. Every other wheel is telemetry-only or button-only; when `revFlagCount == 0` the buggy expression collapsed to the correct `ButtonRangeMap(0, …)`, so they never reproduced it.

## Fix

```csharp
maps.Add(new ButtonRangeMap(0, buttonCount));
```

Matches the convention every native SimHub device uses. Physical placement is unchanged, so individual mode keeps working.

## Tests

Added `FanatecLedDriverTests`:
- **Mapper regression** (3): grouped-mode buttons read `ButtonsState`, grouped-mode telemetry reads `LedsState`, individual-mode reads `RawState`. The grouped-button test fails against the old code.
- **Per-combo dispatch** (8): one representative example per wheel-lighting combo, asserting which hardware command (col03/col01 subcmd) a lit LED produces — revRgb+flagRgb, +buttonRgb (GTSWX), buttonRgb-only, buttonRgb+aux intensity, and the four legacy col01 channels.

All 128 tests pass.

## Release

- Bumped `VersionPrefix` to **v0.3.2** (`Directory.Build.props`)
- Added the v0.3.2 changelog entry
- Marked the GTSWX profile `verified: true` and moved it to the **Tested** table in `supported-devices.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)