### PR TITLE
Add native ITM telemetry display support for Fanatec wheels

### DIFF
--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -1,0 +1,469 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using FanaBridge.Adapters;
+using FanaBridge.Protocol;
+using FanaBridge.Transport;
+using GameReaderCommon;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class ItmDisplayDriverTests
+    {
+        // ── Test doubles ─────────────────────────────────────────────────
+
+        private class RecordingTransport : IDeviceTransport
+        {
+            public bool IsConnected { get; set; } = true;
+            public int Col03MaxInputReportLength { get; set; } = 64;
+            public List<byte[]> Sent { get; } = new List<byte[]>();
+
+            public bool SendCol03(byte[] data)
+            {
+                var copy = new byte[data.Length];
+                Array.Copy(data, copy, data.Length);
+                Sent.Add(copy);
+                return true;
+            }
+
+            public bool SendCol01(byte[] data) => true;
+            public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public IDisposable BeginBatch() => new NoOp();
+            private sealed class NoOp : IDisposable { public void Dispose() { } }
+        }
+
+        // Frame classifiers (col03: [0]=0xFF, [1]=class, [2]=subcmd)
+        private static bool IsEnable(byte[] r) => r[1] == 0x02 && r[2] == 0x02;
+        private static bool IsValueUpdate(byte[] r) => r[1] == 0x05 && r[2] == 0x01;
+        private static bool IsKeepalive(byte[] r) => r[1] == 0x05 && r[2] == 0x04 && r[3] == 0x02 && r[4] == 0x0B;
+
+        private sealed class Clock { public long T; public long Now() => T; }
+
+        private static ItmDisplayDriver MakeDriver(out RecordingTransport t, out Clock clock)
+        {
+            t = new RecordingTransport();
+            clock = new Clock();
+            return new ItmDisplayDriver(new ItmEncoder(t), clock.Now);
+        }
+
+        // ── GameData (see ItmTelemetryTests) ─────────────────────────────
+        private static readonly Type StatusDataType =
+            typeof(GameData).Assembly.GetType("GameReaderCommon.StatusData`1").MakeGenericType(typeof(object));
+        private static object NewStatus() => FormatterServices.GetUninitializedObject(StatusDataType);
+        private static void Set(object s, string p, object v) =>
+            s.GetType().GetProperty(p).GetSetMethod(true).Invoke(s, new[] { v });
+        private static GameData Data(object status) => new GameData { NewData = (StatusDataBase)status };
+        private static GameData EmptyData() => Data(NewStatus());
+
+        // A firmware subscription report (col03-IN). Tyre page: SPEED@0, GEAR@1,
+        // FL(42)@0x82, RL(48)@0x83.
+        private static readonly byte[] TyreSubReport =
+            HexToBytes("ff05010300010034030104001203822a00320383300032");
+        private static byte[] HexToBytes(string hex)
+        {
+            var b = new byte[hex.Length / 2];
+            for (int i = 0; i < b.Length; i++) b[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            return b;
+        }
+
+        private static void Enable(ItmDisplayDriver driver, Clock clock)
+        {
+            driver.Start();
+            driver.Update(EmptyData());   // Enabling -> Running (Enable + seed)
+        }
+
+        // ── Lifecycle ────────────────────────────────────────────────────
+
+        [Fact]
+        public void Update_BeforeStart_SendsNothing()
+        {
+            var driver = MakeDriver(out var t, out _);
+            driver.Update(EmptyData());
+            Assert.Empty(t.Sent);
+            Assert.False(driver.IsRunning);
+        }
+
+        private static bool IsItmModeOn(byte[] r) => r[1] == 0x05 && r[2] == 0x02 && r[3] == 0x01;
+
+        [Fact]
+        public void Start_EnablesOnce_ThenRunning()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+
+            Assert.True(driver.IsRunning);
+            Assert.Single(t.Sent.Where(IsEnable));
+        }
+
+        [Fact]
+        public void BringUp_EnablesFirmwareItmGateBeforeSession()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+
+            int gateIdx = t.Sent.FindIndex(IsItmModeOn);
+            int enableIdx = t.Sent.FindIndex(IsEnable);
+            Assert.True(gateIdx >= 0, "ITM gate (FF 05 02 01) was not sent");
+            Assert.True(gateIdx < enableIdx, "ITM gate must precede the session enable");
+        }
+
+        [Fact]
+        public void Enable_SeedsLapInfoSubscriptions()
+        {
+            var driver = MakeDriver(out _, out var clock);
+            Enable(driver, clock);
+
+            // Lap Info has 6 params; seeded so the first (Enable-default) page populates
+            // before any firmware push.
+            Assert.Equal(6, driver.SubscriptionCount);
+        }
+
+        [Fact]
+        public void Enable_DoesNotOverwriteAlreadyReceivedSubscriptions()
+        {
+            var driver = MakeDriver(out _, out var clock);
+            driver.OnSubscriptionReport(TyreSubReport);   // 4 subs arrive before Enable
+            Enable(driver, clock);
+
+            Assert.Equal(4, driver.SubscriptionCount);    // seed skipped
+        }
+
+        [Fact]
+        public void Running_SendsKeepalive_OnInterval()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            t.Sent.Clear();
+
+            clock.T += 100;
+            driver.Update(EmptyData());
+
+            Assert.Contains(t.Sent, IsKeepalive);
+        }
+
+        // ── Enable/disable gate ──────────────────────────────────────────
+        private static bool IsItmModeOff(byte[] r) => r[1] == 0x05 && r[2] == 0x02 && r[3] == 0x00;
+
+        [Fact]
+        public void Disabled_SendsItmModeOff_AndGoesDormant()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            t.Sent.Clear();
+
+            driver.Enabled = false;
+            driver.Update(EmptyData());
+
+            Assert.Contains(t.Sent, IsItmModeOff);   // FF 05 02 00 sent
+            Assert.False(driver.IsRunning);
+            Assert.Equal(0, driver.SubscriptionCount);
+
+            // Dormant: no keepalives/values on later ticks.
+            t.Sent.Clear();
+            clock.T += 500;
+            driver.Update(EmptyData());
+            Assert.Empty(t.Sent);
+        }
+
+        [Fact]
+        public void Disabled_SendsItmModeOff_OnlyOnce()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.Enabled = false;
+
+            driver.Update(EmptyData());
+            clock.T += 500;
+            driver.Update(EmptyData());
+
+            Assert.Single(t.Sent, IsItmModeOff);
+        }
+
+        [Fact]
+        public void ReEnable_AfterDisable_ResumesBringUp()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.Enabled = false;
+            driver.Update(EmptyData());
+            t.Sent.Clear();
+
+            driver.Enabled = true;
+            driver.Update(EmptyData());   // Disabled -> Enabling -> Running in one tick
+
+            Assert.True(driver.IsRunning);
+            Assert.Contains(t.Sent, IsItmModeOn);   // gate turned back on
+            Assert.Contains(t.Sent, IsEnable);      // session re-enabled
+        }
+
+        [Fact]
+        public void DisabledFromIdle_SendsItmModeOff_WithoutBringUp()
+        {
+            // User has ITM disabled from the start (never Start()ed): still enforce "off".
+            var driver = MakeDriver(out var t, out _);
+            driver.Enabled = false;
+            driver.Update(EmptyData());
+
+            Assert.Contains(t.Sent, IsItmModeOff);
+            Assert.DoesNotContain(t.Sent, IsEnable);
+            Assert.False(driver.IsRunning);
+        }
+
+        [Fact]
+        public void SendValues_UnknownSubscribedParam_LogsOnce()
+        {
+            var t = new RecordingTransport();
+            var clock = new Clock();
+            var logs = new List<string>();
+            var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, logs.Add);
+
+            // Subscribe param 9999 (outside every page layout) at handle 2 (fw 0x82).
+            driver.OnSubscriptionReport(HexToBytes("ff050103820f2700"));
+            driver.Start();
+            driver.Update(EmptyData());   // Enabling -> Running
+            clock.T += 40;
+            driver.Update(EmptyData());   // SendSubscribedValues encounters the unknown param
+            clock.T += 40;
+            driver.Update(EmptyData());   // ticks again — must not re-log
+
+            Assert.Single(logs, m => m.Contains("no encoder for subscribed param 9999"));
+        }
+
+        // ── Subscription handling ────────────────────────────────────────
+
+        [Fact]
+        public void OnSubscriptionReport_AddsSubscriptions()
+        {
+            var driver = MakeDriver(out _, out _);
+            driver.OnSubscriptionReport(TyreSubReport);
+            Assert.Equal(4, driver.SubscriptionCount);   // SPEED, GEAR, FL, RL
+        }
+
+        [Fact]
+        public void OnSubscriptionReport_UnsubscribeRemovesHandles()
+        {
+            var driver = MakeDriver(out _, out _);
+            driver.OnSubscriptionReport(TyreSubReport);
+
+            // Unsubscribe handles 0 and 1 (FF FF param).
+            driver.OnSubscriptionReport(HexToBytes("ff05010300ffff340301ffff12"));
+            Assert.Equal(2, driver.SubscriptionCount);   // FL, RL remain
+        }
+
+        // A firmware unsubscribe report (FF FF param) for the given handles.
+        private static byte[] UnsubReport(params byte[] handles)
+        {
+            var list = new List<byte> { 0xFF, 0x05, 0x01 };
+            foreach (var h in handles) { list.Add(0x03); list.Add(h); list.Add(0xFF); list.Add(0xFF); list.Add(0x00); }
+            return list.ToArray();
+        }
+
+        [Fact]
+        public void AllUnsubscribed_SendsNoValues()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);   // seeds the 6 Lap Info handles
+            driver.OnSubscriptionReport(UnsubReport(0, 1, 2, 3, 4, 5));
+            Assert.Equal(0, driver.SubscriptionCount);
+            t.Sent.Clear();
+
+            clock.T += 40;
+            driver.Update(Data(NewStatus()));
+
+            Assert.DoesNotContain(t.Sent, IsValueUpdate);   // nothing subscribed
+        }
+
+        [Fact]
+        public void SubscriptionWithUnits_SendsParamDefsSuffix()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);          // Lap Info seed
+            driver.OnSubscriptionReport(TyreSubReport);   // tyre temps carry 'C'
+            t.Sent.Clear();
+
+            clock.T += 40;
+            driver.Update(EmptyData());     // ParamDefs refreshed here
+
+            var pd = t.Sent.First(IsParamDefs);
+            // entry: [03][slot][posLo][posHi][suffixLen][suffix]; tyre FL handle 2 -> slot 0x82
+            Assert.Equal(0x03, pd[3]);
+            Assert.Equal(0x82, pd[4]);                 // slot = 0x80 | handle 2
+            Assert.Equal(0x01, pd[7]);                 // suffix length 1
+            Assert.Equal((byte)'C', pd[8]);            // Celsius
+        }
+
+        [Fact]
+        public void LapAndPosition_SendParamDefsTotalSuffix()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            var s = NewStatus();
+            Set(s, "TotalLaps", 34);
+            Set(s, "CurrentLap", 5);
+            Set(s, "OpponentsCount", 20);   // field of 20 (list already includes the player)
+            Set(s, "Position", 7);
+
+            driver.Start();
+            driver.Update(Data(s));         // Enable + seed Lap Info (lap@h2, position@h3)
+            t.Sent.Clear();
+            clock.T += 40;
+            driver.Update(Data(s));         // ParamDefs with the dynamic totals
+
+            var pd = t.Sent.First(IsParamDefs);
+            // First suffixed slot is lap (handle 2 -> slot 0x82) with "/34".
+            Assert.Equal(0x82, pd[4]);
+            Assert.Equal(0x03, pd[7]);                 // suffix length 3
+            Assert.Equal((byte)'/', pd[8]);
+            Assert.Equal((byte)'3', pd[9]);
+            Assert.Equal((byte)'4', pd[10]);
+        }
+
+        [Fact]
+        public void Total_ClearedWithEmptySuffix_WhenItBecomesImplausible()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            var s = NewStatus();
+            Set(s, "OpponentsCount", 2); Set(s, "Position", 2);   // field 2, P2 -> "/2"
+            driver.Start();
+            driver.Update(Data(s));          // Enable + seed (position@h3)
+            clock.T += 40;
+            driver.Update(Data(s));          // sends "/2" on the position slot
+            t.Sent.Clear();
+
+            Set(s, "Position", 3);           // now P3 in a field of 2 -> implausible
+            clock.T += 40;
+            driver.Update(Data(s));
+
+            // The position slot (0x83) must be re-emitted with an empty suffix to clear it.
+            var pd = t.Sent.First(IsParamDefs);
+            bool clearsPosition = false;
+            for (int i = 3; i + 5 <= pd.Length && pd[i] == 0x03; i += 5 + pd[i + 4])
+                if (pd[i + 1] == 0x83 && pd[i + 4] == 0x00) clearsPosition = true;
+            Assert.True(clearsPosition);
+        }
+
+        [Fact]
+        public void ShowPositionTotalOff_SuppressesPositionTotal()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            driver.ShowPositionTotal = false;
+            var s = NewStatus();
+            Set(s, "OpponentsCount", 20); Set(s, "Position", 7);   // would be "/20"
+            driver.Start();
+            driver.Update(Data(s));
+            clock.T += 40;
+            driver.Update(Data(s));
+
+            // Position slot (0x83) is present but with an empty suffix (length 0).
+            var pd = t.Sent.First(IsParamDefs);
+            for (int i = 3; i + 5 <= pd.Length && pd[i] == 0x03; i += 5 + pd[i + 4])
+                if (pd[i + 1] == 0x83) Assert.Equal(0x00, pd[i + 4]);   // suffix length 0
+        }
+
+        private static bool IsParamDefs(byte[] r) => r[1] == 0x05 && r[2] == 0x03;
+
+        [Fact]
+        public void Running_SendsValuesForSubscribedParams()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+            t.Sent.Clear();
+
+            var s = NewStatus();
+            Set(s, "TyreTemperatureFrontLeft", 88.0);
+            clock.T += 40;
+            driver.Update(Data(s));
+
+            var vu = t.Sent.First(IsValueUpdate);
+            // Header [FF 05 01], then entries [03][handle][idLo][idHi][size][val...].
+            // First subscribed handle is 0 (SPEED).
+            Assert.Equal(0x03, vu[3]);   // entry marker
+            Assert.Equal(0x00, vu[4]);   // handle 0
+            Assert.Contains(t.Sent, IsValueUpdate);
+        }
+
+        [Fact]
+        public void Values_NotResent_WhenUnchanged()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+
+            var s = NewStatus();
+            Set(s, "TyreTemperatureFrontLeft", 80.0);
+            clock.T += 40;
+            driver.Update(Data(s));
+            t.Sent.Clear();
+
+            clock.T += 100;
+            driver.Update(Data(s));   // identical telemetry
+
+            Assert.DoesNotContain(t.Sent, IsValueUpdate);
+        }
+
+        [Fact]
+        public void Values_Resent_WhenSubscriptionChanges()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+
+            var s = NewStatus();
+            clock.T += 40;
+            driver.Update(Data(s));
+            t.Sent.Clear();
+
+            // A new subscription report forces a fresh send even with identical telemetry.
+            driver.OnSubscriptionReport(TyreSubReport);
+            clock.T += 40;
+            driver.Update(Data(s));
+
+            Assert.Contains(t.Sent, IsValueUpdate);
+        }
+
+        [Fact]
+        public void Values_RateLimited_WithinInterval()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+
+            var s = NewStatus();
+            Set(s, "TyreTemperatureFrontLeft", 80.0);
+            clock.T += 40;
+            driver.Update(Data(s));
+            t.Sent.Clear();
+
+            Set(s, "TyreTemperatureFrontLeft", 90.0);
+            clock.T += 10;   // within ValueIntervalMs
+            driver.Update(Data(s));
+
+            Assert.DoesNotContain(t.Sent, IsValueUpdate);
+        }
+
+        // ── Stop / restart ───────────────────────────────────────────────
+
+        [Fact]
+        public void Stop_ClearsSubscriptionsAndHalts()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+
+            driver.Stop();
+            Assert.False(driver.IsRunning);
+            Assert.Equal(0, driver.SubscriptionCount);
+            t.Sent.Clear();
+
+            clock.T += 1000;
+            driver.Update(EmptyData());
+            Assert.Empty(t.Sent);
+
+            driver.Start();
+            driver.Update(EmptyData());
+            Assert.Contains(t.Sent, IsEnable);   // fresh Enable on restart
+        }
+    }
+}

--- a/FanaBridge.Tests/ItmEncoderTests.cs
+++ b/FanaBridge.Tests/ItmEncoderTests.cs
@@ -1,0 +1,463 @@
+using System;
+using System.Collections.Generic;
+using FanaBridge.Protocol;
+using FanaBridge.Transport;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class ItmEncoderTests
+    {
+        // ── Test stub ────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Records every col03 report the encoder emits. ITM uses only the col03
+        /// path; SendCol03 can be made to fail to exercise the AND-of-sends result.
+        /// </summary>
+        private class RecordingTransport : IDeviceTransport
+        {
+            public bool IsConnected { get; set; } = true;
+            public int Col03MaxInputReportLength { get; set; } = 64;
+            public bool FailSends { get; set; }
+
+            public List<byte[]> SentCol03Reports { get; } = new List<byte[]>();
+            public int BatchDepth { get; private set; }
+
+            public bool SendCol03(byte[] data)
+            {
+                var copy = new byte[data.Length];
+                Array.Copy(data, copy, data.Length);
+                SentCol03Reports.Add(copy);
+                return !FailSends;
+            }
+
+            public bool SendCol01(byte[] data) => true;
+            public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+
+            public IDisposable BeginBatch()
+            {
+                BatchDepth++;
+                return new BatchScope(this);
+            }
+
+            private sealed class BatchScope : IDisposable
+            {
+                private readonly RecordingTransport _t;
+                private bool _done;
+                public BatchScope(RecordingTransport t) { _t = t; }
+                public void Dispose() { if (!_done) { _done = true; _t.BatchDepth--; } }
+            }
+
+            public byte[] Last => SentCol03Reports[SentCol03Reports.Count - 1];
+        }
+
+        private static ItmEncoder MakeEncoder(out RecordingTransport transport)
+        {
+            transport = new RecordingTransport();
+            return new ItmEncoder(transport);
+        }
+
+        // ── Construction ─────────────────────────────────────────────────
+
+        [Fact]
+        public void Ctor_NullTransport_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ItmEncoder(null));
+        }
+
+        // ── Enable ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void EnableItm_BuildsExpectedFrame()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            Assert.True(encoder.EnableItm());
+
+            var r = t.Last;
+            Assert.Equal(64, r.Length);
+            Assert.Equal(0xFF, r[0]);
+            Assert.Equal(0x02, r[1]);   // command class — ITM enable
+            Assert.Equal(0x02, r[2]);   // sub-command
+            Assert.Equal(0x00, r[3]);   // default page
+        }
+
+        [Fact]
+        public void EnableItm_CarriesPageByte()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            encoder.EnableItm(4);
+
+            Assert.Equal(0x04, t.Last[3]);
+        }
+
+        [Fact]
+        public void SetItmMode_BuildsGateFrame()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            encoder.SetItmMode(true);
+            var on = t.Last;
+            Assert.Equal(0xFF, on[0]);
+            Assert.Equal(0x05, on[1]);   // ITM display class
+            Assert.Equal(0x02, on[2]);   // ITM mode gate
+            Assert.Equal(0x01, on[3]);   // on
+
+            encoder.SetItmMode(false);
+            Assert.Equal(0x00, t.Last[3]);   // off
+        }
+
+        // ── PageSet ──────────────────────────────────────────────────────
+
+        [Fact]
+        public void SetPage_BuildsExpectedFrame()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            encoder.SetPage(ItmDevice.BmeOrGtswx, 3);
+
+            var r = t.Last;
+            Assert.Equal(0xFF, r[0]);
+            Assert.Equal(0x05, r[1]);
+            Assert.Equal(0x04, r[2]);
+            Assert.Equal(0x03, r[3]);   // device ID 3 (BME/GTSWX)
+            Assert.Equal(0x03, r[4]);   // page
+        }
+
+        [Fact]
+        public void SetPage_DeviceEnumMapsToWireId()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            encoder.SetPage(ItmDevice.Base, 1);
+            Assert.Equal(0x01, t.Last[3]);
+
+            encoder.SetPage(ItmDevice.Bentley, 2);
+            Assert.Equal(0x04, t.Last[3]);
+        }
+
+        // ── Keepalive ────────────────────────────────────────────────────
+
+        [Fact]
+        public void SendKeepalive_BuildsExpectedFrame()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            encoder.SendKeepalive();
+
+            var r = t.Last;
+            Assert.Equal(0xFF, r[0]);
+            Assert.Equal(0x05, r[1]);
+            Assert.Equal(0x04, r[2]);
+            Assert.Equal(0x02, r[3]);
+            Assert.Equal(0x0B, r[4]);
+        }
+
+        // ── ValueUpdate framing ──────────────────────────────────────────
+
+        [Fact]
+        public void SendValues_PacksHeaderAndEntry()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            // SPEED (id 1), Int16 LE, value 142 = 0x008E
+            Assert.True(encoder.SendValues(new[] { ItmValue.Int16(0, 1, 142) }));
+
+            var r = t.Last;
+            Assert.Equal(0xFF, r[0]);
+            Assert.Equal(0x05, r[1]);
+            Assert.Equal(0x01, r[2]);   // subcmd ValueUpdate
+            // entry: marker, handle, idLo, idHi, size, value LE
+            Assert.Equal(0x03, r[3]);   // marker (0x03, confirmed by capture — not 0x01)
+            Assert.Equal(0x00, r[4]);   // handle
+            Assert.Equal(0x01, r[5]);   // param id lo
+            Assert.Equal(0x00, r[6]);   // param id hi
+            Assert.Equal(0x02, r[7]);   // size
+            Assert.Equal(0x8E, r[8]);   // value lo
+            Assert.Equal(0x00, r[9]);   // value hi
+        }
+
+        [Fact]
+        public void SendValues_UInt8_EmitsSingleValueByte()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            // GEAR (id 4), Uint8, value 5
+            encoder.SendValues(new[] { ItmValue.UInt8(2, 4, 5) });
+
+            var r = t.Last;
+            Assert.Equal(0x03, r[3]);   // marker
+            Assert.Equal(0x02, r[4]);   // handle
+            Assert.Equal(0x04, r[5]);   // id lo
+            Assert.Equal(0x00, r[6]);   // id hi
+            Assert.Equal(0x01, r[7]);   // size
+            Assert.Equal(0x05, r[8]);   // value
+        }
+
+        [Fact]
+        public void SendValues_Int32_EmitsLittleEndian()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            // RPM (id 2), Int32, value 0x01020304
+            encoder.SendValues(new[] { ItmValue.Int32(1, 2, 0x01020304) });
+
+            var r = t.Last;
+            Assert.Equal(0x04, r[7]);   // size
+            Assert.Equal(0x04, r[8]);   // LE byte 0
+            Assert.Equal(0x03, r[9]);
+            Assert.Equal(0x02, r[10]);
+            Assert.Equal(0x01, r[11]);
+        }
+
+        [Fact]
+        public void SendValues_Float32_EmitsIeee754LittleEndian()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            // 1.0f = 0x3F800000
+            encoder.SendValues(new[] { ItmValue.Float32(0, 509, 1.0f) });
+
+            var r = t.Last;
+            Assert.Equal(0x04, r[7]);   // size
+            Assert.Equal(0x00, r[8]);
+            Assert.Equal(0x00, r[9]);
+            Assert.Equal(0x80, r[10]);
+            Assert.Equal(0x3F, r[11]);
+        }
+
+        [Fact]
+        public void Float32_SanitizesNaNAndInfinity()
+        {
+            // NaN/Inf would wedge the firmware — they must become 0 (bits 0x00000000).
+            Assert.Equal(0u, ItmValue.Float32(0, 1, float.NaN).Raw);
+            Assert.Equal(0u, ItmValue.Float32(0, 1, float.PositiveInfinity).Raw);
+            Assert.Equal(0u, ItmValue.Float32(0, 1, float.NegativeInfinity).Raw);
+        }
+
+        [Fact]
+        public void Float32_ClampsAbsurdMagnitude()
+        {
+            var v = ItmValue.Float32(0, 1, 1e9f);
+            float decoded = BitConverter.ToSingle(BitConverter.GetBytes(v.Raw), 0);
+            Assert.Equal(1_000_000f, decoded);
+        }
+
+        [Fact]
+        public void SendValues_MultipleEntries_PackedIntoOneReport()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            encoder.SendValues(new[]
+            {
+                ItmValue.Int16(0, 1, 100),   // 7 bytes
+                ItmValue.UInt8(1, 4, 3),     // 6 bytes
+            });
+
+            Assert.Single(t.SentCol03Reports);
+            var r = t.Last;
+            // second entry starts right after the first (3 header + 7)
+            Assert.Equal(0x03, r[10]);   // marker of 2nd entry
+            Assert.Equal(0x01, r[11]);   // handle
+            Assert.Equal(0x04, r[12]);   // id lo
+        }
+
+        [Fact]
+        public void SendValues_OverflowSplitsAcrossReports()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            // 9 Int32 entries × 9 bytes = 81 bytes payload > 61 → needs 2 reports.
+            var values = new List<ItmValue>();
+            for (int i = 0; i < 9; i++)
+                values.Add(ItmValue.Int32((byte)i, 2, i));
+
+            Assert.True(encoder.SendValues(values));
+            Assert.Equal(2, t.SentCol03Reports.Count);
+            // every report keeps the FF 05 01 header
+            foreach (var r in t.SentCol03Reports)
+            {
+                Assert.Equal(0xFF, r[0]);
+                Assert.Equal(0x05, r[1]);
+                Assert.Equal(0x01, r[2]);
+            }
+        }
+
+        [Fact]
+        public void SendValues_UsesBatchForAtomicity()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            encoder.SendValues(new[] { ItmValue.Int16(0, 1, 1) });
+
+            Assert.Equal(0, t.BatchDepth);   // batch opened and released
+        }
+
+        [Theory]
+        [InlineData(null)]
+        public void SendValues_NullList_ReturnsFalse(IReadOnlyList<ItmValue> values)
+        {
+            var encoder = MakeEncoder(out var t);
+            Assert.False(encoder.SendValues(values));
+            Assert.Empty(t.SentCol03Reports);
+        }
+
+        [Fact]
+        public void SendValues_EmptyList_ReturnsFalse()
+        {
+            var encoder = MakeEncoder(out var t);
+            Assert.False(encoder.SendValues(new ItmValue[0]));
+            Assert.Empty(t.SentCol03Reports);
+        }
+
+        [Fact]
+        public void SendValues_TooManyParams_ReturnsFalse()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            var values = new List<ItmValue>();
+            for (int i = 0; i < ItmEncoder.MaxParams + 1; i++)
+                values.Add(ItmValue.UInt8(0, 4, 0));
+
+            Assert.False(encoder.SendValues(values));
+            Assert.Empty(t.SentCol03Reports);
+        }
+
+        [Fact]
+        public void SendValues_BadSize_ReturnsFalse()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            // Widths outside 1..4 are invalid (0 and 5 here). Size 3 is valid — ASCII text.
+            Assert.False(encoder.SendValues(new[] { new ItmValue(0, 1, 0, 0) }));
+            Assert.False(encoder.SendValues(new[] { new ItmValue(0, 1, 5, 0) }));
+        }
+
+        [Fact]
+        public void SendValues_AsciiThreeBytes_IsSent()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            // ENGINE_MAPPING-style 3-char ASCII value ("100") must be accepted and framed.
+            Assert.True(encoder.SendValues(new[] { ItmValue.Ascii(4, 26, "100") }));
+            var r = t.Last;
+            // FF 05 01 <marker=03> <handle=04> <id 26 LE=1a00> <size=03> '1' '0' '0'
+            var expected = new byte[] { 0xFF, 0x05, 0x01, 0x03, 0x04, 0x1A, 0x00, 0x03, 0x31, 0x30, 0x30 };
+            for (int i = 0; i < expected.Length; i++)
+                Assert.Equal(expected[i], r[i]);
+        }
+
+        [Fact]
+        public void SendValues_PropagatesTransportFailure()
+        {
+            var encoder = MakeEncoder(out var t);
+            t.FailSends = true;
+
+            Assert.False(encoder.SendValues(new[] { ItmValue.UInt8(0, 4, 1) }));
+        }
+
+        // ── ParamDefs framing ────────────────────────────────────────────
+
+        [Fact]
+        public void SetParamDefs_PacksHeaderAndEntry()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            Assert.True(encoder.SetParamDefs(new[] { new ItmParamDef(0x82) }));
+
+            var r = t.Last;
+            Assert.Equal(0xFF, r[0]);
+            Assert.Equal(0x05, r[1]);
+            Assert.Equal(0x03, r[2]);   // subcmd ParamDefs
+            // entry: marker, slotId, posLo, posHi, suffixLen
+            Assert.Equal(0x03, r[3]);   // marker
+            Assert.Equal(0x82, r[4]);   // slot id
+            Assert.Equal(0x00, r[5]);   // pos lo
+            Assert.Equal(0x00, r[6]);   // pos hi
+            Assert.Equal(0x00, r[7]);   // suffix length
+        }
+
+        [Fact]
+        public void SetParamDefs_EncodesSuffixBytes()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            // "/0" total-companion suffix from the protocol reference.
+            encoder.SetParamDefs(new[] { ItmParamDef.WithSuffix(0x82, "/0") });
+
+            var r = t.Last;
+            Assert.Equal(0x82, r[4]);
+            Assert.Equal(0x02, r[7]);   // suffix length
+            Assert.Equal((byte)'/', r[8]);
+            Assert.Equal((byte)'0', r[9]);
+        }
+
+        [Fact]
+        public void SetParamDefs_EncodesPositionLittleEndian()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            encoder.SetParamDefs(new[] { new ItmParamDef(0x85, 0x0102) });
+
+            var r = t.Last;
+            Assert.Equal(0x02, r[5]);   // pos lo
+            Assert.Equal(0x01, r[6]);   // pos hi
+        }
+
+        [Fact]
+        public void SetParamDefs_OverflowSplitsAcrossReports()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            // Each entry with a max suffix nearly fills a report, forcing a split.
+            var big = new string('x', ItmEncoder.MaxSuffixLength);
+            var defs = new[]
+            {
+                ItmParamDef.WithSuffix(0x82, big),
+                ItmParamDef.WithSuffix(0x83, big),
+            };
+
+            Assert.True(encoder.SetParamDefs(defs));
+            Assert.Equal(2, t.SentCol03Reports.Count);
+            foreach (var r in t.SentCol03Reports)
+            {
+                Assert.Equal(0xFF, r[0]);
+                Assert.Equal(0x05, r[1]);
+                Assert.Equal(0x03, r[2]);
+            }
+        }
+
+        [Fact]
+        public void SetParamDefs_SuffixTooLong_ReturnsFalse()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            var tooLong = new string('x', ItmEncoder.MaxSuffixLength + 1);
+            Assert.False(encoder.SetParamDefs(new[] { ItmParamDef.WithSuffix(0x82, tooLong) }));
+        }
+
+        [Fact]
+        public void SetParamDefs_NullOrEmpty_ReturnsFalse()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            Assert.False(encoder.SetParamDefs(null));
+            Assert.False(encoder.SetParamDefs(new ItmParamDef[0]));
+            Assert.Empty(t.SentCol03Reports);
+        }
+
+        [Fact]
+        public void SetParamDefs_TooManyParams_ReturnsFalse()
+        {
+            var encoder = MakeEncoder(out var t);
+
+            var defs = new List<ItmParamDef>();
+            for (int i = 0; i < ItmEncoder.MaxParams + 1; i++)
+                defs.Add(new ItmParamDef(0x82));
+
+            Assert.False(encoder.SetParamDefs(defs));
+            Assert.Empty(t.SentCol03Reports);
+        }
+    }
+}

--- a/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -1,0 +1,431 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using FanaBridge.Protocol;
+using GameReaderCommon;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class ItmTelemetryTests
+    {
+        // ── GameData construction (see FanatecDisplayDriverTests) ─────────
+        // StatusDataBase is abstract with internal setters; its only concrete
+        // subclass is StatusData<T>. Close it over object, create uninitialized,
+        // and drive the internal setters by reflection.
+        private static readonly Type StatusDataType =
+            typeof(GameData).Assembly
+                .GetType("GameReaderCommon.StatusData`1")
+                .MakeGenericType(typeof(object));
+
+        private static object NewStatus() =>
+            FormatterServices.GetUninitializedObject(StatusDataType);
+
+        private static void Set(object status, string property, object value) =>
+            status.GetType().GetProperty(property).GetSetMethod(true)
+                .Invoke(status, new[] { value });
+
+        private static GameData Wrap(object status) =>
+            new GameData { NewData = (StatusDataBase)status };
+
+        // ── ItmValue decoders ────────────────────────────────────────────
+        private static short AsI16(ItmValue v) => unchecked((short)(ushort)v.Raw);
+        private static int AsI32(ItmValue v) => unchecked((int)v.Raw);
+        private static byte AsU8(ItmValue v) => (byte)v.Raw;
+        private static float AsF32(ItmValue v) => BitConverter.ToSingle(BitConverter.GetBytes(v.Raw), 0);
+        private static string AsAscii(ItmValue v)
+        {
+            var sb = new System.Text.StringBuilder();
+            uint raw = v.Raw;
+            for (int i = 0; i < v.Size; i++) { sb.Append((char)(byte)(raw & 0xFF)); raw >>= 8; }
+            return sb.ToString();
+        }
+
+        // ── ParamsFor ────────────────────────────────────────────────────
+
+        [Fact]
+        public void ParamsFor_LapInfo_HasExpectedOrder()
+        {
+            Assert.Equal(
+                new ushort[] { 1, 4, 505, 501, 509, 510 },
+                ParamsArray(ItmPage.LapInfo));
+        }
+
+        [Fact]
+        public void ParamsFor_AllPages_LeadWithSpeedAndGear()
+        {
+            foreach (ItmPage page in new[]
+                { ItmPage.LapInfo, ItmPage.FuelErsDrs, ItmPage.CarSettings, ItmPage.LapTimes, ItmPage.TyreTemps })
+            {
+                var ids = ParamsArray(page);
+                Assert.Equal(ItmParam.Speed, ids[0]);
+                Assert.Equal(ItmParam.Gear, ids[1]);
+            }
+        }
+
+        [Fact]
+        public void ParamsFor_Legacy_IsEmpty()
+        {
+            Assert.Empty(ParamsArray(ItmPage.Legacy));
+        }
+
+        private static ushort[] ParamsArray(ItmPage page)
+        {
+            var list = ItmTelemetry.ParamsFor(page);
+            var arr = new ushort[list.Count];
+            for (int i = 0; i < list.Count; i++) arr[i] = list[i];
+            return arr;
+        }
+
+        // ── BuildValues guards ───────────────────────────────────────────
+
+        [Fact]
+        public void BuildValues_NullData_IsEmpty()
+        {
+            Assert.Empty(ItmTelemetry.BuildValues(ItmPage.LapInfo, null));
+            Assert.Empty(ItmTelemetry.BuildValues(ItmPage.LapInfo, new GameData())); // NewData null
+        }
+
+        [Fact]
+        public void BuildValues_LegacyPage_IsEmpty()
+        {
+            Assert.Empty(ItmTelemetry.BuildValues(ItmPage.Legacy, Wrap(NewStatus())));
+        }
+
+        [Fact]
+        public void BuildValues_AssignsSequentialHandles()
+        {
+            var values = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(NewStatus()));
+
+            for (int i = 0; i < values.Count; i++)
+                Assert.Equal((byte)i, values[i].Handle);
+        }
+
+        [Fact]
+        public void BuildValues_HandleBase_OffsetsHandles()
+        {
+            var values = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(NewStatus()), handleBase: 2);
+
+            for (int i = 0; i < values.Count; i++)
+                Assert.Equal((byte)(2 + i), values[i].Handle);
+        }
+
+        // ── LapInfo encoding ─────────────────────────────────────────────
+
+        [Fact]
+        public void LapInfo_EncodesHeaderAndTimingFields()
+        {
+            var s = NewStatus();
+            Set(s, "SpeedLocal", 142.4);
+            Set(s, "Gear", "3");
+            Set(s, "CurrentLap", 5);
+            Set(s, "Position", 7);
+            Set(s, "CurrentLapTime", TimeSpan.FromSeconds(83.5));
+            Set(s, "LastLapTime", TimeSpan.FromSeconds(82.25));
+
+            var v = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(s));
+
+            Assert.Equal(ItmParam.Speed, v[0].ParamId);
+            Assert.Equal((short)142, AsI16(v[0]));     // SpeedLocal rounded
+            Assert.Equal(ItmParam.Gear, v[1].ParamId);
+            Assert.Equal((byte)3, AsU8(v[1]));
+            Assert.Equal(ItmParam.Lap, v[2].ParamId);
+            Assert.Equal((byte)5, AsU8(v[2]));
+            Assert.Equal(ItmParam.Position, v[3].ParamId);
+            Assert.Equal((byte)7, AsU8(v[3]));
+            Assert.Equal(ItmParam.LapTime, v[4].ParamId);
+            Assert.Equal(83.5f, AsF32(v[4]), 3);
+            Assert.Equal(ItmParam.LastLapTime, v[5].ParamId);
+            Assert.Equal(82.25f, AsF32(v[5]), 3);
+        }
+
+        [Theory]
+        [InlineData("N", 0)]
+        [InlineData("", 0)]
+        [InlineData("R", 0xFF)]      // reverse sentinel (-1 as uint8, rendered "r")
+        [InlineData("reverse", 0xFF)]
+        [InlineData("4", 4)]
+        [InlineData("garbage", 0)]
+        public void Gear_ParsesToUint8(string gear, int expected)
+        {
+            var s = NewStatus();
+            Set(s, "Gear", gear);
+
+            var v = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(s));
+
+            Assert.Equal((byte)expected, AsU8(v[1]));
+        }
+
+        [Theory]
+        [InlineData(-10, 0)]              // negative speed clamps to 0
+        [InlineData(40000, short.MaxValue)] // beyond Int16 clamps
+        public void Speed_ClampsToInt16Range(double speedLocal, int expected)
+        {
+            var s = NewStatus();
+            Set(s, "SpeedLocal", speedLocal);
+
+            var v = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(s));
+
+            Assert.Equal((short)expected, AsI16(v[0]));
+        }
+
+        // ── CarSettings encoding ─────────────────────────────────────────
+
+        [Fact]
+        public void CarSettings_BrakeBias_SentAsTenthsOfPercentInt32()
+        {
+            var s = NewStatus();
+            Set(s, "BrakeBias", 51.2);   // percentage from SimHub
+
+            var v = ItmTelemetry.BuildValues(ItmPage.CarSettings, Wrap(s));
+
+            // Order (per capture): Speed, Gear, TC, ABS, EngineMap, OilTemp, BrakeBias.
+            // Int32 in tenths of a percent — 51.2% => 512 (confirmed by capture).
+            Assert.Equal(ItmParam.BrakeBias, v[6].ParamId);
+            Assert.Equal(4, v[6].Size);
+            Assert.Equal(512, AsI32(v[6]));
+        }
+
+        [Fact]
+        public void CarSettings_BrakeBias_ClampsTo1000()
+        {
+            var s = NewStatus();
+            Set(s, "BrakeBias", 150.0);   // absurd; clamps to 1000 (100.0%)
+
+            var v = ItmTelemetry.BuildValues(ItmPage.CarSettings, Wrap(s));
+
+            Assert.Equal(1000, AsI32(v[6]));
+        }
+
+        [Fact]
+        public void CarSettings_EncodesSettingsBytes()
+        {
+            var s = NewStatus();
+            Set(s, "TCLevel", 4);
+            Set(s, "ABSLevel", 2);
+            Set(s, "EngineMap", 6);
+            Set(s, "OilTemperature", 98.7);
+
+            var v = ItmTelemetry.BuildValues(ItmPage.CarSettings, Wrap(s));
+
+            Assert.Equal(ItmParam.TcSetting, v[2].ParamId);
+            Assert.Equal((byte)4, AsU8(v[2]));
+            Assert.Equal(ItmParam.AbsSetting, v[3].ParamId);
+            Assert.Equal((byte)2, AsU8(v[3]));
+            // ENGINE_MAPPING is ASCII text — map 6 travels as the single byte '6'.
+            Assert.Equal(ItmParam.EngineMapping, v[4].ParamId);
+            Assert.Equal((byte)1, v[4].Size);
+            Assert.Equal("6", AsAscii(v[4]));
+            Assert.Equal(ItmParam.OilTemp, v[5].ParamId);
+            Assert.Equal((byte)99, AsU8(v[5]));   // 98.7 rounds to 99
+        }
+
+        // ── FuelErsDrs encoding ──────────────────────────────────────────
+
+        [Fact]
+        public void FuelErsDrs_EncodesFuelErsAndDrsFlags()
+        {
+            var s = NewStatus();
+            Set(s, "Fuel", 12.5);
+            Set(s, "ERSPercent", 73.0);
+            Set(s, "DRSAvailable", 1);
+            Set(s, "DRSEnabled", 0);
+
+            var v = ItmTelemetry.BuildValues(ItmPage.FuelErsDrs, Wrap(s));
+
+            Assert.Equal(ItmParam.Fuel, v[2].ParamId);
+            Assert.Equal(12.5f, AsF32(v[2]), 3);
+            Assert.Equal(ItmParam.ErsLevel, v[3].ParamId);
+            Assert.Equal(73, AsI32(v[3]));
+            Assert.Equal(ItmParam.DrsZone, v[4].ParamId);
+            Assert.Equal((byte)1, AsU8(v[4]));
+            Assert.Equal(ItmParam.DrsActive, v[5].ParamId);
+            Assert.Equal((byte)0, AsU8(v[5]));
+        }
+
+        // ── TyreTemps encoding ───────────────────────────────────────────
+
+        // ── Subscription report parsing (firmware-driven path) ───────────
+
+        // Real tyre-page subscription report from the official-software capture:
+        // FF 05 01, then [03][fwHandle][paramId-LE][unit] entries.
+        private static byte[] HexToBytes(string hex)
+        {
+            var b = new byte[hex.Length / 2];
+            for (int i = 0; i < b.Length; i++) b[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            return b;
+        }
+
+        [Fact]
+        public void ParseSubscriptionReport_TyrePage_DecodesHandlesAndParams()
+        {
+            // h0=SPEED, h1=GEAR, h0x82=FL(42), h0x83=RL(48) — four complete entries.
+            var report = HexToBytes("ff05010300010034030104001203822a00320383300032");
+            var subs = ItmTelemetry.ParseSubscriptionReport(report, report.Length);
+
+            Assert.Equal(4, subs.Count);
+            Assert.Equal(0, subs[0].Handle); Assert.Equal(ItmParam.Speed, subs[0].ParamId);
+            Assert.Equal(1, subs[1].Handle); Assert.Equal(ItmParam.Gear, subs[1].ParamId);
+            // 0x82 -> host handle 2 (slot-marker bit cleared)
+            Assert.Equal(2, subs[2].Handle); Assert.Equal(ItmParam.TyreFlTemp, subs[2].ParamId);
+            Assert.Equal(3, subs[3].Handle); Assert.Equal(ItmParam.TyreRlTemp, subs[3].ParamId);
+            Assert.All(subs, s => Assert.False(s.IsUnsubscribe));
+        }
+
+        [Fact]
+        public void ParseSubscriptionReport_DecodesUnsubscribe()
+        {
+            // FF 05 01, then [03][h][FF FF][unit] entries = unsubscribe
+            var report = HexToBytes("ff05010300ffff340301ffff12");
+            var subs = ItmTelemetry.ParseSubscriptionReport(report, report.Length);
+
+            Assert.Equal(2, subs.Count);
+            Assert.True(subs[0].IsUnsubscribe);
+            Assert.True(subs[1].IsUnsubscribe);
+            Assert.Equal(0, subs[0].Handle);
+            Assert.Equal(1, subs[1].Handle);
+        }
+
+        [Fact]
+        public void ParseSubscriptionReport_NonItm_IsEmpty()
+        {
+            Assert.Empty(ItmTelemetry.ParseSubscriptionReport(HexToBytes("ff080c00"), 4));
+            Assert.Empty(ItmTelemetry.ParseSubscriptionReport(null, 0));
+        }
+
+        [Fact]
+        public void TryEncodeParam_KnownParam_Encodes()
+        {
+            var s = NewStatus();
+            Set(s, "TyreTemperatureFrontLeft", 88.0);
+
+            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.TyreFlTemp, 2, Wrap(s), out var v));
+            Assert.Equal(2, v.Handle);
+            Assert.Equal(ItmParam.TyreFlTemp, v.ParamId);
+            Assert.Equal((byte)88, AsU8(v));
+        }
+
+        [Fact]
+        public void TryEncodeParam_UnknownParam_ReturnsFalse()
+        {
+            Assert.False(ItmTelemetry.TryEncodeParam(9999, 0, Wrap(NewStatus()), out _));
+        }
+
+        [Fact]
+        public void TryEncodeParam_EngineMapping_SentAsAsciiText()
+        {
+            // ENGINE_MAPPING is ASCII on the wire: map 3 => single byte '3' (0x33).
+            var s = NewStatus();
+            Set(s, "EngineMap", 3);
+            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.EngineMapping, 4, Wrap(s), out var v));
+            Assert.Equal((byte)1, v.Size);
+            Assert.Equal("3", AsAscii(v));
+        }
+
+        [Fact]
+        public void TryEncodeParam_EngineMapping_TwoDigitIsTwoBytes()
+        {
+            // Map 10 => two bytes '1','0' (matches official capture: p26 sz2 = 3130).
+            var s = NewStatus();
+            Set(s, "EngineMap", 10);
+            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.EngineMapping, 4, Wrap(s), out var v));
+            Assert.Equal((byte)2, v.Size);
+            Assert.Equal("10", AsAscii(v));
+        }
+
+        // ── Car ahead / behind gaps ──────────────────────────────────────
+
+        private static readonly Type OpponentType =
+            typeof(GameData).Assembly.GetType("GameReaderCommon.Opponent");
+
+        private static IList OpponentList(params double?[] relGaps)
+        {
+            var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(OpponentType));
+            var setter = OpponentType.GetProperty("RelativeGapToPlayer").GetSetMethod(true);
+            foreach (var g in relGaps)
+            {
+                var opp = FormatterServices.GetUninitializedObject(OpponentType);
+                setter.Invoke(opp, new object[] { g });
+                list.Add(opp);
+            }
+            return list;
+        }
+
+        [Fact]
+        public void CarAhead_NoOpponents_IsZero()
+        {
+            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.CarAhead, 4, Wrap(NewStatus()), out var v));
+            Assert.Equal(0f, AsF32(v), 3);
+        }
+
+        [Fact]
+        public void CarAheadBehind_UseNearestOpponentGap()
+        {
+            var s = NewStatus();
+            Set(s, "OpponentsAheadOnTrack", OpponentList(2.5, 0.8, 5.0));    // nearest = 0.8
+            Set(s, "OpponentsBehindOnTrack", OpponentList(-1.2, -3.4));     // nearest = 1.2 (abs)
+
+            // Car ahead is negative (you're behind them); car behind is positive.
+            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.CarAhead, 4, Wrap(s), out var ahead));
+            Assert.Equal(-0.8f, AsF32(ahead), 3);
+            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.CarBehind, 5, Wrap(s), out var behind));
+            Assert.Equal(1.2f, AsF32(behind), 3);
+        }
+
+        // ── Total suffixes (lap/position) ────────────────────────────────
+
+        [Fact]
+        public void TotalSuffix_ShownForPlausibleTotals()
+        {
+            var s = NewStatus();
+            Set(s, "TotalLaps", 34); Set(s, "CurrentLap", 5);
+            Set(s, "OpponentsCount", 20); Set(s, "Position", 7);
+
+            Assert.True(ItmTelemetry.TryGetTotalSuffix(ItmParam.Lap, Wrap(s), out var lap));
+            Assert.Equal("/34", lap);
+            Assert.True(ItmTelemetry.TryGetTotalSuffix(ItmParam.Position, Wrap(s), out var pos));
+            Assert.Equal("/20", pos);   // field = OpponentsCount (list includes the player)
+        }
+
+        [Fact]
+        public void TotalSuffix_SuppressedWhenGameLacksRaceStructure()
+        {
+            // Forza-like: TotalLaps 0, only 1 reported opponent while in P7.
+            var s = NewStatus();
+            Set(s, "TotalLaps", 0); Set(s, "CurrentLap", 1);
+            Set(s, "OpponentsCount", 1); Set(s, "Position", 7);
+
+            Assert.False(ItmTelemetry.TryGetTotalSuffix(ItmParam.Lap, Wrap(s), out _));
+            Assert.False(ItmTelemetry.TryGetTotalSuffix(ItmParam.Position, Wrap(s), out _));
+        }
+
+        [Fact]
+        public void TotalSuffix_NoneForParamWithoutTotal()
+        {
+            Assert.False(ItmTelemetry.TryGetTotalSuffix(ItmParam.Speed, Wrap(NewStatus()), out _));
+        }
+
+        [Fact]
+        public void TyreTemps_EncodesAllFourCorners()
+        {
+            var s = NewStatus();
+            Set(s, "TyreTemperatureFrontLeft", 85.0);
+            Set(s, "TyreTemperatureFrontRight", 86.0);
+            Set(s, "TyreTemperatureRearLeft", 90.0);
+            Set(s, "TyreTemperatureRearRight", 91.0);
+
+            var v = ItmTelemetry.BuildValues(ItmPage.TyreTemps, Wrap(s));
+
+            // Order (per capture): FL, RL, FR, RR
+            Assert.Equal(ItmParam.TyreFlTemp, v[2].ParamId);
+            Assert.Equal((byte)85, AsU8(v[2]));
+            Assert.Equal(ItmParam.TyreRlTemp, v[3].ParamId);
+            Assert.Equal((byte)90, AsU8(v[3]));
+            Assert.Equal(ItmParam.TyreFrTemp, v[4].ParamId);
+            Assert.Equal((byte)86, AsU8(v[4]));
+            Assert.Equal(ItmParam.TyreRrTemp, v[5].ParamId);
+            Assert.Equal((byte)91, AsU8(v[5]));
+        }
+    }
+}

--- a/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -140,6 +140,26 @@ namespace FanaBridge.Tests
             Assert.Equal(82.25f, AsF32(v[5]), 3);
         }
 
+        [Fact]
+        public void NonFiniteTelemetry_EncodesAsZero()
+        {
+            // NaN/Infinity must not slip through the clamp helpers into an undefined cast
+            // (which could send a garbage value to the firmware).
+            var s = NewStatus();
+            Set(s, "SpeedLocal", double.NaN);
+            Set(s, "OilTemperature", double.PositiveInfinity);
+            Set(s, "ERSPercent", double.NaN);
+
+            var lap = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(s));
+            Assert.Equal((short)0, AsI16(lap[0]));   // ClampSpeed(NaN) -> 0
+
+            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.OilTemp, 5, Wrap(s), out var oil));
+            Assert.Equal((byte)0, AsU8(oil));        // ClampByte(Inf) -> 0
+
+            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.ErsLevel, 3, Wrap(s), out var ers));
+            Assert.Equal(0, AsI32(ers));             // SafeRound(NaN) -> 0
+        }
+
         [Theory]
         [InlineData("N", 0)]
         [InlineData("", 0)]

--- a/FanaBridge/Adapters/DisplaySettings.cs
+++ b/FanaBridge/Adapters/DisplaySettings.cs
@@ -9,8 +9,38 @@ namespace FanaBridge.Adapters
         public const string DefaultMode = "Gear";
 
         /// <summary>
+        /// Sentinel <see cref="DisplayMode"/> meaning "no legacy page". Offered only on ITM
+        /// wheels, where the legacy gear/speed page is optional; selecting it turns the
+        /// legacy page off. Basic 7-segment wheels never use this value.
+        /// </summary>
+        public const string ModeNone = "None";
+
+        /// <summary>
         /// Display mode: "Gear", "Speed", "GearAndSpeed", or "GearUpshiftBrackets".
+        /// On basic 7-segment wheels this is the only display. On ITM wheels it selects the
+        /// optional legacy gear/speed page's mode, and "None" turns that page off. ITM
+        /// telemetry pages themselves are firmware-driven (chosen with the wheel button).
         /// </summary>
         public string DisplayMode { get; set; } = DefaultMode;
+
+        // ── ITM options ───────────────────────────────────────────────────
+
+        public const bool DefaultItmEnabled = true;
+        /// <summary>
+        /// Whether the ITM telemetry display is enabled. Unchecking sends the firmware
+        /// "ITM off" command (as the Fanatec software does); rechecking re-enables it.
+        /// </summary>
+        public bool ItmEnabled { get; set; } = DefaultItmEnabled;
+
+        // Some games don't report a usable total laps or field size, producing misleading
+        // "/0" or "/2" suffixes. These let the user turn the totals off per total.
+
+        public const bool DefaultShowLapTotal = true;
+        /// <summary>Show the "/total laps" suffix on the ITM lap field.</summary>
+        public bool ItmShowLapTotal { get; set; } = DefaultShowLapTotal;
+
+        public const bool DefaultShowPositionTotal = true;
+        /// <summary>Show the "/field size" suffix on the ITM position field.</summary>
+        public bool ItmShowPositionTotal { get; set; } = DefaultShowPositionTotal;
     }
 }

--- a/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -43,6 +43,14 @@ namespace FanaBridge.Adapters
         private FanatecDisplayDriver _displayManager;
         private DisplaySettings _displaySettings = new DisplaySettings();
 
+        // ITM display driver — null until a wheel with an ITM display is driven.
+        private ItmDisplayDriver _itmDisplay;
+        private bool _itmWasRunning;
+        private bool _itmErrorLogged;
+        // True once the legacy page has been blanked after switching to mode "None",
+        // so it is cleared once on the transition rather than every frame.
+        private bool _legacyBlanked;
+
         // Track connection state transitions for cleanup on disconnect.
         private bool _wasConnected;
 
@@ -115,6 +123,9 @@ namespace FanaBridge.Adapters
                 ["wheelType"] = _config.WheelCode ?? "",
                 ["moduleType"] = _config.ModuleCode ?? "",
                 ["displayMode"] = DisplaySettings.DefaultMode,
+                ["itmEnabled"] = DisplaySettings.DefaultItmEnabled,
+                ["itmShowLapTotal"] = DisplaySettings.DefaultShowLapTotal,
+                ["itmShowPositionTotal"] = DisplaySettings.DefaultShowPositionTotal,
             };
             _displaySettings = new DisplaySettings();
 
@@ -199,7 +210,8 @@ namespace FanaBridge.Adapters
 
             // Extract custom settings
             _customSettings = new JObject();
-            foreach (var key in new[] { "wheelType", "moduleType", "displayMode" })
+            foreach (var key in new[] { "wheelType", "moduleType", "displayMode", "itmEnabled",
+                                        "itmShowLapTotal", "itmShowPositionTotal" })
             {
                 if (obj[key] != null)
                     _customSettings[key] = obj[key].DeepClone();
@@ -231,7 +243,11 @@ namespace FanaBridge.Adapters
             _displaySettings = new DisplaySettings
             {
                 DisplayMode = (string)_customSettings["displayMode"] ?? DisplaySettings.DefaultMode,
+                ItmEnabled = (bool?)_customSettings["itmEnabled"] ?? DisplaySettings.DefaultItmEnabled,
+                ItmShowLapTotal = (bool?)_customSettings["itmShowLapTotal"] ?? DisplaySettings.DefaultShowLapTotal,
+                ItmShowPositionTotal = (bool?)_customSettings["itmShowPositionTotal"] ?? DisplaySettings.DefaultShowPositionTotal,
             };
+
             _displayManager?.UpdateSettings(_displaySettings);
         }
 
@@ -247,6 +263,8 @@ namespace FanaBridge.Adapters
                     "]: Lost connection");
 
                 _displayManager?.Clear();
+                _itmDisplay?.Stop();
+                _itmWasRunning = false;
             }
 
             _wasConnected = isConnected;
@@ -266,8 +284,73 @@ namespace FanaBridge.Adapters
             if (plugin.WizardActive)
                 return;
 
-            // ── Display (ITM falls back to basic 7-seg until ITM support is implemented) ──
-            if (_config.Capabilities.Display != DisplayType.None)
+            // ── Display ──────────────────────────────────────────────────
+            var displayType = _config.Capabilities.Display;
+            if (displayType == DisplayType.Itm)
+            {
+                if (_itmDisplay == null)
+                {
+                    _itmDisplay = new ItmDisplayDriver(plugin.Itm,
+                        log: msg => SimHub.Logging.Current.Info("FanaBridge: " + msg));
+                    SimHub.Logging.Current.Info(
+                        "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: Created ITM display driver");
+                }
+
+                // Guard the ITM/legacy display work: an exception here (firmware quirk,
+                // transport hiccup) must not skip the LED update further down this same
+                // DataUpdate call. Log the first failure, then stay quiet to avoid spam.
+                try
+                {
+                    _itmDisplay.Enabled = _displaySettings.ItmEnabled;
+                    if (_displaySettings.ItmEnabled)
+                        _itmDisplay.Start();   // idempotent — re-arms bring-up after a disconnect
+                    _itmDisplay.ShowLapTotal = _displaySettings.ItmShowLapTotal;
+                    _itmDisplay.ShowPositionTotal = _displaySettings.ItmShowPositionTotal;
+
+                    // Feed the firmware's pushed ITM subscription reports (col03-IN) to the
+                    // driver so it follows the page the wheel button selects.
+                    plugin.Wheelbase?.DrainItmReports(_itmDisplay.OnSubscriptionReport);
+
+                    _itmDisplay.Update(data);
+
+                    // Log the bring-up completing once, so hardware verification can
+                    // confirm from the SimHub log that ITM went live.
+                    if (_itmDisplay.IsRunning && !_itmWasRunning)
+                        SimHub.Logging.Current.Info(
+                            "FanatecWheelDeviceInstance[" + _config.Capabilities.Name +
+                            "]: ITM enabled — following firmware subscriptions");
+                    _itmWasRunning = _itmDisplay.IsRunning;
+
+                    // Optionally also drive the legacy 7-segment gear/speed over col01. On an
+                    // ITM OLED (e.g. PBME) the firmware renders this on its legacy page. This
+                    // adds col01 traffic interleaved with col03 ITM, which can destabilise the
+                    // firmware under load, so it is opt-in — the "Legacy Display Mode" dropdown,
+                    // where "None" leaves it off.
+                    if (_displaySettings.DisplayMode != DisplaySettings.ModeNone)
+                    {
+                        if (_displayManager == null)
+                            _displayManager = new FanatecDisplayDriver(plugin.Display, _displaySettings);
+                        _displayManager.Update(data);
+                        _legacyBlanked = false;
+                    }
+                    else if (_displayManager != null && !_legacyBlanked)
+                    {
+                        _displayManager.Clear();   // switched to None — blank the legacy page once
+                        _legacyBlanked = true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (!_itmErrorLogged)
+                    {
+                        _itmErrorLogged = true;
+                        SimHub.Logging.Current.Error(
+                            "FanatecWheelDeviceInstance[" + _config.Capabilities.Name +
+                            "]: ITM display update failed (LEDs unaffected): " + ex);
+                    }
+                }
+            }
+            else if (displayType != DisplayType.None)
             {
                 if (_displayManager == null)
                 {
@@ -301,6 +384,7 @@ namespace FanaBridge.Adapters
                 "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: End called");
 
             _displayManager?.Clear();
+            _itmDisplay?.Stop();
             _ledModule?.FinalizeModule();
         }
 
@@ -333,9 +417,13 @@ namespace FanaBridge.Adapters
                 screenPanel.Bind(_displaySettings, _config.Capabilities.Display);
                 screenPanel.SettingsChanged += () =>
                 {
-                    // Sync back to JObject for persistence
+                    // Sync back to JObject for persistence.
                     _customSettings["displayMode"] = _displaySettings.DisplayMode;
+                    _customSettings["itmEnabled"] = _displaySettings.ItmEnabled;
+                    _customSettings["itmShowLapTotal"] = _displaySettings.ItmShowLapTotal;
+                    _customSettings["itmShowPositionTotal"] = _displaySettings.ItmShowPositionTotal;
                     _displayManager?.UpdateSettings(_displaySettings);
+                    // ITM driver reads _displaySettings live each frame.
                 };
 
                 yield return new DeviceSettingControl(

--- a/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -265,6 +265,10 @@ namespace FanaBridge.Adapters
                 _displayManager?.Clear();
                 _itmDisplay?.Stop();
                 _itmWasRunning = false;
+                // Reset one-shot latches so a reconnect starts clean: errors can log again
+                // and the legacy page can re-blank when the mode is "None".
+                _itmErrorLogged = false;
+                _legacyBlanked = false;
             }
 
             _wasConnected = isConnected;

--- a/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FanaBridge.Protocol;
+using GameReaderCommon;
+
+namespace FanaBridge.Adapters
+{
+    /// <summary>
+    /// Drives a Fanatec ITM telemetry display, firmware-driven: it enables ITM once,
+    /// keeps the display alive with periodic keepalives, and sends rate-limited value
+    /// updates for exactly the parameters the firmware has subscribed.
+    ///
+    /// The wheel owns page selection. When the user presses the wheel's ITM page button,
+    /// the firmware pushes subscription reports on col03-IN telling the host which
+    /// parameter sits at which handle for the new page (see
+    /// <see cref="ItmTelemetry.ParseSubscriptionReport"/>); the host echoes values back at
+    /// those handles. There is no host page-select command — host-driven page switching
+    /// (PageSet / Enable-byte) was tried and does not make the firmware accept values.
+    ///
+    /// Sits above <see cref="ItmEncoder"/> (framing) and <see cref="ItmTelemetry"/>
+    /// (value encoding + subscription parsing). The clock is injectable so the timing is
+    /// unit testable.
+    ///
+    /// FIRMWARE SAFETY (PBME is the crash-prone target): Enable is sent once per bring-up
+    /// (never in a loop); value updates are rate-limited and skipped when unchanged. The
+    /// format-sensitive parameters (BRAKE_BIAS as Int32 tenths, ENGINE_MAPPING as ASCII
+    /// text) are encoded to the firmware's expected form upstream in <see cref="ItmTelemetry"/>.
+    /// </summary>
+    public class ItmDisplayDriver
+    {
+        private readonly ItmEncoder _encoder;
+        private readonly Func<long> _now;
+        private readonly Action<string> _log;
+
+        // ── Tunables (ms) ────────────────────────────────────────────────
+        /// <summary>Keepalive cadence. The display sleeps without one roughly every 100&#160;ms.</summary>
+        public int KeepaliveIntervalMs { get; set; } = 100;
+
+        /// <summary>Minimum spacing between value-update sends (caps the rate).</summary>
+        public int ValueIntervalMs { get; set; } = 40;
+
+        /// <summary>Whether to show the "/total laps" suffix on the lap field.</summary>
+        public bool ShowLapTotal { get; set; } = true;
+
+        /// <summary>Whether to show the "/field size" suffix on the position field.</summary>
+        public bool ShowPositionTotal { get; set; } = true;
+
+        /// <summary>
+        /// Whether the ITM display is enabled. Set false to turn ITM off (the driver sends
+        /// the firmware "ITM off" command and goes dormant); set true to re-enable (the
+        /// next <see cref="Update"/> re-runs bring-up). Read live each frame.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        // ── State ────────────────────────────────────────────────────────
+        private enum Phase { Idle, Enabling, Running, Disabled }
+        private Phase _phase = Phase.Idle;
+
+        private long _lastKeepaliveMs;
+        private long _lastValuesMs;
+
+        // Firmware-driven subscription map: host handle -> parameter ID. Kept sorted by
+        // handle so the dirty-tracking comparison sees a stable order.
+        private readonly SortedDictionary<byte, ushort> _subs = new SortedDictionary<byte, ushort>();
+        private ItmValue[] _lastValues;
+        private bool _loggedFirstValues;
+        private string _lastSlotDefsSig = "";   // last ParamDefs suffix set, to skip redundant writes
+        // Reused per-tick send buffer (avoids a per-frame allocation).
+        private readonly List<ItmValue> _valueBuf = new List<ItmValue>();
+        // Subscribed paramIds we've already warned have no encoder — log each once.
+        private readonly HashSet<ushort> _unencodableWarned = new HashSet<ushort>();
+
+        public ItmDisplayDriver(ItmEncoder encoder, Func<long> nowMs = null, Action<string> log = null)
+        {
+            _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+            _now = nowMs ?? DefaultClock();
+            _log = log ?? (_ => { });
+        }
+
+        private static Func<long> DefaultClock()
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            return () => sw.ElapsedMilliseconds;
+        }
+
+        /// <summary>True once ITM is enabled and values are flowing.</summary>
+        public bool IsRunning => _phase == Phase.Running;
+
+        /// <summary>The number of parameters the firmware currently has subscribed.</summary>
+        public int SubscriptionCount => _subs.Count;
+
+        /// <summary>
+        /// Begins ITM bring-up (a single Enable) on the next <see cref="Update"/>.
+        /// Idempotent — a no-op unless idle, so it is safe to call every frame.
+        /// </summary>
+        public void Start()
+        {
+            if (_phase == Phase.Idle)
+                _phase = Phase.Enabling;
+        }
+
+        /// <summary>
+        /// Stops driving and returns to idle, dropping all subscriptions. Without
+        /// keepalives the firmware reclaims the display. A later <see cref="Start"/>
+        /// re-enables.
+        /// </summary>
+        public void Stop()
+        {
+            _phase = Phase.Idle;
+            _subs.Clear();
+            _lastValues = null;
+            _loggedFirstValues = false;
+            _lastSlotDefsSig = "";
+        }
+
+        /// <summary>
+        /// Applies a firmware ITM subscription report (col03-IN, pushed on a wheel-button
+        /// page change): subscribes/updates each handle's parameter, removes unsubscribed
+        /// handles. Safe to call before <see cref="Start"/> — the map is simply pre-seeded.
+        /// </summary>
+        public void OnSubscriptionReport(byte[] report)
+        {
+            var subs = ItmTelemetry.ParseSubscriptionReport(report, report?.Length ?? 0);
+            if (subs.Count == 0)
+                return;
+
+            foreach (var s in subs)
+            {
+                if (s.IsUnsubscribe)
+                    _subs.Remove(s.Handle);
+                else
+                    _subs[s.Handle] = s.ParamId;
+            }
+
+            _lastValues = null;   // subscription set changed — force a fresh value send
+            _log("ITM: subscriptions now — " + Describe());
+            // ParamDefs (suffixes) are refreshed from Update(), where telemetry is
+            // available for the dynamic "/total" suffixes.
+        }
+
+        // Sends ParamDefs declaring each subscribed param's display suffix — a static
+        // unit (e.g. "C", "L") or a dynamic total ("/34" for lap/position). Cosmetic:
+        // the value renders from ValueUpdate regardless. Slot ID = 0x80 | handle, per
+        // the capture. Only writes when the suffix set actually changes (subscription
+        // change or a moving total), so it does not flood the bus.
+        private void UpdateSlotDefs(GameData data)
+        {
+            List<ItmParamDef> defs = null;
+            var sig = new System.Text.StringBuilder();
+
+            foreach (var kv in _subs)
+            {
+                string suffix;
+                if (ItmTelemetry.TryGetUnitSuffix(kv.Value, out suffix))
+                {
+                    // Static unit (e.g. "C", "L").
+                }
+                else if (ItmTelemetry.IsTotalParam(kv.Value))
+                {
+                    // Lap/position: always emit an entry so a total that disappears is
+                    // actively cleared (empty suffix), not left stale on the firmware.
+                    suffix = ShowTotalFor(kv.Value)
+                          && ItmTelemetry.TryGetTotalSuffix(kv.Value, data, out var total)
+                        ? total
+                        : "";
+                }
+                else
+                {
+                    continue;
+                }
+
+                sig.Append(kv.Key).Append('=').Append(suffix).Append(';');
+                if (defs == null) defs = new List<ItmParamDef>();
+                defs.Add(ItmParamDef.WithSuffix((byte)(0x80 | kv.Key), suffix));
+            }
+
+            string s = sig.ToString();
+            if (s == _lastSlotDefsSig)
+                return;   // unchanged — nothing to send
+            _lastSlotDefsSig = s;
+
+            if (defs != null)
+            {
+                _encoder.SetParamDefs(defs);
+                _log("ITM: ParamDefs sent — suffixes: " + s);
+            }
+        }
+
+        private bool ShowTotalFor(ushort paramId)
+        {
+            if (paramId == ItmParam.Lap) return ShowLapTotal;
+            if (paramId == ItmParam.Position) return ShowPositionTotal;
+            return false;
+        }
+
+        /// <summary>Drives the state machine one tick. Call once per frame while connected.</summary>
+        public void Update(GameData data)
+        {
+            // User turned ITM off: send the firmware "ITM off" command once, then stay
+            // dormant (no keepalives/values) so the display stays off, as the Fanatec
+            // software does. Re-enabling drops back into bring-up below.
+            if (!Enabled)
+            {
+                if (_phase != Phase.Disabled)
+                {
+                    _encoder.SetItmMode(false);   // FF 05 02 00
+                    _subs.Clear();
+                    _lastValues = null;
+                    _loggedFirstValues = false;
+                    _lastSlotDefsSig = "";
+                    _phase = Phase.Disabled;
+                    _log("ITM: disabled by user — sent ITM off");
+                }
+                return;
+            }
+
+            // Enabled again after being disabled — re-arm bring-up.
+            if (_phase == Phase.Disabled)
+                _phase = Phase.Enabling;
+
+            if (_phase == Phase.Idle)
+                return;
+
+            long now = _now();
+
+            if (_phase == Phase.Enabling)
+            {
+                _encoder.SetItmMode(true);   // ensure the firmware ITM gate is on (FF 05 02 01)
+                _encoder.EnableItm(0);       // start ITM on the default (Lap Info) page
+                SeedInitialSubscriptions();
+                _log("ITM: enabled — seeded " + _subs.Count + " params, following firmware subscriptions");
+                _lastKeepaliveMs = now;
+                _phase = Phase.Running;
+                return;
+            }
+
+            // Running
+            UpdateSlotDefs(data);   // refresh unit/total suffixes when they change
+            if (now - _lastKeepaliveMs >= KeepaliveIntervalMs)
+            {
+                _encoder.SendKeepalive();
+                _lastKeepaliveMs = now;
+            }
+
+            if (now - _lastValuesMs >= ValueIntervalMs)
+            {
+                SendSubscribedValues(data);
+                _lastValuesMs = now;
+            }
+        }
+
+        // The firmware announces subscriptions only on a page change, not on bare
+        // Enable, so the initial (Enable-default) page would stay blank. Seed the Lap
+        // Info handle→param map — the firmware accepts these on its default page, and
+        // its first page-change push replaces them. Only seeds when nothing's subscribed.
+        private void SeedInitialSubscriptions()
+        {
+            if (_subs.Count > 0)
+                return;
+            var ids = ItmTelemetry.ParamsFor(ItmPage.LapInfo);
+            for (int h = 0; h < ids.Count; h++)
+                _subs[(byte)h] = ids[h];
+        }
+
+        private void SendSubscribedValues(GameData data)
+        {
+            if (_subs.Count == 0)
+                return;
+
+            _valueBuf.Clear();
+            foreach (var kv in _subs)
+            {
+                if (ItmTelemetry.TryEncodeParam(kv.Value, kv.Key, data, out var v))
+                    _valueBuf.Add(v);
+                else if (_unencodableWarned.Add(kv.Value))
+                    // Firmware subscribed a parameter outside our page layouts — it will
+                    // render as dashes. Note it once so the gap is diagnosable.
+                    _log("ITM: no encoder for subscribed param " + kv.Value +
+                         " (handle " + kv.Key + ") — field will show dashes");
+            }
+
+            if (_valueBuf.Count == 0 || !HasChanged(_valueBuf))
+                return;
+
+            _encoder.SendValues(_valueBuf);
+            Remember(_valueBuf);
+
+            if (!_loggedFirstValues)
+            {
+                _loggedFirstValues = true;
+                _log("ITM: first value update — " + _valueBuf.Count + " params: " + Describe());
+            }
+        }
+
+        private string Describe()
+            => string.Join(" ", _subs.Select(kv => "h" + kv.Key + "=p" + kv.Value));
+
+        private bool HasChanged(IReadOnlyList<ItmValue> values)
+        {
+            if (_lastValues == null || _lastValues.Length != values.Count)
+                return true;
+            for (int i = 0; i < values.Count; i++)
+            {
+                var a = _lastValues[i];
+                var b = values[i];
+                if (a.ParamId != b.ParamId || a.Size != b.Size || a.Raw != b.Raw || a.Handle != b.Handle)
+                    return true;
+            }
+            return false;
+        }
+
+        private void Remember(IReadOnlyList<ItmValue> values)
+        {
+            if (_lastValues == null || _lastValues.Length != values.Count)
+                _lastValues = new ItmValue[values.Count];
+            for (int i = 0; i < values.Count; i++)
+                _lastValues[i] = values[i];
+        }
+    }
+}

--- a/FanaBridge/FanatecPlugin.cs
+++ b/FanaBridge/FanatecPlugin.cs
@@ -31,6 +31,7 @@ namespace FanaBridge
         private LedEncoder _leds;
         private LegacyLedEncoder _legacyLeds;
         private DisplayEncoder _display;
+        private ItmEncoder _itm;
 
         /// <summary>Fired when connection status or wheel identity changes. May fire from any thread.</summary>
         public event Action StateChanged;
@@ -110,6 +111,9 @@ namespace FanaBridge
         /// <summary>Shared display encoder — used by DeviceInstance display managers and wizard.</summary>
         public DisplayEncoder Display => _display;
 
+        /// <summary>Shared ITM encoder (col03) — used by DeviceInstance ITM display drivers.</summary>
+        public ItmEncoder Itm => _itm;
+
         /// <summary>Shared tuning controller — used by TuningSettingsPanel for encoder config.</summary>
         public FanatecTuningController Tuning => _tuning;
 
@@ -136,6 +140,7 @@ namespace FanaBridge
             _leds = new LedEncoder(transport);
             _legacyLeds = new LegacyLedEncoder(transport);
             _display = new DisplayEncoder(transport);
+            _itm = new ItmEncoder(transport);
             _tuning = new FanatecTuningController(
                 transport,
                 msg => SimHub.Logging.Current.Warn(msg),

--- a/FanaBridge/Protocol/ItmEncoder.cs
+++ b/FanaBridge/Protocol/ItmEncoder.cs
@@ -1,0 +1,391 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using FanaBridge.Transport;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// Target display device for an ITM page change (col03 <c>FF 05 04</c>, byte[3]).
+    /// Multiple ITM-capable surfaces can be present at once, each addressed by its
+    /// own device ID. See the protocol reference, "ITM Supported Devices".
+    /// </summary>
+    public enum ItmDevice : byte
+    {
+        /// <summary>The wheelbase's own display (PDD1/PDD1-PS4/PDD2).</summary>
+        Base = 1,
+
+        /// <summary>
+        /// The PBME's large OLED or the GTSWX's built-in display. These share device
+        /// ID 3 on the wire and are mutually exclusive — a setup has one or the other.
+        /// </summary>
+        BmeOrGtswx = 3,
+
+        /// <summary>The Bentley GT3 wheel's built-in display.</summary>
+        Bentley = 4,
+    }
+
+    /// <summary>
+    /// A single telemetry value for an ITM ValueUpdate entry (col03 <c>FF 05 01</c>).
+    /// The <see cref="Raw"/> bits are emitted little-endian, <see cref="Size"/> bytes
+    /// wide. Use the typed factory helpers (<see cref="UInt8"/>, <see cref="Int16"/>,
+    /// <see cref="Int32"/>, <see cref="Float32"/>) rather than packing bits by hand.
+    /// </summary>
+    public readonly struct ItmValue
+    {
+        /// <summary>Parameter handle assigned to this slot during ParamDefs.</summary>
+        public byte Handle { get; }
+
+        /// <summary>Parameter ID (see the protocol reference, "ITM Parameter IDs").</summary>
+        public ushort ParamId { get; }
+
+        /// <summary>Value width on the wire: 1, 2, or 4 bytes.</summary>
+        public byte Size { get; }
+
+        /// <summary>Value bits held in the low <see cref="Size"/> bytes, emitted little-endian.</summary>
+        public uint Raw { get; }
+
+        public ItmValue(byte handle, ushort paramId, byte size, uint raw)
+        {
+            Handle = handle;
+            ParamId = paramId;
+            Size = size;
+            Raw = raw;
+        }
+
+        /// <summary>An unsigned 8-bit value (e.g. GEAR, POSITION, TC_SETTING).</summary>
+        public static ItmValue UInt8(byte handle, ushort paramId, byte value)
+            => new ItmValue(handle, paramId, 1, value);
+
+        /// <summary>A signed 16-bit value (e.g. SPEED).</summary>
+        public static ItmValue Int16(byte handle, ushort paramId, short value)
+            => new ItmValue(handle, paramId, 2, (ushort)value);
+
+        /// <summary>A signed 32-bit value (e.g. RPM, ERS_LEVEL).</summary>
+        public static ItmValue Int32(byte handle, ushort paramId, int value)
+            => new ItmValue(handle, paramId, 4, unchecked((uint)value));
+
+        /// <summary>A 32-bit float value (e.g. FUEL, LAP_TIME, BRAKE_BIAS).</summary>
+        public static ItmValue Float32(byte handle, ushort paramId, float value)
+            => new ItmValue(handle, paramId, 4, FloatBits(Sanitize(value)));
+
+        /// <summary>
+        /// A short ASCII-text value. Some params (e.g. ENGINE_MAPPING) are displayed by the
+        /// firmware as text — map "10" travels as the two bytes '1','0', not a numeric 0x0A.
+        /// Sending the wrong (numeric) form wedges the PBME firmware. Up to 4 characters,
+        /// packed little-endian; the payload size is the character count.
+        /// </summary>
+        public static ItmValue Ascii(byte handle, ushort paramId, string text)
+        {
+            if (string.IsNullOrEmpty(text)) text = "0";
+            int len = Math.Min(text.Length, 4);
+            uint raw = 0;
+            for (int i = 0; i < len; i++)
+                raw |= (uint)(byte)text[i] << (8 * i);
+            return new ItmValue(handle, paramId, (byte)len, raw);
+        }
+
+        // Keep NaN/Infinity and absurd magnitudes off the wire — an out-of-range float
+        // can wedge the PBME firmware. Telemetry can briefly produce these before a
+        // session settles.
+        private static float Sanitize(float value)
+        {
+            if (float.IsNaN(value) || float.IsInfinity(value)) return 0f;
+            const float bound = 1_000_000f;
+            if (value > bound) return bound;
+            if (value < -bound) return -bound;
+            return value;
+        }
+
+        // Reinterpret a float's bits as a uint without a heap allocation
+        // (no BitConverter.SingleToUInt32Bits on .NET Framework 4.8).
+        private static uint FloatBits(float value)
+        {
+            var u = new FloatUnion { F = value };
+            return u.U;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct FloatUnion
+        {
+            [FieldOffset(0)] public float F;
+            [FieldOffset(0)] public uint U;
+        }
+    }
+
+    /// <summary>
+    /// A single display-slot definition for an ITM ParamDefs entry (col03 <c>FF 05 03</c>).
+    /// Tells the firmware which slot to populate and an optional ASCII suffix to render
+    /// after the value (e.g. the "/0" total-companion marker).
+    /// </summary>
+    public readonly struct ItmParamDef
+    {
+        /// <summary>Display-layout slot identifier (e.g. 0x82, 0x85, 0x88).</summary>
+        public byte SlotId { get; }
+
+        /// <summary>16-bit position, emitted little-endian. Typically 0.</summary>
+        public ushort Position { get; }
+
+        /// <summary>ASCII suffix bytes appended after the value, or null/empty for none.</summary>
+        public byte[] Suffix { get; }
+
+        public ItmParamDef(byte slotId, ushort position = 0, byte[] suffix = null)
+        {
+            SlotId = slotId;
+            Position = position;
+            Suffix = suffix;
+        }
+
+        /// <summary>Convenience builder that encodes <paramref name="suffix"/> as ASCII bytes.</summary>
+        public static ItmParamDef WithSuffix(byte slotId, string suffix, ushort position = 0)
+            => new ItmParamDef(slotId, position,
+                string.IsNullOrEmpty(suffix) ? null : Encoding.ASCII.GetBytes(suffix));
+    }
+
+    /// <summary>
+    /// Encodes and sends ITM (telemetry display) control reports for Fanatec wheels
+    /// over the col03 interface. Covers the four ITM frames documented in the protocol
+    /// reference: Enable (<c>FF 02 02</c>), ParamDefs (<c>FF 05 03</c>), ValueUpdate
+    /// (<c>FF 05 01</c>), and the PageSet/Keepalive config frame (<c>FF 05 04</c>).
+    ///
+    /// This is a pure framing layer — like <see cref="LedEncoder"/> and
+    /// <see cref="DisplayEncoder"/>, it builds and writes reports but holds no display
+    /// state. Page selection, keepalive scheduling, telemetry-to-parameter mapping, and
+    /// the firmware-safety rate limits (e.g. don't call <see cref="EnableItm"/> in a tight
+    /// loop) are the caller's responsibility.
+    /// </summary>
+    public class ItmEncoder
+    {
+        // ── Protocol constants (col03 report format) ─────────────────────
+        private const int REPORT_LENGTH = 64;
+        private const byte REPORT_PREFIX = 0xFF;
+        private const int HEADER_SIZE = 3;   // [0xFF, cmd_class, subcmd]
+
+        // Command classes (byte[1])
+        private const byte CMD_ITM_ENABLE = 0x02;   // ITM enable lives on its own class
+        private const byte CMD_ITM_DISPLAY = 0x05;  // ParamDefs / ValueUpdate / config
+
+        // Sub-commands (byte[2])
+        private const byte SUBCMD_ENABLE = 0x02;
+        private const byte SUBCMD_VALUE_UPDATE = 0x01;
+        private const byte SUBCMD_ITM_MODE = 0x02;   // under FF 05: firmware ITM on/off gate
+        private const byte SUBCMD_PARAM_DEFS = 0x03;
+        private const byte SUBCMD_CONFIG = 0x04;     // PageSet + Keepalive
+
+        // Per-entry markers. BOTH ValueUpdate and ParamDefs entries use 0x03 — this
+        // is confirmed against an official-software USB capture. (The protocol
+        // reference claims ValueUpdate entries use 0x01; that is wrong, and entries
+        // marked 0x01 are silently ignored by the firmware.)
+        private const byte MARKER_VALUE = 0x03;
+        private const byte MARKER_PARAM_DEF = 0x03;
+
+        // Keepalive config selector (FF 05 04 02 0B)
+        private const byte KEEPALIVE_CONFIG_TYPE = 0x02;
+        private const byte KEEPALIVE_CONFIG_VALUE = 0x0B;
+
+        // Fixed-size prefixes of a single entry, before the variable tail.
+        // ValueUpdate:  marker, handle, idLo, idHi, size            (+ Size value bytes)
+        // ParamDefs:    marker, slotId, posLo, posHi, suffixLen     (+ suffix bytes)
+        private const int VALUE_ENTRY_HEADER = 5;
+        private const int PARAM_DEF_ENTRY_HEADER = 5;
+
+        private const int PAYLOAD_CAPACITY = REPORT_LENGTH - HEADER_SIZE;   // 61
+
+        /// <summary>Maximum parameters the firmware will track at once (per the protocol reference).</summary>
+        public const int MaxParams = 16;
+
+        /// <summary>Largest ASCII suffix that still fits a ParamDefs entry in one report.</summary>
+        public const int MaxSuffixLength = PAYLOAD_CAPACITY - PARAM_DEF_ENTRY_HEADER;   // 56
+
+        private readonly IDeviceTransport _transport;
+
+        // Pooled report buffer — avoid per-frame heap allocations.
+        private readonly byte[] _reportBuf = new byte[REPORT_LENGTH];
+
+        public ItmEncoder(IDeviceTransport transport)
+        {
+            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        }
+
+        /// <summary>
+        /// Sets the firmware ITM mode gate (col03 <c>FF 05 02 &lt;01|00&gt;</c>) — the same
+        /// on/off state the Fanatec software's ITM switch controls. This is distinct from
+        /// <see cref="EnableItm"/>, which starts a display session: ITM must be gated ON
+        /// here first or the session enable is ignored and no subscriptions are pushed.
+        /// The gate is persistent (survives power cycles), confirmed against a capture of
+        /// the official software toggling ITM.
+        /// </summary>
+        public bool SetItmMode(bool on)
+        {
+            Array.Clear(_reportBuf, 0, REPORT_LENGTH);
+            _reportBuf[0] = REPORT_PREFIX;
+            _reportBuf[1] = CMD_ITM_DISPLAY;   // 0x05
+            _reportBuf[2] = SUBCMD_ITM_MODE;   // 0x02
+            _reportBuf[3] = on ? (byte)0x01 : (byte)0x00;
+            return _transport.SendCol03(_reportBuf);
+        }
+
+        /// <summary>
+        /// Activates ITM mode and selects the analysis page (0 = default/reset).
+        /// Resets the firmware's slot table, so <see cref="SetParamDefs"/> must be
+        /// re-sent after every enable. Do NOT call in a tight loop — rapid repeated
+        /// enables can crash the PBME firmware; the caller must rate-limit.
+        /// </summary>
+        public bool EnableItm(byte page = 0)
+        {
+            Array.Clear(_reportBuf, 0, REPORT_LENGTH);
+            _reportBuf[0] = REPORT_PREFIX;
+            _reportBuf[1] = CMD_ITM_ENABLE;
+            _reportBuf[2] = SUBCMD_ENABLE;
+            _reportBuf[3] = page;
+            return _transport.SendCol03(_reportBuf);
+        }
+
+        /// <summary>
+        /// Selects the active ITM page on a specific display device. Page changes
+        /// should be spaced at least 100&#160;ms apart (firmware reconfiguration time) —
+        /// the caller is responsible for that spacing.
+        /// </summary>
+        public bool SetPage(ItmDevice device, byte page) => SetPage((byte)device, page);
+
+        /// <summary>Raw overload of <see cref="SetPage(ItmDevice, byte)"/> for an arbitrary device ID.</summary>
+        public bool SetPage(byte deviceId, byte page)
+        {
+            Array.Clear(_reportBuf, 0, REPORT_LENGTH);
+            _reportBuf[0] = REPORT_PREFIX;
+            _reportBuf[1] = CMD_ITM_DISPLAY;
+            _reportBuf[2] = SUBCMD_CONFIG;
+            _reportBuf[3] = deviceId;
+            _reportBuf[4] = page;
+            return _transport.SendCol03(_reportBuf);
+        }
+
+        /// <summary>
+        /// Sends the ITM keepalive. Must be sent roughly every 100&#160;ms to keep the
+        /// display awake — the caller owns the scheduling.
+        /// </summary>
+        public bool SendKeepalive()
+        {
+            Array.Clear(_reportBuf, 0, REPORT_LENGTH);
+            _reportBuf[0] = REPORT_PREFIX;
+            _reportBuf[1] = CMD_ITM_DISPLAY;
+            _reportBuf[2] = SUBCMD_CONFIG;
+            _reportBuf[3] = KEEPALIVE_CONFIG_TYPE;
+            _reportBuf[4] = KEEPALIVE_CONFIG_VALUE;
+            return _transport.SendCol03(_reportBuf);
+        }
+
+        /// <summary>
+        /// Defines the display-slot layout (subcmd 0x03). Entries are packed into as
+        /// many 64-byte reports as needed, each carrying the <c>FF 05 03</c> header.
+        /// Re-send after every <see cref="EnableItm"/>. Returns false if the list is
+        /// null/empty, exceeds <see cref="MaxParams"/>, or any suffix exceeds
+        /// <see cref="MaxSuffixLength"/>.
+        /// </summary>
+        public bool SetParamDefs(IReadOnlyList<ItmParamDef> defs)
+        {
+            if (defs == null || defs.Count == 0 || defs.Count > MaxParams)
+                return false;
+
+            using (_transport.BeginBatch())
+            {
+                bool ok = true;
+                int i = 0;
+                while (i < defs.Count)
+                {
+                    int pos = BeginReport(SUBCMD_PARAM_DEFS);
+
+                    for (; i < defs.Count; i++)
+                    {
+                        var d = defs[i];
+                        int suffixLen = d.Suffix?.Length ?? 0;
+                        if (suffixLen > MaxSuffixLength)
+                            return false;
+
+                        int entryLen = PARAM_DEF_ENTRY_HEADER + suffixLen;
+                        // A fresh report can always hold one entry (suffix bounded above);
+                        // break only to flush a partially-filled report.
+                        if (pos + entryLen > REPORT_LENGTH)
+                            break;
+
+                        _reportBuf[pos++] = MARKER_PARAM_DEF;
+                        _reportBuf[pos++] = d.SlotId;
+                        _reportBuf[pos++] = (byte)(d.Position & 0xFF);
+                        _reportBuf[pos++] = (byte)((d.Position >> 8) & 0xFF);
+                        _reportBuf[pos++] = (byte)suffixLen;
+                        if (suffixLen > 0)
+                        {
+                            Array.Copy(d.Suffix, 0, _reportBuf, pos, suffixLen);
+                            pos += suffixLen;
+                        }
+                    }
+
+                    ok = _transport.SendCol03(_reportBuf) && ok;
+                }
+                return ok;
+            }
+        }
+
+        /// <summary>
+        /// Sends telemetry values (subcmd 0x01). Entries are packed into as many
+        /// 64-byte reports as needed, each carrying the <c>FF 05 01</c> header.
+        /// Returns false if the list is null/empty, exceeds <see cref="MaxParams"/>,
+        /// or any entry has a size other than 1, 2, or 4.
+        /// </summary>
+        public bool SendValues(IReadOnlyList<ItmValue> values)
+        {
+            if (values == null || values.Count == 0 || values.Count > MaxParams)
+                return false;
+
+            using (_transport.BeginBatch())
+            {
+                bool ok = true;
+                int i = 0;
+                while (i < values.Count)
+                {
+                    int pos = BeginReport(SUBCMD_VALUE_UPDATE);
+
+                    for (; i < values.Count; i++)
+                    {
+                        var v = values[i];
+                        // 1/2/4 for numeric values; 3 occurs for ASCII text (e.g. a 3-char map).
+                        if (v.Size < 1 || v.Size > 4)
+                            return false;
+
+                        int entryLen = VALUE_ENTRY_HEADER + v.Size;
+                        if (pos + entryLen > REPORT_LENGTH)
+                            break;
+
+                        _reportBuf[pos++] = MARKER_VALUE;
+                        _reportBuf[pos++] = v.Handle;
+                        _reportBuf[pos++] = (byte)(v.ParamId & 0xFF);
+                        _reportBuf[pos++] = (byte)((v.ParamId >> 8) & 0xFF);
+                        _reportBuf[pos++] = v.Size;
+
+                        uint raw = v.Raw;
+                        for (int b = 0; b < v.Size; b++)
+                        {
+                            _reportBuf[pos++] = (byte)(raw & 0xFF);
+                            raw >>= 8;
+                        }
+                    }
+
+                    ok = _transport.SendCol03(_reportBuf) && ok;
+                }
+                return ok;
+            }
+        }
+
+        // Zero the pooled buffer and lay down the [0xFF, 0x05, subcmd] header,
+        // returning the offset where entries begin.
+        private int BeginReport(byte subcmd)
+        {
+            Array.Clear(_reportBuf, 0, REPORT_LENGTH);
+            _reportBuf[0] = REPORT_PREFIX;
+            _reportBuf[1] = CMD_ITM_DISPLAY;
+            _reportBuf[2] = subcmd;
+            return HEADER_SIZE;
+        }
+    }
+}

--- a/FanaBridge/Protocol/ItmEncoder.cs
+++ b/FanaBridge/Protocol/ItmEncoder.cs
@@ -60,7 +60,7 @@ namespace FanaBridge.Protocol
 
         /// <summary>A signed 16-bit value (e.g. SPEED).</summary>
         public static ItmValue Int16(byte handle, ushort paramId, short value)
-            => new ItmValue(handle, paramId, 2, (ushort)value);
+            => new ItmValue(handle, paramId, 2, unchecked((ushort)value));
 
         /// <summary>A signed 32-bit value (e.g. RPM, ERS_LEVEL).</summary>
         public static ItmValue Int32(byte handle, ushort paramId, int value)
@@ -288,6 +288,12 @@ namespace FanaBridge.Protocol
             if (defs == null || defs.Count == 0 || defs.Count > MaxParams)
                 return false;
 
+            // Validate the whole list before touching the transport — otherwise an invalid
+            // entry after a report boundary would return false with a partial batch sent.
+            for (int j = 0; j < defs.Count; j++)
+                if ((defs[j].Suffix?.Length ?? 0) > MaxSuffixLength)
+                    return false;
+
             using (_transport.BeginBatch())
             {
                 bool ok = true;
@@ -300,8 +306,6 @@ namespace FanaBridge.Protocol
                     {
                         var d = defs[i];
                         int suffixLen = d.Suffix?.Length ?? 0;
-                        if (suffixLen > MaxSuffixLength)
-                            return false;
 
                         int entryLen = PARAM_DEF_ENTRY_HEADER + suffixLen;
                         // A fresh report can always hold one entry (suffix bounded above);
@@ -338,6 +342,13 @@ namespace FanaBridge.Protocol
             if (values == null || values.Count == 0 || values.Count > MaxParams)
                 return false;
 
+            // Validate every entry before touching the transport — otherwise a bad size
+            // after a report boundary would return false with a partial batch sent.
+            // (1/2/4 for numeric values; 3 occurs for ASCII text, e.g. a 3-char map.)
+            for (int j = 0; j < values.Count; j++)
+                if (values[j].Size < 1 || values[j].Size > 4)
+                    return false;
+
             using (_transport.BeginBatch())
             {
                 bool ok = true;
@@ -349,9 +360,6 @@ namespace FanaBridge.Protocol
                     for (; i < values.Count; i++)
                     {
                         var v = values[i];
-                        // 1/2/4 for numeric values; 3 occurs for ASCII text (e.g. a 3-char map).
-                        if (v.Size < 1 || v.Size > 4)
-                            return false;
 
                         int entryLen = VALUE_ENTRY_HEADER + v.Size;
                         if (pos + entryLen > REPORT_LENGTH)

--- a/FanaBridge/Protocol/ItmTelemetry.cs
+++ b/FanaBridge/Protocol/ItmTelemetry.cs
@@ -138,6 +138,8 @@ namespace FanaBridge.Protocol
         // SpeedLocal honours the user's km/h vs mph choice, matching the 7-seg driver.
         private static readonly Field SpeedField = I16(ItmParam.Speed, d => ClampSpeed(d.SpeedLocal));
         private static readonly Field GearField = U8(ItmParam.Gear, d => EncodeGear(d.Gear));
+        // Shared: appears on both the Lap Info and Lap Times pages.
+        private static readonly Field LastLapTimeField = F32(ItmParam.LastLapTime, d => Seconds(d.LastLapTime));
 
         // ── Page layouts ─────────────────────────────────────────────────
         private static readonly Field[] LapInfo =
@@ -147,7 +149,7 @@ namespace FanaBridge.Protocol
             U8(ItmParam.Lap, d => ClampByte(d.CurrentLap)),
             U8(ItmParam.Position, d => ClampByte(d.Position)),
             F32(ItmParam.LapTime, d => Seconds(d.CurrentLapTime)),
-            F32(ItmParam.LastLapTime, d => Seconds(d.LastLapTime)),
+            LastLapTimeField,
         };
 
         private static readonly Field[] FuelErsDrs =
@@ -155,7 +157,7 @@ namespace FanaBridge.Protocol
             SpeedField,
             GearField,
             F32(ItmParam.Fuel, d => (float)d.Fuel),
-            I32(ItmParam.ErsLevel, d => (int)Math.Round(d.ERSPercent)),
+            I32(ItmParam.ErsLevel, d => SafeRound(d.ERSPercent)),
             U8(ItmParam.DrsZone, d => (byte)(d.DRSAvailable != 0 ? 1 : 0)),
             U8(ItmParam.DrsActive, d => (byte)(d.DRSEnabled != 0 ? 1 : 0)),
             F32(ItmParam.DeltaOwnBest, d => (float)(d.DeltaToSessionBest ?? 0.0)),
@@ -181,7 +183,7 @@ namespace FanaBridge.Protocol
         {
             SpeedField,
             GearField,
-            F32(ItmParam.LastLapTime, d => Seconds(d.LastLapTime)),
+            LastLapTimeField,
             F32(ItmParam.BestLapTime, d => Seconds(d.BestLapTime)),
             // Car ahead is shown as a negative gap (you're behind them); car behind positive.
             F32(ItmParam.CarAhead, d => -NearestGap(d.OpponentsAheadOnTrack)),
@@ -404,9 +406,16 @@ namespace FanaBridge.Protocol
             return best == double.MaxValue ? 0f : (float)best;
         }
 
+        // Round a possibly non-finite value to int, mapping NaN/Infinity to 0. A NaN
+        // would otherwise slip through range comparisons (all false) into an undefined
+        // cast — the same firmware-safety concern BrakeBiasTenths guards against.
+        private static int SafeRound(double value)
+            => double.IsNaN(value) || double.IsInfinity(value) ? 0 : (int)Math.Round(value);
+
         // Speed is non-negative; clamp to [0, Int16 max] (the SPEED param is Int16).
         private static short ClampSpeed(double value)
         {
+            if (double.IsNaN(value) || double.IsInfinity(value)) return 0;
             double v = Math.Round(value);
             if (v < 0) return 0;
             if (v > short.MaxValue) return short.MaxValue;
@@ -415,6 +424,7 @@ namespace FanaBridge.Protocol
 
         private static byte ClampByte(double value)
         {
+            if (double.IsNaN(value) || double.IsInfinity(value)) return 0;
             double v = Math.Round(value);
             if (v < 0) return 0;
             if (v > 255) return 255;

--- a/FanaBridge/Protocol/ItmTelemetry.cs
+++ b/FanaBridge/Protocol/ItmTelemetry.cs
@@ -1,0 +1,473 @@
+using System;
+using System.Collections.Generic;
+using GameReaderCommon;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// ITM telemetry page. Each page is a fixed parameter layout the firmware
+    /// renders; SPEED and GEAR appear on every page as persistent headers. Values
+    /// match the Base/BME page numbering in the protocol reference, "ITM Page Layouts".
+    /// </summary>
+    public enum ItmPage : byte
+    {
+        LapInfo = 1,
+        FuelErsDrs = 2,
+        CarSettings = 3,
+        LapTimes = 4,
+        TyreTemps = 5,
+        /// <summary>Legacy / default fallback — carries no telemetry parameters.</summary>
+        Legacy = 6,
+    }
+
+    /// <summary>
+    /// ITM parameter IDs (the firmware's telemetry vocabulary). Only the subset
+    /// used by the built-in page layouts is defined here; see the protocol
+    /// reference, "ITM Parameter IDs", for the full list.
+    /// </summary>
+    public static class ItmParam
+    {
+        // Vehicle telemetry (1–84)
+        public const ushort Speed = 1;
+        public const ushort Rpm = 2;
+        public const ushort RpmMax = 3;
+        public const ushort Gear = 4;
+        public const ushort Fuel = 5;
+        public const ushort FuelMax = 6;
+        public const ushort FuelPerLap = 7;
+        public const ushort ErsLevel = 9;
+        public const ushort DrsZone = 14;
+        public const ushort DrsActive = 15;
+        public const ushort AbsSetting = 18;
+        public const ushort TcSetting = 20;
+        public const ushort BrakeBias = 25;
+        public const ushort EngineMapping = 26;
+        public const ushort OilTemp = 33;
+        public const ushort TyreFlTemp = 42;
+        public const ushort TyreFrTemp = 45;
+        public const ushort TyreRlTemp = 48;
+        public const ushort TyreRrTemp = 51;
+
+        // Race / timing (501–536)
+        public const ushort Position = 501;
+        public const ushort Lap = 505;
+        public const ushort LapTime = 509;
+        public const ushort LastLapTime = 510;
+        public const ushort BestLapTime = 511;
+        public const ushort DeltaOwnBest = 516;
+        public const ushort CarAhead = 519;
+        public const ushort CarBehind = 520;
+
+        /// <summary>Sentinel that unsubscribes a slot.</summary>
+        public const ushort Unsubscribe = 0xFFFF;
+    }
+
+    /// <summary>
+    /// One entry from a firmware ITM subscription report (col03-IN). The firmware
+    /// dictates which parameter sits at which handle for the current page; the host
+    /// echoes values back at the same handle. <see cref="IsUnsubscribe"/> marks a slot
+    /// the firmware is dropping (paramId 0xFFFF).
+    /// </summary>
+    public readonly struct ItmSubscription
+    {
+        /// <summary>Host handle (firmware handle with the 0x80 slot-marker bit cleared).</summary>
+        public byte Handle { get; }
+
+        /// <summary>Subscribed parameter ID, or 0xFFFF for an unsubscribe.</summary>
+        public ushort ParamId { get; }
+
+        public bool IsUnsubscribe => ParamId == ItmParam.Unsubscribe;
+
+        public ItmSubscription(byte firmwareHandle, ushort paramId)
+        {
+            Handle = (byte)(firmwareHandle & 0x7F);
+            ParamId = paramId;
+        }
+    }
+
+    /// <summary>
+    /// Maps SimHub <see cref="GameData"/> telemetry to the encoded
+    /// <see cref="ItmValue"/> entries for a given <see cref="ItmPage"/>, ready to
+    /// hand to <see cref="ItmEncoder.SendValues"/>.
+    ///
+    /// This is the pure, per-frame translation step — the ITM analogue of
+    /// <c>FanatecDisplayDriver</c>'s telemetry reads. It holds no state and does
+    /// no I/O; page selection, keepalive scheduling, and the enable/ParamDefs
+    /// sequence belong to the (future) ITM display driver above it.
+    ///
+    /// Handles are assigned sequentially (0..N-1) in page-field order. That mirrors
+    /// a straightforward ParamDefs slot layout; if the on-hardware slot/handle
+    /// mapping (protocol reference, "Slot &amp; Handle Mapping") proves to need
+    /// specific handle ranges per page, this is the single place to change it.
+    /// </summary>
+    public static class ItmTelemetry
+    {
+        // A single page field: its parameter ID plus how to read+encode it from
+        // a telemetry frame for a given handle.
+        private sealed class Field
+        {
+            public readonly ushort ParamId;
+            private readonly Func<StatusDataBase, byte, ItmValue> _encode;
+
+            public Field(ushort paramId, Func<StatusDataBase, byte, ItmValue> encode)
+            {
+                ParamId = paramId;
+                _encode = encode;
+            }
+
+            public ItmValue Encode(StatusDataBase data, byte handle) => _encode(data, handle);
+        }
+
+        // ── Typed field builders ─────────────────────────────────────────
+        private static Field U8(ushort id, Func<StatusDataBase, byte> sel)
+            => new Field(id, (d, h) => ItmValue.UInt8(h, id, sel(d)));
+
+        private static Field I16(ushort id, Func<StatusDataBase, short> sel)
+            => new Field(id, (d, h) => ItmValue.Int16(h, id, sel(d)));
+
+        private static Field I32(ushort id, Func<StatusDataBase, int> sel)
+            => new Field(id, (d, h) => ItmValue.Int32(h, id, sel(d)));
+
+        private static Field F32(ushort id, Func<StatusDataBase, float> sel)
+            => new Field(id, (d, h) => ItmValue.Float32(h, id, sel(d)));
+
+        private static Field Str(ushort id, Func<StatusDataBase, string> sel)
+            => new Field(id, (d, h) => ItmValue.Ascii(h, id, sel(d)));
+
+        // SPEED + GEAR head every page (protocol reference, "ITM Page Layouts").
+        // SpeedLocal honours the user's km/h vs mph choice, matching the 7-seg driver.
+        private static readonly Field SpeedField = I16(ItmParam.Speed, d => ClampSpeed(d.SpeedLocal));
+        private static readonly Field GearField = U8(ItmParam.Gear, d => EncodeGear(d.Gear));
+
+        // ── Page layouts ─────────────────────────────────────────────────
+        private static readonly Field[] LapInfo =
+        {
+            SpeedField,
+            GearField,
+            U8(ItmParam.Lap, d => ClampByte(d.CurrentLap)),
+            U8(ItmParam.Position, d => ClampByte(d.Position)),
+            F32(ItmParam.LapTime, d => Seconds(d.CurrentLapTime)),
+            F32(ItmParam.LastLapTime, d => Seconds(d.LastLapTime)),
+        };
+
+        private static readonly Field[] FuelErsDrs =
+        {
+            SpeedField,
+            GearField,
+            F32(ItmParam.Fuel, d => (float)d.Fuel),
+            I32(ItmParam.ErsLevel, d => (int)Math.Round(d.ERSPercent)),
+            U8(ItmParam.DrsZone, d => (byte)(d.DRSAvailable != 0 ? 1 : 0)),
+            U8(ItmParam.DrsActive, d => (byte)(d.DRSEnabled != 0 ? 1 : 0)),
+            F32(ItmParam.DeltaOwnBest, d => (float)(d.DeltaToSessionBest ?? 0.0)),
+        };
+
+        // Field order (handles 2..6) matches the official-software capture:
+        // TC, ABS, EngineMap, OilTemp, BrakeBias.
+        private static readonly Field[] CarSettings =
+        {
+            SpeedField,
+            GearField,
+            U8(ItmParam.TcSetting, d => ClampByte(d.TCLevel)),
+            U8(ItmParam.AbsSetting, d => ClampByte(d.ABSLevel)),
+            // ENGINE_MAPPING is ASCII text on the wire — map 10 travels as "10", not 0x0A.
+            // Sending the numeric byte wedges the firmware (verified via official capture).
+            Str(ItmParam.EngineMapping, d => EngineMapText(d.EngineMap)),
+            U8(ItmParam.OilTemp, d => ClampByte(d.OilTemperature)),
+            // BRAKE_BIAS is Int32 tenths of a percent (512 = 51.2%); see BrakeBiasTenths.
+            I32(ItmParam.BrakeBias, d => BrakeBiasTenths(d.BrakeBias)),
+        };
+
+        private static readonly Field[] LapTimes =
+        {
+            SpeedField,
+            GearField,
+            F32(ItmParam.LastLapTime, d => Seconds(d.LastLapTime)),
+            F32(ItmParam.BestLapTime, d => Seconds(d.BestLapTime)),
+            // Car ahead is shown as a negative gap (you're behind them); car behind positive.
+            F32(ItmParam.CarAhead, d => -NearestGap(d.OpponentsAheadOnTrack)),
+            F32(ItmParam.CarBehind, d => NearestGap(d.OpponentsBehindOnTrack)),
+        };
+
+        // Field order (handles 2..5) matches the official-software capture:
+        // FL, RL, FR, RR (left column, then right column).
+        private static readonly Field[] TyreTemps =
+        {
+            SpeedField,
+            GearField,
+            U8(ItmParam.TyreFlTemp, d => ClampByte(d.TyreTemperatureFrontLeft)),
+            U8(ItmParam.TyreRlTemp, d => ClampByte(d.TyreTemperatureRearLeft)),
+            U8(ItmParam.TyreFrTemp, d => ClampByte(d.TyreTemperatureFrontRight)),
+            U8(ItmParam.TyreRrTemp, d => ClampByte(d.TyreTemperatureRearRight)),
+        };
+
+        private static readonly Field[] Empty = new Field[0];
+
+        // Flat paramId -> encoder registry, built from every page's fields. Lets the
+        // firmware-driven path encode a value for any subscribed parameter ID without
+        // caring which page it belongs to.
+        private static readonly Dictionary<ushort, Field> ByParam = BuildRegistry();
+
+        // Parameters that wedge the PBME firmware when sent — never put them on the wire.
+        // The firmware may still subscribe them (so the field shows dashes), but sending a
+        // value locks up the display.
+        //
+        // Currently empty: ENGINE_MAPPING used to live here because sending it as a numeric
+        // byte froze the Car Settings page. A USBPcap of the official software revealed it is
+        // ASCII text (map "10" = bytes '1','0'), so it is now sent via Str(...) instead of
+        // being suppressed. Keep the set for any future param that proves unsendable.
+        private static readonly HashSet<ushort> Unsupported = new HashSet<ushort>();
+
+        private static Dictionary<ushort, Field> BuildRegistry()
+        {
+            var map = new Dictionary<ushort, Field>();
+            foreach (var page in new[] { LapInfo, FuelErsDrs, CarSettings, LapTimes, TyreTemps })
+                foreach (var f in page)
+                    if (!map.ContainsKey(f.ParamId))
+                        map[f.ParamId] = f;
+            return map;
+        }
+
+        private static Field[] FieldsFor(ItmPage page)
+        {
+            switch (page)
+            {
+                case ItmPage.LapInfo: return LapInfo;
+                case ItmPage.FuelErsDrs: return FuelErsDrs;
+                case ItmPage.CarSettings: return CarSettings;
+                case ItmPage.LapTimes: return LapTimes;
+                case ItmPage.TyreTemps: return TyreTemps;
+                default: return Empty;   // Legacy / unknown: no parameters
+            }
+        }
+
+        // ── Public API ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// The ordered parameter IDs that make up a page. Use to build the
+        /// ParamDefs slot layout. Empty for <see cref="ItmPage.Legacy"/>.
+        /// </summary>
+        public static IReadOnlyList<ushort> ParamsFor(ItmPage page)
+        {
+            var fields = FieldsFor(page);
+            var ids = new ushort[fields.Length];
+            for (int i = 0; i < fields.Length; i++)
+                ids[i] = fields[i].ParamId;
+            return ids;
+        }
+
+        // ASCII unit suffixes the display appends to a parameter's value, sent via
+        // ParamDefs. Matches the official software's suffixes from the capture
+        // ('C' on temperatures, 'L' on fuel). Temperatures assume Celsius.
+        private static readonly Dictionary<ushort, string> UnitSuffixes = new Dictionary<ushort, string>
+        {
+            { ItmParam.OilTemp, "C" },
+            { ItmParam.TyreFlTemp, "C" },
+            { ItmParam.TyreFrTemp, "C" },
+            { ItmParam.TyreRlTemp, "C" },
+            { ItmParam.TyreRrTemp, "C" },
+            { ItmParam.Fuel, "L" },
+        };
+
+        /// <summary>
+        /// The ASCII unit suffix a parameter's value should display (e.g. "C" for a
+        /// temperature), or false if it has none. Used to build ParamDefs entries.
+        /// </summary>
+        public static bool TryGetUnitSuffix(ushort paramId, out string suffix)
+            => UnitSuffixes.TryGetValue(paramId, out suffix);
+
+        /// <summary>Whether a parameter can carry a dynamic "/total" suffix (lap, position).</summary>
+        public static bool IsTotalParam(ushort paramId)
+            => paramId == ItmParam.Lap || paramId == ItmParam.Position;
+
+        /// <summary>
+        /// The dynamic "/total" suffix for a parameter that has one — lap of total laps
+        /// ("/34") and position of field size ("/20") — computed from the current
+        /// telemetry. The firmware cannot know these, so the host supplies them.
+        ///
+        /// Returns false (no suffix) when the parameter has no total, there is no
+        /// telemetry frame, or the game does not report a plausible total — i.e. the
+        /// total must be present and at least the current value. This drops misleading
+        /// "/0" / "/2" suffixes from games (e.g. Forza Horizon) that don't expose a race
+        /// structure, while real races still show the total.
+        /// </summary>
+        public static bool TryGetTotalSuffix(ushort paramId, GameData data, out string suffix)
+        {
+            suffix = null;
+            var s = data?.NewData;
+            if (s == null) return false;
+
+            switch (paramId)
+            {
+                case ItmParam.Lap:
+                    if (s.TotalLaps > 0 && s.TotalLaps >= s.CurrentLap)
+                        suffix = "/" + s.TotalLaps;
+                    return suffix != null;
+                case ItmParam.Position:
+                    int field = s.OpponentsCount;   // SimHub's opponents list already includes the player
+                    if (field > 1 && field >= s.Position)
+                        suffix = "/" + field;
+                    return suffix != null;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Encodes a single subscribed parameter's current value at <paramref name="handle"/>,
+        /// for the firmware-driven path. Returns false when there is no telemetry frame or
+        /// the parameter has no known encoder.
+        /// </summary>
+        public static bool TryEncodeParam(ushort paramId, byte handle, GameData data, out ItmValue value)
+        {
+            value = default;
+            if (Unsupported.Contains(paramId))
+                return false;   // never send — wedges the firmware
+            var status = data?.NewData;
+            if (status == null || !ByParam.TryGetValue(paramId, out var field))
+                return false;
+            value = field.Encode(status, handle);
+            return true;
+        }
+
+        /// <summary>
+        /// Parses a firmware ITM subscription report (col03-IN, <c>FF 05 01</c>) into its
+        /// entries. Each entry is <c>[03][fwHandle][paramId-LE][unit]</c>; the host handle
+        /// is <c>fwHandle &amp; 0x7F</c> and <c>paramId == 0xFFFF</c> means unsubscribe.
+        /// Returns an empty list if the report carries no recognizable entries.
+        /// </summary>
+        public static IReadOnlyList<ItmSubscription> ParseSubscriptionReport(byte[] report, int len)
+        {
+            var result = new List<ItmSubscription>();
+            if (report == null) return result;
+            if (len <= 0 || len > report.Length) len = report.Length;
+
+            // Find the FF 05 01 header (tolerate a leading report-ID in the first bytes).
+            int start = -1;
+            for (int i = 0; i <= 2 && i + 3 <= len; i++)
+                if (report[i] == 0xFF && report[i + 1] == 0x05 && report[i + 2] == 0x01)
+                {
+                    start = i + 3;
+                    break;
+                }
+            if (start < 0) return result;
+
+            // Entries: [03][fwHandle][idLo][idHi][unit], 5 bytes each, until a non-0x03 marker.
+            for (int i = start; i + 5 <= len; i += 5)
+            {
+                if (report[i] != 0x03) break;
+                byte fwHandle = report[i + 1];
+                ushort pid = (ushort)(report[i + 2] | (report[i + 3] << 8));
+                result.Add(new ItmSubscription(fwHandle, pid));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Encodes the current telemetry for <paramref name="page"/> into the value
+        /// entries to send via <see cref="ItmEncoder.SendValues"/>. Handles are
+        /// assigned <paramref name="handleBase"/>..+N-1 in field order. Returns an
+        /// empty list when there is no telemetry frame or the page carries no parameters.
+        /// </summary>
+        public static IReadOnlyList<ItmValue> BuildValues(ItmPage page, GameData data, byte handleBase = 0)
+        {
+            var status = data?.NewData;
+            var fields = FieldsFor(page);
+            if (status == null || fields.Length == 0)
+                return Array.Empty<ItmValue>();
+
+            var values = new ItmValue[fields.Length];
+            for (int i = 0; i < fields.Length; i++)
+                values[i] = fields[i].Encode(status, (byte)(handleBase + i));
+            return values;
+        }
+
+        // ── Encoding helpers ─────────────────────────────────────────────
+
+        private static float Seconds(TimeSpan t) => (float)t.TotalSeconds;
+
+        // The nearest on-track gap (seconds) among a set of opponents, or 0 if none /
+        // unknown. SimHub gives no scalar gap-to-car-ahead/behind, so take the smallest
+        // |RelativeGapToPlayer| from the ahead/behind list (robust to list ordering).
+        private static float NearestGap(System.Collections.Generic.IEnumerable<Opponent> opponents)
+        {
+            if (opponents == null) return 0f;
+            double best = double.MaxValue;
+            foreach (var o in opponents)
+            {
+                double? g = o?.RelativeGapToPlayer;
+                if (g.HasValue)
+                {
+                    double a = Math.Abs(g.Value);
+                    if (a < best) best = a;
+                }
+            }
+            return best == double.MaxValue ? 0f : (float)best;
+        }
+
+        // Speed is non-negative; clamp to [0, Int16 max] (the SPEED param is Int16).
+        private static short ClampSpeed(double value)
+        {
+            double v = Math.Round(value);
+            if (v < 0) return 0;
+            if (v > short.MaxValue) return short.MaxValue;
+            return (short)v;
+        }
+
+        private static byte ClampByte(double value)
+        {
+            double v = Math.Round(value);
+            if (v < 0) return 0;
+            if (v > 255) return 255;
+            return (byte)v;
+        }
+
+        private static byte ClampByte(int value)
+        {
+            if (value < 0) return 0;
+            if (value > 255) return 255;
+            return (byte)value;
+        }
+
+        // BRAKE_BIAS is an Int32 in tenths of a percent (confirmed by capture: 51.2% =>
+        // 512). SimHub reports a percentage, so send round(percent * 10), clamped to
+        // [0, 1000] (0–100.0%).
+        private static int BrakeBiasTenths(double percent)
+        {
+            if (double.IsNaN(percent) || double.IsInfinity(percent)) return 0;
+            int v = (int)Math.Round(percent * 10.0);
+            if (v < 0) return 0;
+            if (v > 1000) return 1000;
+            return v;
+        }
+
+        // ENGINE_MAPPING is rendered by the firmware as text (e.g. "1", "10"). SimHub reports
+        // the map as an int; send its decimal string. Clamp to [0, 99] so the payload stays
+        // within two ASCII bytes (the range the official software was observed to use).
+        private static string EngineMapText(int map)
+        {
+            if (map < 0) map = 0;
+            if (map > 99) map = 99;
+            return map.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>Reverse sentinel: -1 as a Uint8, which the firmware renders as "r".</summary>
+        private const byte GearReverse = 0xFF;
+
+        /// <summary>
+        /// Parses SimHub's gear string to the ITM Uint8 gear value: "N"/empty = 0,
+        /// "1".."9" = that number, "R" = <see cref="GearReverse"/>. Forward gears are
+        /// literal, confirmed against an official-software capture (N=0, 2=2, 3=3).
+        /// </summary>
+        private static byte EncodeGear(string gear)
+        {
+            if (string.IsNullOrEmpty(gear))
+                return 0;
+
+            gear = gear.Trim().ToUpperInvariant();
+            if (gear == "R" || gear == "REVERSE") return GearReverse;
+            if (gear == "N" || gear == "NEUTRAL") return 0;
+
+            return int.TryParse(gear, out int g) && g >= 0 && g <= 254 ? (byte)g : (byte)0;
+        }
+    }
+}

--- a/FanaBridge/Protocol/SystemReportReader.cs
+++ b/FanaBridge/Protocol/SystemReportReader.cs
@@ -75,10 +75,12 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
-        /// Non-blocking drain of pushed reports; every FF 08 report found is passed
-        /// to <paramref name="onReading"/>. Returns the number delivered.
+        /// Non-blocking drain of pushed reports. Every FF 08 identity report is passed
+        /// to <paramref name="onReading"/>; if <paramref name="onItmReport"/> is provided,
+        /// every FF 05 ITM report (the firmware's subscription pushes) is passed to it as
+        /// a private copy. Returns the number of identity readings delivered.
         /// </summary>
-        public int DrainPushes(IDeviceTransport io, Action<Reading> onReading)
+        public int DrainPushes(IDeviceTransport io, Action<Reading> onReading, Action<byte[]> onItmReport = null)
         {
             int count = 0;
             using (io.BeginBatch())
@@ -90,13 +92,32 @@ namespace FanaBridge.Protocol
                     if (n <= 0) break;
 
                     int sig = FindSignature(buf, n);
-                    if (sig < 0) continue; // axis/other report — not FF 08
+                    if (sig >= 0)
+                    {
+                        onReading(Decode(buf, sig, n));
+                        count++;
+                        continue;
+                    }
 
-                    onReading(Decode(buf, sig, n));
-                    count++;
+                    if (onItmReport != null && IsItmReport(buf, n))
+                    {
+                        var copy = new byte[n];
+                        Array.Copy(buf, copy, n);
+                        onItmReport(copy);
+                    }
                 }
             }
             return count;
+        }
+
+        // True if the report carries the col03 ITM signature (FF 05), tolerating a
+        // leading report-ID byte. The firmware pushes these on ITM page changes.
+        private static bool IsItmReport(byte[] buf, int len)
+        {
+            for (int i = 0; i <= 2 && i + 1 < len; i++)
+                if (buf[i] == 0xFF && buf[i + 1] == 0x05)
+                    return true;
+            return false;
         }
 
         /// <summary>

--- a/FanaBridge/Transport/FanatecWheelbase.cs
+++ b/FanaBridge/Transport/FanatecWheelbase.cs
@@ -43,6 +43,7 @@ namespace FanaBridge.Transport
         public FanatecWheelbase()
         {
             _ingest = OnDrainReading;
+            _bufferItm = BufferItmReport;
         }
 
         /// <summary>The wheelbase's HID transport — used by LED/display/tuning encoders.</summary>
@@ -63,6 +64,17 @@ namespace FanaBridge.Transport
         private readonly Action<SystemReportReader.Reading> _ingest;
         private long _lastEnableMs;
         private long _drainNow;
+
+        // ── ITM subscription reports (col03-IN FF 05 pushes) ──────────────
+        // The firmware pushes these on ITM page changes; they tell the host which
+        // params to display at which handles. Buffered here during the identity
+        // drain and consumed by the ITM display driver each frame.
+        private readonly Action<byte[]> _bufferItm;
+        private readonly object _itmLock = new object();
+        private readonly System.Collections.Generic.List<byte[]> _itmReports =
+            new System.Collections.Generic.List<byte[]>();
+        private const int ItmReportBufferCap = 32;
+        private bool _itmDropWarned;
 
         // Most recent drained reading; decoded into the public properties on commit.
         private SystemReportReader.Reading _lastReading;
@@ -422,7 +434,7 @@ namespace FanaBridge.Transport
             }
 
             _drainNow = now;
-            _reportReader.DrainPushes(_transport, _ingest);
+            _reportReader.DrainPushes(_transport, _ingest, _bufferItm);
 
             bool changed = _settler.Tick(now, out _, out _);
             _identityStable = _settler.IsStable;
@@ -434,6 +446,49 @@ namespace FanaBridge.Transport
         // Drain callback: record the reading and offer it to the settler. _drainNow
         // carries the current clock so the cached delegate needs no per-frame closure.
         private void OnDrainReading(SystemReportReader.Reading r) => IngestReading(r, _drainNow);
+
+        // Drain callback for ITM subscription reports: buffer them for the ITM driver.
+        private void BufferItmReport(byte[] report)
+        {
+            lock (_itmLock)
+            {
+                // Bound the buffer so a consumer that stalls (e.g. during the setup wizard)
+                // can't grow it without limit. Evict the OLDEST when full — only the latest
+                // subscription state matters, so keeping the newest reports is what the
+                // driver needs. Warn once so a stall is diagnosable.
+                if (_itmReports.Count >= ItmReportBufferCap)
+                {
+                    _itmReports.RemoveAt(0);
+                    if (!_itmDropWarned)
+                    {
+                        _itmDropWarned = true;
+                        SimHub.Logging.Current.Warn(
+                            "FanatecWheelbase: ITM subscription buffer full (" + ItmReportBufferCap +
+                            ") — dropping oldest reports; is the ITM driver draining?");
+                    }
+                }
+                _itmReports.Add(report);
+            }
+        }
+
+        /// <summary>
+        /// Passes each ITM subscription report the firmware has pushed since the last
+        /// call to <paramref name="handler"/>, then clears the buffer. Called each frame
+        /// by the ITM display driver so it can follow the wheel's current page.
+        /// </summary>
+        public void DrainItmReports(Action<byte[]> handler)
+        {
+            if (handler == null) return;
+            byte[][] batch;
+            lock (_itmLock)
+            {
+                if (_itmReports.Count == 0) return;
+                batch = _itmReports.ToArray();
+                _itmReports.Clear();
+            }
+            foreach (var r in batch)
+                handler(r);
+        }
 
         private void IngestReading(SystemReportReader.Reading r, long now)
         {
@@ -533,6 +588,7 @@ namespace FanaBridge.Transport
             _settler.Reset();
             _identityStable = true;
             _lastReading = default;
+            lock (_itmLock) _itmReports.Clear();
 
             ConnectedProductId = 0;
             ProductName = null;

--- a/FanaBridge/UI/ScreenSettingsPanel.xaml
+++ b/FanaBridge/UI/ScreenSettingsPanel.xaml
@@ -5,19 +5,37 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
         <StackPanel Margin="8">
 
-            <!-- Shown when the wheel has an ITM display but ITM is not yet supported -->
+            <!-- Shown for wheels with an ITM display (pages are wheel-controlled) -->
             <Border x:Name="borderItmInfo" Visibility="Collapsed"
                     Background="#1A4488CC" BorderBrush="#4488CC" BorderThickness="1"
                     CornerRadius="4" Padding="10,8" Margin="0,0,0,12">
                 <TextBlock Foreground="#AADDFF" FontSize="12" TextWrapping="Wrap">
-                    &#x2139;  This wheel has an ITM display. FanaBridge currently supports basic display mode only — full ITM display support is planned.
+                    &#x2139;  This wheel has an ITM telemetry display. Pages are selected with the wheel's display button — FanaBridge follows the wheel and shows live SimHub telemetry on each page (speed, gear, lap times, tyre temps, and more). The wheel's legacy page shows the simple gear/speed display picked under Legacy Display Mode below; choose "None" to leave it off.
                 </TextBlock>
             </Border>
 
-            <styles:SHSubSection Title="Display Mode">
+            <!-- ITM display options -->
+            <styles:SHSubSection x:Name="sectionItmOptions" Title="ITM Options" Visibility="Collapsed">
+                <StackPanel>
+                    <CheckBox x:Name="chkEnableItm" Content="Enable ITM display"
+                              Checked="ItmOption_Changed" Unchecked="ItmOption_Changed" Margin="0,2,0,8" />
+                    <TextBlock Foreground="#999999" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,8">
+                        Show "/total" on the lap and position fields (e.g. "Lap 5 / 34" rather than "Lap 5"). Turn off for games that don't report usable totals.
+                    </TextBlock>
+                    <CheckBox x:Name="chkShowLapTotal" Content="Show lap total (Lap 5 / 34)"
+                              Checked="ItmOption_Changed" Unchecked="ItmOption_Changed" Margin="0,2" />
+                    <CheckBox x:Name="chkShowPositionTotal" Content="Show position total (P3 / 20)"
+                              Checked="ItmOption_Changed" Unchecked="ItmOption_Changed" Margin="0,4,0,2" />
+                </StackPanel>
+            </styles:SHSubSection>
+
+            <!-- 7-segment display mode. Title becomes "Legacy Display Mode" (with a "None"
+                 option) on ITM wheels; plain "Display Mode" on basic wheels. -->
+            <styles:SHSubSection x:Name="sectionDisplayMode" Title="Display Mode">
                 <ComboBox x:Name="cmbDisplayMode"
                           SelectionChanged="CmbDisplayMode_SelectionChanged"
                           Width="200" HorizontalAlignment="Left">
+                    <ComboBoxItem x:Name="cmbItemNone" Content="None" Tag="None" Visibility="Collapsed" />
                     <ComboBoxItem Content="Gear" Tag="Gear" />
                     <ComboBoxItem Content="Speed" Tag="Speed" />
                     <ComboBoxItem Content="Gear + Speed" Tag="GearAndSpeed" />

--- a/FanaBridge/UI/ScreenSettingsPanel.xaml.cs
+++ b/FanaBridge/UI/ScreenSettingsPanel.xaml.cs
@@ -28,35 +28,60 @@ namespace FanaBridge.UI
             _settings = settings ?? new DisplaySettings();
             _suppressEvents = true;
 
-            string mode = _settings.DisplayMode ?? DisplaySettings.DefaultMode;
-            foreach (ComboBoxItem item in cmbDisplayMode.Items)
-            {
-                if ((string)item.Tag == mode)
-                {
-                    cmbDisplayMode.SelectedItem = item;
-                    break;
-                }
-            }
+            // ITM displays are firmware-driven (pages chosen on the wheel), so they get
+            // the info banner plus the ITM Options section. Basic 7-segment displays get
+            // only the mode selector.
+            bool isItm = displayType == DisplayType.Itm;
 
-            // Show ITM info banner for wheels with graphical displays
-            borderItmInfo.Visibility = displayType == DisplayType.Itm
-                ? Visibility.Visible
-                : Visibility.Collapsed;
+            // "None" (legacy page off) is an ITM-only choice; hide it on basic wheels.
+            cmbItemNone.Visibility = isItm ? Visibility.Visible : Visibility.Collapsed;
+            SelectByTag(cmbDisplayMode, _settings.DisplayMode ?? DisplaySettings.DefaultMode);
+            chkEnableItm.IsChecked = _settings.ItmEnabled;
+            chkShowLapTotal.IsChecked = _settings.ItmShowLapTotal;
+            chkShowPositionTotal.IsChecked = _settings.ItmShowPositionTotal;
+
+            borderItmInfo.Visibility = isItm ? Visibility.Visible : Visibility.Collapsed;
+            sectionItmOptions.Visibility = isItm ? Visibility.Visible : Visibility.Collapsed;
+            // The mode selector drives the simple 7-seg gear/speed — the only display on
+            // basic wheels, and the optional legacy page on an ITM OLED. Shown in both
+            // cases, but titled "Legacy Display Mode" on ITM wheels.
+            sectionDisplayMode.Title = isItm ? "Legacy Display Mode" : "Display Mode";
+            sectionDisplayMode.Visibility = Visibility.Visible;
 
             _suppressEvents = false;
+        }
+
+        private static void SelectByTag(ComboBox combo, string tag)
+        {
+            foreach (ComboBoxItem item in combo.Items)
+            {
+                if ((string)item.Tag == tag)
+                {
+                    combo.SelectedItem = item;
+                    return;
+                }
+            }
         }
 
         private void CmbDisplayMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (_suppressEvents || _settings == null) return;
 
-            var selected = cmbDisplayMode.SelectedItem as ComboBoxItem;
-            if (selected != null)
+            if (cmbDisplayMode.SelectedItem is ComboBoxItem selected)
             {
                 _settings.DisplayMode = (string)selected.Tag;
                 SettingsChanged?.Invoke();
             }
         }
 
+        private void ItmOption_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_suppressEvents || _settings == null) return;
+
+            _settings.ItmEnabled = chkEnableItm.IsChecked == true;
+            _settings.ItmShowLapTotal = chkShowLapTotal.IsChecked == true;
+            _settings.ItmShowPositionTotal = chkShowPositionTotal.IsChecked == true;
+            SettingsChanged?.Invoke();
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 - **RGB button and encoder LEDs** — Full RGB color and 8-level intensity per LED, including Rev/RPM and Flag/status LED strips where present
 - **3-digit display** — Wheels with a basic display show gear, speed, or gear-then-speed overlay
+- **Experimental: ITM telemetry display** — Wheels/modules with a graphical ITM display (e.g. Button Module Endurance) show live SimHub telemetry across all pages — speed, gear, lap times, position, fuel/ERS/DRS, car settings, tyre temps. Pages are selected with the wheel's display button
 - **SimHub LED profiles** — Wheels appear in SimHub's Devices view with standard LED Editor support
 - **Compatible with LED profile plugins** — Works with [ATSR Hub EVO](https://github.com/ATSR-Alex/ATSR-Hub-EVO) and other SimHub LED profile plugins
 - **Automatic detection** — Detects connected wheels, hubs and button modules directly over HID and matches to a profile
@@ -30,7 +31,6 @@
 ### Planned
 
 - Customizable telemetry display and arbitrary text/messages (e.g., function layer activation)
-- ITM display support
 
 ## Supported Devices
 

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -47,11 +47,12 @@ Fanatec wheelbases communicate with the host PC over USB HID (Human Interface De
     - [Live Change Notifications](#live-change-notifications)
     - [CBP in Tuning Context](#cbp-in-tuning-context)
   - [0x05 — ITM Display](#0x05--itm-display)
+    - [0x02 — ITM Mode (Enable Gate)](#0x02--itm-mode-enable-gate)
     - [0x01 — ValueUpdate](#0x01--valueupdate)
     - [0x03 — ParamDefs](#0x03--paramdefs)
+    - [Firmware Subscription Pushes (Device → Host)](#firmware-subscription-pushes-device--host)
     - [0x04 — PageSet / Keepalive / Config](#0x04--pageset--keepalive--config)
-    - [Slot & Handle Mapping (Raw HID)](#slot--handle-mapping-raw-hid)
-    - [Control Model: Official Software vs Raw HID](#control-model-official-software-vs-raw-hid)
+    - [Control Model (Firmware-Driven)](#control-model-firmware-driven)
     - [Timing & Rate Limiting](#timing--rate-limiting)
     - [Automatic Page Changes (Alerts)](#automatic-page-changes-alerts)
   - [0x08 — System Report (Identity)](#0x08--system-report-identity)
@@ -536,9 +537,8 @@ FF 02 02 00 [00 x60]
 | 3 | `0x00` | Page (0 = default/reset) |
 
 **Important:**
-- Enable **resets the slot table** — ParamDefs must be re-sent after each Enable.
-- Do not call Enable in a tight loop — rapid repeated calls can crash the PBME firmware.
-- Byte[3] can also be set to 0–6 to select the analysis page.
+- Enable once, then keep the display alive with the [keepalive](#0x04--pageset--keepalive--config); do not call Enable in a tight loop — rapid repeated calls can crash the PBME firmware.
+- After Enable the display sits on the default page (Lap Info). Page selection is firmware-driven (the wheel button) — see [Control Model](#control-model-firmware-driven). Byte[3] nudges the displayed page but does **not** change which page's values the firmware accepts, so it is not a substitute for the firmware's [subscription pushes](#firmware-subscription-pushes-device--host).
 
 ### 0x03 — Tuning Menu
 
@@ -777,6 +777,21 @@ Byte:  [0]   [1]   [2]      [3..63]
        0xFF  0x05  subcmd   payload
 ```
 
+#### 0x02 — ITM Mode (Enable Gate)
+
+Turns ITM on or off at the firmware level — the same persistent state the Fanatec software's "ITM" switch sets. **ITM must be gated on here before anything else works**: with it off, the firmware ignores the [session enable](#0x02--itm-enable), pushes no [subscriptions](#firmware-subscription-pushes-device--host), and the wheel shows no ITM indicator or pages.
+
+```
+Enable:   FF 05 02 01 [00 x60]
+Disable:  FF 05 02 00 [00 x60]
+```
+
+| Byte | Value | Description |
+|------|-------|-------------|
+| 3 | `0x01` / `0x00` | ITM on / off |
+
+The setting is **persistent** (survives power cycles). A host bring-up should be: `FF 05 02 01` (gate on) → [`FF 02 02`](#0x02--itm-enable) (session enable) → keepalive + values. Confirmed against a capture of the official software toggling its ITM switch on/off/on/off.
+
 #### 0x01 — ValueUpdate
 
 Sends telemetry values for display. Each entry contains a handle, parameter ID, and value:
@@ -789,11 +804,13 @@ Each entry:
 
 | Offset | Size | Field | Description |
 |--------|------|-------|-------------|
-| 0 | 1 | Marker | Always `0x01` |
-| 1 | 1 | Handle | Parameter handle (assigned during ParamDefs) |
+| 0 | 1 | Marker | Always `0x03` |
+| 1 | 1 | Handle | Parameter handle (dictated by the firmware — see [Firmware Subscription Pushes](#firmware-subscription-pushes-device--host)) |
 | 2–3 | 2 | Param ID | Parameter ID (little-endian). See [ITM Parameter IDs](#itm-parameter-ids). |
 | 4 | 1 | Size | Value size in bytes (1, 2, or 4) |
 | 5+ | N | Value | Parameter value (little-endian, size from above) |
+
+> **The entry marker is `0x03`, not `0x01`.** Confirmed against a USB capture of the official software on a PBME: entries marked `0x01` are silently ignored by the firmware. Multiple entries may be packed into one report; the firmware accepts batched updates.
 
 #### 0x03 — ParamDefs
 
@@ -820,9 +837,33 @@ Each entry:
 03 83 00 00 02 2F 30   ← slot 0x83, suffix "/0"
 ```
 
-The suffix system corresponds to the unit display feature in the official software — the "/0" suffix likely represents the total denominator (e.g., "Lap 5 / 20").
+The suffix system attaches a unit/total to a slot (e.g. `2F 30` = "/0" total denominator → "Lap 5 / 20"; `43` = "C" for °C on temperature params). **The slot ID is `0x80 + handle`** — i.e. ParamDefs decorates the same handles used by [ValueUpdate](#0x01--valueupdate), but with the high bit set. ParamDefs is **cosmetic** (units only): a param's value renders from its ValueUpdate alone; only params that carry a unit/total get a ParamDefs entry.
 
 Maximum subscribed parameters per device: **16**.
+
+#### Firmware Subscription Pushes (Device → Host)
+
+This is the key to multi-page support. **The wheel — not the host — owns page selection** (the wheel's display button cycles pages). On every page change the firmware *pushes* one or more `FF 05 01` reports on the col03 **input** endpoint telling the host exactly which parameters to display at which handles for the new page. The host then echoes [ValueUpdate](#0x01--valueupdate)s for those subscriptions. There is no working host page-select command — `PageSet` and the Enable page byte change the layout but do **not** make the firmware accept a page's values; only the firmware's own (button-driven) page state does.
+
+Each pushed report uses the same `FF 05 01` framing, with 5-byte entries:
+
+| Offset | Size | Field | Description |
+|--------|------|-------|-------------|
+| 0 | 1 | Marker | Always `0x03` |
+| 1 | 1 | Handle | Firmware handle. The `0x80` bit marks a "slot" param (one with a ParamDefs unit). **Host ValueUpdate handle = handle `& 0x7F`.** |
+| 2–3 | 2 | Param ID | Subscribed parameter (little-endian), or `0xFFFF` = **unsubscribe** that handle. |
+| 4 | 1 | Unit | Unit/format hint (see [ITM Unit System](#itm-unit-system)). |
+
+A page change arrives as an UNSUBSCRIBE report (old params, `0xFFFF`) followed by the new page's subscriptions. Example — switching to the Tyre Temps page:
+
+```
+FF 05 01  03 00 0001 34  03 01 0004 12  03 82 002A 32  03 83 0030 32 ...
+          └ h0=SPEED ┘   └ h1=GEAR ┘    └ h2=TYRE_FL ┘ └ h3=TYRE_RL ┘
+```
+
+(`0x82 & 0x7F = 2`, so the host sends TYRE_FL at handle 2.)
+
+**Initial page.** The firmware pushes a subscription only on a *change*, not on the initial [Enable](#0x02--itm-enable). After Enable the display sits on its default page (Lap Info), which the host can populate directly by sending that page's ValueUpdates — the firmware accepts the default page's params without a push. Subsequent button presses then drive the subscription pushes.
 
 #### 0x04 — PageSet / Keepalive / Config
 
@@ -852,35 +893,16 @@ FF 05 04 02 0B [00 x59]
 | 3 | `0x02` | Config type |
 | 4 | `0x0B` | Config value |
 
-#### Slot & Handle Mapping (Raw HID)
+#### Control Model (Firmware-Driven)
 
-When using raw HID (bypassing the official software), displays require explicit slot configuration via ParamDefs:
+The working model — verified on a PBME — is firmware-driven:
 
-| Page(s) | Slot IDs | Handle Range | Suffix |
-|---------|----------|--------------|--------|
-| 1, 5 | 0x82, 0x83, 0x84, 0x85 | 0–5 | "/0" (Page 1 only) |
-| 2, 4 | 0x88 | 6–12 | "/0" (Page 2 only) |
-| 3 | 0x85 | 0–5 + 13 | none |
+1. **Enable** ITM once (`FF 02 02 00`).
+2. **Keepalive** every ~100&#160;ms (`FF 05 04 02 0B`) to keep the display awake.
+3. The firmware owns page selection (wheel button) and **pushes** the current page's [subscriptions](#firmware-subscription-pushes-device--host) on col03-IN.
+4. The host **reads** those pushes and sends [ValueUpdate](#0x01--valueupdate)s at the firmware-dictated handles, for the subscribed params only.
 
-#### Control Model: Official Software vs Raw HID
-
-**Official Software Approach (Firmware-Driven):**
-
-The firmware maintains a subscription table of up to 16 parameter slots. The host queries which parameters the firmware expects for the current page, then populates them:
-
-1. Firmware owns the page layout
-2. Host queries the firmware to learn what params are needed for the current page
-3. Host sends values for subscribed params only
-4. Page content is fixed by firmware
-
-**Raw HID Approach (Host-Driven):**
-
-1. Host sends PageSet — tells firmware which page
-2. Host sends ParamDefs — tells firmware the slot layout
-3. Host sends ValueUpdate — sends actual data
-4. Host can potentially choose which params appear on each page
-
-The raw HID approach gives more flexibility but requires knowing the [page layouts](#itm-page-layouts) in advance and carries the risk that untested parameter IDs may not render correctly.
+The host does not choose the page or the handles. A purely host-driven approach (PageSet / ParamDefs / guessed handles) was tried and does **not** work — the firmware ignores values for a page it has not announced. The [page layouts](#itm-page-layouts) below are still useful for seeding the default page and as a reference for what each page contains, but the authoritative handle→param map for any page is whatever the firmware pushes.
 
 #### Timing & Rate Limiting
 
@@ -1118,8 +1140,8 @@ The firmware recognizes a vocabulary of parameter IDs. Only a subset is confirme
 | 15 | DRS_ACTIVE | 1 | Uint8 | 0 or 1 |
 | 18 | ABS_SETTING | 1 | Uint8 | |
 | 20 | TC_SETTING | 1 | Uint8 | |
-| 25 | BRAKE_BIAS | 4 | Float32 LE | Must be 4 bytes — values >= 127 can crash PBME firmware |
-| 26 | ENGINE_MAPPING | 1 | Uint8 | |
+| 25 | BRAKE_BIAS | 4 | Int32 LE | Tenths of a percent — 51.2% = `512`. **Int32, not Float32** (confirmed by capture; sending a float displays a capped 99.9%). |
+| 26 | ENGINE_MAPPING | 1–2 | ASCII text | The map **rendered as text** — map 10 travels as bytes `'1' '0'` (`31 30`), size = digit count. **Not a Uint8** (confirmed by capture; sending the numeric byte hangs the PBME Car Settings page). |
 | 33 | OIL_TEMP | 1 | Uint8 | Unit-converted (C/F) |
 | 42 | TYRE_FL_C_TEMP | 1 | Uint8 | Unit-converted (C/F) |
 | 45 | TYRE_FR_C_TEMP | 1 | Uint8 | Unit-converted (C/F) |
@@ -1212,13 +1234,13 @@ Detection signature: ERS_LEVEL (9).
 | 4 | GEAR | 1 | Uint8 |
 | 20 | TC_SETTING | 1 | Uint8 |
 | 18 | ABS_SETTING | 1 | Uint8 |
-| 25 | BRAKE_BIAS | 4 | Float32 LE |
-| 26 | ENGINE_MAPPING | 1 | Uint8 |
+| 25 | BRAKE_BIAS | 4 | Int32 LE (tenths of a percent) |
+| 26 | ENGINE_MAPPING | 1–2 | ASCII text |
 | 33 | OIL_TEMP | 1 | Uint8 |
 
 Detection signature: OIL_TEMP (33).
 
-> **Warning:** BRAKE_BIAS values >= 127 have been observed to crash PBME firmware. Rapid value cycling on this page can also cause firmware lockups.
+> **Warning:** This page is format-sensitive. BRAKE_BIAS is an Int32 in tenths of a percent (a Float32 shows a capped 99.9%), and ENGINE_MAPPING is ASCII text (map 10 = `31 30`) — sending it as a numeric Uint8 hangs the PBME firmware. Rapid value cycling on this page can also cause firmware lockups.
 
 **Page 4 — Lap Times:**
 


### PR DESCRIPTION
## Summary

Adds native support for the modern Fanatec **ITM (Integrated Telemetry Management)** OLED display, driven over HID with no dependency on the Fanatec driver. Verified end-to-end on real PBME (Podium Button Module Endurance) hardware.

The wheel owns page selection (its display button); FanaBridge follows the firmware's pushed subscriptions and streams live SimHub telemetry for each page — speed, gear, lap/position, lap times, fuel/ERS/DRS, car settings, tyre temps, and car ahead/behind gaps.

## What's included

- **col03 ITM protocol encoder** (`ItmEncoder`) — ValueUpdate / ParamDefs / keepalive / session-enable / ITM-mode-gate framing, reverse-engineered from USB captures.
- **Telemetry mapping** (`ItmTelemetry`) — SimHub → ITM parameters per page, plus firmware subscription-report parsing, unit suffixes, and dynamic `/total` suffixes for lap/position.
- **Firmware-driven display driver** (`ItmDisplayDriver`) — enables ITM once, seeds the initial page, follows subscription pushes, sends rate-limited values + keepalives; an "Enable ITM display" toggle that sends the real firmware ITM on/off command.
- **Settings UI** — an ITM Options section (Enable, show lap/position totals) and a "Legacy Display Mode" dropdown with a "None" option, shown only on ITM wheels; basic 7-segment wheels are unchanged.
- **Docs** — the protocol reference updated with the ITM findings.

## Capture-confirmed encodings

Several encodings in the original protocol notes were wrong and were corrected against USB captures of the official software:

- **BRAKE_BIAS** is `Int32` in tenths of a percent (512 = 51.2%), not `Float32`.
- **ENGINE_MAPPING** is ASCII text ("10" = bytes `31 30`), not `Uint8` — sending the numeric form wedges the firmware.
- Car-ahead gaps report negative, car-behind positive; position field size uses `OpponentsCount` (which already includes the player).

## Testing

- 286 unit tests pass.
- Verified on PBME hardware across all ITM pages.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)