### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.4.0 - Unreleased
+## v0.4.0 - 2026-07-01
 
 ### Changed
 - **Device detection is now handled entirely by FanaBridge over HID** — wheel, hub, and module identity is read straight from the wheelbase (the col03 `FF 08` system report), dropping the dependency on SimHub's Fanatec SDK integration (`SimHub.FanatecManaged.dll`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - A disconnected device now shows *why* (no device found, interface in use, lost connection, …).
 
 ### Fixed
-- Wheels and hubs are now detected on Podium DD wheelbases.
+- Detection now covers hardware SimHub's Fanatec SDK couldn't identify — Podium DD wheelbases and newer wheels such as the ClubSport Formula V3 are now recognized, both for FanaBridge's own device matching and for the Control Mapper integration.
 
 ## v0.3.2 - 2026-06-22
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - **Automatic detection** — Detects connected wheels, hubs and button modules directly over HID and matches to a profile
 - **Hot-plug support** — Reconnects gracefully when devices are plugged/unplugged or wheels are swapped
 - **Custom wheel profiles** — JSON-based profiles mean unsupported wheels can be added without waiting for a plugin update
-- **Experimental: Control Mapper integration** — Supplies FanaBridge's wheel identity to SimHub's Control Mapper so it can keep separate button mappings per Fanatec wheel, including bases and wheels SimHub can't identify on its own (Podium DD, newer wheels)
+- **Experimental: Control Mapper integration** — Supplies FanaBridge's wheel identity to SimHub's Control Mapper so it can keep separate button mappings per Fanatec wheel, including bases and wheels SimHub can't identify on its own (Podium DD wheelbases, newer wheels such as the ClubSport Formula V3)
 - **Experimental: Encoder mode** — Configure encoder behavior (relative, pulse, constant, auto) directly on supported devices
 
 ### Planned

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - **Automatic detection** — Detects connected wheels, hubs and button modules directly over HID and matches to a profile
 - **Hot-plug support** — Reconnects gracefully when devices are plugged/unplugged or wheels are swapped
 - **Custom wheel profiles** — JSON-based profiles mean unsupported wheels can be added without waiting for a plugin update
+- **Experimental: Control Mapper integration** — Supplies FanaBridge's wheel identity to SimHub's Control Mapper so it can keep separate button mappings per Fanatec wheel, including bases and wheels SimHub can't identify on its own (Podium DD, newer wheels)
 - **Experimental: Encoder mode** — Configure encoder behavior (relative, pulse, constant, auto) directly on supported devices
 
 ### Planned


### PR DESCRIPTION
Prep for cutting the **v0.4.0** release.

`VersionPrefix` was already bumped to `0.4.0` in `Directory.Build.props`, and the CHANGELOG's v0.4.0 section was drafted across prior PRs. This PR finalizes the release docs:

- **CHANGELOG** — set the v0.4.0 release date (`Unreleased` → `2026-07-01`).
- **README** — add a Features entry for the new **Control Mapper integration** (#39). The "Automatic detection … directly over HID" bullet already reflects the SDK-drop from #31.

### What's in v0.4.0
- HID-native device identity — drops the `SimHub.FanatecManaged.dll` dependency (#31)
- Control Mapper integration for per-wheel button mappings (experimental) (#39)
- Device Status hardware chain + connection indicator, Copy Debug Info diagnostics
- Fix: wheels/hubs now detected on Podium DD wheelbases

### After merge
Tag `v0.4.0` on `main` to trigger `.github/workflows/release.yml`, which builds and publishes the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)