### PR TITLE
docs: reference PR and issue in v0.3.2 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.3.2 - 2026-06-22
 
 ### Fixed
-- Button LEDs on the GT Steering Wheel Extreme (GTSWX) now work when "Individual LEDs profiles" is disabled. The button LED region was mapped with the wrong offset, so button lighting only worked in individual-LEDs mode ([#29](https://github.com/kelchm/FanaBridge/issues/29))
+- Button LEDs on the GT Steering Wheel Extreme (GTSWX) now work when "Individual LEDs profiles" is disabled. The button LED region was mapped with the wrong offset, so button lighting only worked in individual-LEDs mode ([#34](https://github.com/kelchm/FanaBridge/pull/34), fixes [#29](https://github.com/kelchm/FanaBridge/issues/29))
 
 ### Changed
 - GT Steering Wheel Extreme (GTSWX) profile marked as verified


### PR DESCRIPTION
Standardizes the v0.3.2 changelog entry to reference both the PR and the issue (`#34, fixes #29`), per the agreed convention.

Follow-up to #34. Once merged, the `v0.3.2` release tag will be cut pointing at the resulting `main` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog entry for v0.3.2 to properly document the GT Steering Wheel Extreme button LED fix with correct cross-references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->