### PR TITLE
ITM Display Improvements

### DIFF
--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -19,13 +19,15 @@ namespace FanaBridge.Tests
             public bool IsConnected { get; set; } = true;
             public int Col03MaxInputReportLength { get; set; } = 64;
             public List<byte[]> Sent { get; } = new List<byte[]>();
+            // Simulate a transport-level send failure (SendCol03 returns false).
+            public bool SendReturns { get; set; } = true;
 
             public bool SendCol03(byte[] data)
             {
                 var copy = new byte[data.Length];
                 Array.Copy(data, copy, data.Length);
                 Sent.Add(copy);
-                return true;
+                return SendReturns;
             }
 
             public bool SendCol01(byte[] data) => true;
@@ -98,15 +100,15 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void BringUp_EnablesFirmwareItmGateBeforeSession()
+        public void BringUp_ForcesDefaultPage()
         {
             var driver = MakeDriver(out var t, out var clock);
             Enable(driver, clock);
 
-            int gateIdx = t.Sent.FindIndex(IsItmModeOn);
-            int enableIdx = t.Sent.FindIndex(IsEnable);
-            Assert.True(gateIdx >= 0, "ITM gate (FF 05 02 01) was not sent");
-            Assert.True(gateIdx < enableIdx, "ITM gate must precede the session enable");
+            // Bring-up starts the session (FF 02 02) and forces page 1 (FF 05 04 03 01) so the
+            // display matches the Lap Info seed. Detecting the wheel's actual page is deferred (#43).
+            Assert.Contains(t.Sent, IsEnable);
+            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[3] == 0x03 && r[4] == 0x01);
         }
 
         [Fact]
@@ -320,7 +322,7 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void Total_ClearedWithEmptySuffix_WhenItBecomesImplausible()
+        public void Total_ClearedWithBlankSuffix_WhenItBecomesImplausible()
         {
             var driver = MakeDriver(out var t, out var clock);
             var s = NewStatus();
@@ -335,11 +337,12 @@ namespace FanaBridge.Tests
             clock.T += 40;
             driver.Update(Data(s));
 
-            // The position slot (0x83) must be re-emitted with an empty suffix to clear it.
+            // The position slot (0x83) must be re-emitted with a blank " " suffix to clear it —
+            // a zero-length suffix does NOT overwrite the firmware's default "/0" on hardware.
             var pd = t.Sent.First(IsParamDefs);
             bool clearsPosition = false;
             for (int i = 3; i + 5 <= pd.Length && pd[i] == 0x03; i += 5 + pd[i + 4])
-                if (pd[i + 1] == 0x83 && pd[i + 4] == 0x00) clearsPosition = true;
+                if (pd[i + 1] == 0x83 && pd[i + 4] == 0x01 && pd[i + 5] == (byte)' ') clearsPosition = true;
             Assert.True(clearsPosition);
         }
 
@@ -355,10 +358,55 @@ namespace FanaBridge.Tests
             clock.T += 40;
             driver.Update(Data(s));
 
-            // Position slot (0x83) is present but with an empty suffix (length 0).
+            // Position slot (0x83) is present but blanked with a " " suffix (length 1) — a
+            // zero-length suffix would leave the firmware's default "/0" showing.
             var pd = t.Sent.First(IsParamDefs);
             for (int i = 3; i + 5 <= pd.Length && pd[i] == 0x03; i += 5 + pd[i + 4])
-                if (pd[i + 1] == 0x83) Assert.Equal(0x00, pd[i + 4]);   // suffix length 0
+                if (pd[i + 1] == 0x83) { Assert.Equal(0x01, pd[i + 4]); Assert.Equal((byte)' ', pd[i + 5]); }
+        }
+
+        [Fact]
+        public void Fuel_FallsBackToUnitLabel_WhenNoCapacity()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            driver.OnSubscriptionReport(HexToBytes("ff05010382050018"));   // fuel @ handle 2 (slot 0x82)
+            Enable(driver, clock);                                          // seed skipped; only fuel subscribed
+
+            var s = NewStatus();
+            Set(s, "Fuel", 12.0); Set(s, "MaxFuel", 0.0);   // no tank capacity reported
+            t.Sent.Clear();
+            clock.T += 40;
+            driver.Update(Data(s));
+
+            // With no capacity, the fuel slot (0x82) falls back to the unit label "L" (not a
+            // blank " "), so a bare fuel value still reads as fuel.
+            var pd = t.Sent.First(IsParamDefs);
+            bool fuelLabeled = false;
+            for (int i = 3; i + 5 <= pd.Length && pd[i] == 0x03; i += 5 + pd[i + 4])
+                if (pd[i + 1] == 0x82 && pd[i + 4] == 0x01 && pd[i + 5] == (byte)'L') fuelLabeled = true;
+            Assert.True(fuelLabeled);
+        }
+
+        [Fact]
+        public void TempSuffix_FollowsFrameUnit()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            driver.OnSubscriptionReport(TyreSubReport);   // tyre temps @ 0x82/0x83
+            Enable(driver, clock);
+
+            var s = NewStatus();
+            Set(s, "TemperatureUnit", "F");   // frame reports Fahrenheit
+            t.Sent.Clear();
+            clock.T += 40;
+            driver.Update(Data(s));
+
+            // The tyre slot (0x82) label comes from the frame's TemperatureUnit, not a fixed
+            // default — normalized to a single char.
+            var pd = t.Sent.First(IsParamDefs);
+            bool tyreF = false;
+            for (int i = 3; i + 5 <= pd.Length && pd[i] == 0x03; i += 5 + pd[i + 4])
+                if (pd[i + 1] == 0x82 && pd[i + 4] == 0x01 && pd[i + 5] == (byte)'F') tyreF = true;
+            Assert.True(tyreF);
         }
 
         private static bool IsParamDefs(byte[] r) => r[1] == 0x05 && r[2] == 0x03;
@@ -441,6 +489,31 @@ namespace FanaBridge.Tests
             driver.Update(Data(s));
 
             Assert.DoesNotContain(t.Sent, IsValueUpdate);
+        }
+
+        [Fact]
+        public void Values_RetriedAfterFailedSend()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+
+            var s = NewStatus();
+            Set(s, "TyreTemperatureFrontLeft", 80.0);
+
+            // A value send that fails at the transport must NOT be recorded as last-sent...
+            t.SendReturns = false;
+            clock.T += 40;
+            driver.Update(Data(s));
+            t.Sent.Clear();
+
+            // ...so when the transport recovers, the (unchanged) values are retried rather
+            // than skipped as "already sent".
+            t.SendReturns = true;
+            clock.T += 40;
+            driver.Update(Data(s));
+
+            Assert.Contains(t.Sent, IsValueUpdate);
         }
 
         // ── Stop / restart ───────────────────────────────────────────────

--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -39,7 +39,6 @@ namespace FanaBridge.Tests
         // Frame classifiers (col03: [0]=0xFF, [1]=class, [2]=subcmd)
         private static bool IsEnable(byte[] r) => r[1] == 0x02 && r[2] == 0x02;
         private static bool IsValueUpdate(byte[] r) => r[1] == 0x05 && r[2] == 0x01;
-        private static bool IsKeepalive(byte[] r) => r[1] == 0x05 && r[2] == 0x04 && r[3] == 0x02 && r[4] == 0x0B;
 
         private sealed class Clock { public long T; public long Now() => T; }
 
@@ -117,8 +116,8 @@ namespace FanaBridge.Tests
             var driver = MakeDriver(out _, out var clock);
             Enable(driver, clock);
 
-            // Lap Info has 6 params; seeded so the first (Enable-default) page populates
-            // before any firmware push.
+            // Lap Info has 6 params; seeded so the forced page 1 populates immediately,
+            // before the firmware's push (from the SetPage) arrives.
             Assert.Equal(6, driver.SubscriptionCount);
         }
 
@@ -130,19 +129,6 @@ namespace FanaBridge.Tests
             Enable(driver, clock);
 
             Assert.Equal(4, driver.SubscriptionCount);    // seed skipped
-        }
-
-        [Fact]
-        public void Running_SendsKeepalive_OnInterval()
-        {
-            var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            t.Sent.Clear();
-
-            clock.T += 100;
-            driver.Update(EmptyData());
-
-            Assert.Contains(t.Sent, IsKeepalive);
         }
 
         // ── Enable/disable gate ──────────────────────────────────────────
@@ -162,7 +148,7 @@ namespace FanaBridge.Tests
             Assert.False(driver.IsRunning);
             Assert.Equal(0, driver.SubscriptionCount);
 
-            // Dormant: no keepalives/values on later ticks.
+            // Dormant: no values on later ticks.
             t.Sent.Clear();
             clock.T += 500;
             driver.Update(EmptyData());

--- a/FanaBridge.Tests/ItmEncoderTests.cs
+++ b/FanaBridge.Tests/ItmEncoderTests.cs
@@ -79,17 +79,7 @@ namespace FanaBridge.Tests
             Assert.Equal(0xFF, r[0]);
             Assert.Equal(0x02, r[1]);   // command class — ITM enable
             Assert.Equal(0x02, r[2]);   // sub-command
-            Assert.Equal(0x00, r[3]);   // default page
-        }
-
-        [Fact]
-        public void EnableItm_CarriesPageByte()
-        {
-            var encoder = MakeEncoder(out var t);
-
-            encoder.EnableItm(4);
-
-            Assert.Equal(0x04, t.Last[3]);
+            Assert.Equal(0x00, r[3]);   // byte[3] fixed 0x00 (not a page)
         }
 
         [Fact]
@@ -135,23 +125,6 @@ namespace FanaBridge.Tests
 
             encoder.SetPage(ItmDevice.Bentley, 2);
             Assert.Equal(0x04, t.Last[3]);
-        }
-
-        // ── Keepalive ────────────────────────────────────────────────────
-
-        [Fact]
-        public void SendKeepalive_BuildsExpectedFrame()
-        {
-            var encoder = MakeEncoder(out var t);
-
-            encoder.SendKeepalive();
-
-            var r = t.Last;
-            Assert.Equal(0xFF, r[0]);
-            Assert.Equal(0x05, r[1]);
-            Assert.Equal(0x04, r[2]);
-            Assert.Equal(0x02, r[3]);
-            Assert.Equal(0x0B, r[4]);
         }
 
         // ── ValueUpdate framing ──────────────────────────────────────────

--- a/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -427,6 +427,25 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void TotalSuffix_FuelShowsCapacity()
+        {
+            // The stock app renders fuel as value/capacity (e.g. "/23"), not a unit label.
+            var s = NewStatus();
+            Set(s, "Fuel", 12.0); Set(s, "MaxFuel", 23.0);
+            Assert.True(ItmTelemetry.TryGetTotalSuffix(ItmParam.Fuel, Wrap(s), out var fuel));
+            Assert.Equal("/23", fuel);
+        }
+
+        [Fact]
+        public void TotalSuffix_FuelSuppressedWhenNoCapacity()
+        {
+            // Games that don't report a tank capacity get no "/0" — fall back to bare value.
+            var s = NewStatus();
+            Set(s, "Fuel", 12.0); Set(s, "MaxFuel", 0.0);
+            Assert.False(ItmTelemetry.TryGetTotalSuffix(ItmParam.Fuel, Wrap(s), out _));
+        }
+
+        [Fact]
         public void TyreTemps_EncodesAllFourCorners()
         {
             var s = NewStatus();

--- a/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -34,7 +34,9 @@ namespace FanaBridge.Adapters
         private readonly Action<string> _log;
 
         // ── Tunables (ms) ────────────────────────────────────────────────
-        /// <summary>Keepalive cadence. The display sleeps without one roughly every 100&#160;ms.</summary>
+        /// <summary>Keepalive cadence (ms). Whether the firmware actually requires this is
+        /// unverified — the ~100ms figure is an observed send cadence, not a measured
+        /// timeout. Left at the original cadence pending investigation (see #42).</summary>
         public int KeepaliveIntervalMs { get; set; } = 100;
 
         /// <summary>Minimum spacing between value-update sends (caps the rate).</summary>
@@ -152,18 +154,21 @@ namespace FanaBridge.Adapters
             foreach (var kv in _subs)
             {
                 string suffix;
-                if (ItmTelemetry.TryGetUnitSuffix(kv.Value, out suffix))
+                if (ItmTelemetry.TryGetUnitSuffix(kv.Value, data, out suffix))
                 {
-                    // Static unit (e.g. "C", "L").
+                    // Static unit label (e.g. "C").
                 }
                 else if (ItmTelemetry.IsTotalParam(kv.Value))
                 {
-                    // Lap/position: always emit an entry so a total that disappears is
-                    // actively cleared (empty suffix), not left stale on the firmware.
+                    // Lap/position/fuel: always emit an entry so a total that disappears is
+                    // actively cleared — a zero-length suffix does NOT overwrite the firmware's
+                    // default "/0", so we write a blank " " to clear it. Fuel is special: with no
+                    // tank capacity it falls back to the unit label ("L"/"G") rather than a blank,
+                    // so a bare fuel value still reads as fuel.
                     suffix = ShowTotalFor(kv.Value)
                           && ItmTelemetry.TryGetTotalSuffix(kv.Value, data, out var total)
                         ? total
-                        : "";
+                        : (kv.Value == ItmParam.Fuel ? ItmTelemetry.FuelUnitLabel(data) : " ");
                 }
                 else
                 {
@@ -191,6 +196,7 @@ namespace FanaBridge.Adapters
         {
             if (paramId == ItmParam.Lap) return ShowLapTotal;
             if (paramId == ItmParam.Position) return ShowPositionTotal;
+            if (paramId == ItmParam.Fuel) return true;   // fuel/capacity has no user toggle
             return false;
         }
 
@@ -226,9 +232,14 @@ namespace FanaBridge.Adapters
 
             if (_phase == Phase.Enabling)
             {
-                _encoder.SetItmMode(true);   // ensure the firmware ITM gate is on (FF 05 02 01)
-                _encoder.EnableItm(0);       // start ITM on the default (Lap Info) page
-                SeedInitialSubscriptions();
+                // Bring-up: gate ITM on (FF 05 02 01), start the session (FF 02 02 00), then force
+                // page 1 (FF 05 04 03 01) so the display matches our Lap Info seed and shows correct
+                // values right away. The wheel button navigates from there; detecting the wheel's
+                // current page on cold start (instead of forcing page 1) is deferred — see #43.
+                _encoder.SetItmMode(true);           // FF 05 02 01 — firmware ITM gate on
+                _encoder.EnableItm(0);               // FF 02 02 00 — start the display session
+                _encoder.SetPage((byte)3, (byte)1);  // FF 05 04 03 01 — force page 1
+                SeedInitialSubscriptions();          // page 1 (Lap Info) params
                 _log("ITM: enabled — seeded " + _subs.Count + " params, following firmware subscriptions");
                 _lastKeepaliveMs = now;
                 _phase = Phase.Running;
@@ -283,7 +294,12 @@ namespace FanaBridge.Adapters
             if (_valueBuf.Count == 0 || !HasChanged(_valueBuf))
                 return;
 
-            _encoder.SendValues(_valueBuf);
+            // Only record the values as last-sent (and log the first update) when the send
+            // actually succeeded — a transport failure must not suppress the retry, or the
+            // display would stay stale until a value changes.
+            if (!_encoder.SendValues(_valueBuf))
+                return;
+
             Remember(_valueBuf);
 
             if (!_loggedFirstValues)

--- a/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -7,25 +7,20 @@ using GameReaderCommon;
 namespace FanaBridge.Adapters
 {
     /// <summary>
-    /// Drives a Fanatec ITM telemetry display, firmware-driven: it enables ITM once,
-    /// keeps the display alive with periodic keepalives, and sends rate-limited value
-    /// updates for exactly the parameters the firmware has subscribed.
+    /// Drives a Fanatec ITM telemetry display, firmware-driven: it enables ITM once and
+    /// sends rate-limited value updates for exactly the parameters the firmware has
+    /// subscribed. No keepalive is needed — the display has no idle timeout (hardware-
+    /// confirmed); the value stream, or simply the last frame it holds, keeps it lit.
     ///
-    /// The wheel owns page selection. When the user presses the wheel's ITM page button,
-    /// the firmware pushes subscription reports on col03-IN telling the host which
-    /// parameter sits at which handle for the new page (see
+    /// This driver follows the wheel's subscription reports: when the ITM page changes, the
+    /// firmware pushes subscription reports on col03-IN telling the host which parameter
+    /// sits at which handle for the new page (see
     /// <see cref="ItmTelemetry.ParseSubscriptionReport"/>); the host echoes values back at
-    /// those handles. There is no host page-select command — host-driven page switching
-    /// (PageSet / Enable-byte) was tried and does not make the firmware accept values.
+    /// those handles.
     ///
     /// Sits above <see cref="ItmEncoder"/> (framing) and <see cref="ItmTelemetry"/>
     /// (value encoding + subscription parsing). The clock is injectable so the timing is
     /// unit testable.
-    ///
-    /// FIRMWARE SAFETY (PBME is the crash-prone target): Enable is sent once per bring-up
-    /// (never in a loop); value updates are rate-limited and skipped when unchanged. The
-    /// format-sensitive parameters (BRAKE_BIAS as Int32 tenths, ENGINE_MAPPING as ASCII
-    /// text) are encoded to the firmware's expected form upstream in <see cref="ItmTelemetry"/>.
     /// </summary>
     public class ItmDisplayDriver
     {
@@ -34,11 +29,6 @@ namespace FanaBridge.Adapters
         private readonly Action<string> _log;
 
         // ── Tunables (ms) ────────────────────────────────────────────────
-        /// <summary>Keepalive cadence (ms). Whether the firmware actually requires this is
-        /// unverified — the ~100ms figure is an observed send cadence, not a measured
-        /// timeout. Left at the original cadence pending investigation (see #42).</summary>
-        public int KeepaliveIntervalMs { get; set; } = 100;
-
         /// <summary>Minimum spacing between value-update sends (caps the rate).</summary>
         public int ValueIntervalMs { get; set; } = 40;
 
@@ -59,7 +49,6 @@ namespace FanaBridge.Adapters
         private enum Phase { Idle, Enabling, Running, Disabled }
         private Phase _phase = Phase.Idle;
 
-        private long _lastKeepaliveMs;
         private long _lastValuesMs;
 
         // Firmware-driven subscription map: host handle -> parameter ID. Kept sorted by
@@ -103,9 +92,8 @@ namespace FanaBridge.Adapters
         }
 
         /// <summary>
-        /// Stops driving and returns to idle, dropping all subscriptions. Without
-        /// keepalives the firmware reclaims the display. A later <see cref="Start"/>
-        /// re-enables.
+        /// Stops driving and returns to idle, dropping all subscriptions. A later
+        /// <see cref="Start"/> re-enables.
         /// </summary>
         public void Stop()
         {
@@ -204,8 +192,8 @@ namespace FanaBridge.Adapters
         public void Update(GameData data)
         {
             // User turned ITM off: send the firmware "ITM off" command once, then stay
-            // dormant (no keepalives/values) so the display stays off, as the Fanatec
-            // software does. Re-enabling drops back into bring-up below.
+            // dormant (no values) so the display stays off, as the Fanatec software does.
+            // Re-enabling drops back into bring-up below.
             if (!Enabled)
             {
                 if (_phase != Phase.Disabled)
@@ -237,23 +225,16 @@ namespace FanaBridge.Adapters
                 // values right away. The wheel button navigates from there; detecting the wheel's
                 // current page on cold start (instead of forcing page 1) is deferred — see #43.
                 _encoder.SetItmMode(true);           // FF 05 02 01 — firmware ITM gate on
-                _encoder.EnableItm(0);               // FF 02 02 00 — start the display session
+                _encoder.EnableItm();                // FF 02 02 00 — start the display session
                 _encoder.SetPage((byte)3, (byte)1);  // FF 05 04 03 01 — force page 1
                 SeedInitialSubscriptions();          // page 1 (Lap Info) params
                 _log("ITM: enabled — seeded " + _subs.Count + " params, following firmware subscriptions");
-                _lastKeepaliveMs = now;
                 _phase = Phase.Running;
                 return;
             }
 
             // Running
             UpdateSlotDefs(data);   // refresh unit/total suffixes when they change
-            if (now - _lastKeepaliveMs >= KeepaliveIntervalMs)
-            {
-                _encoder.SendKeepalive();
-                _lastKeepaliveMs = now;
-            }
-
             if (now - _lastValuesMs >= ValueIntervalMs)
             {
                 SendSubscribedValues(data);
@@ -261,10 +242,10 @@ namespace FanaBridge.Adapters
             }
         }
 
-        // The firmware announces subscriptions only on a page change, not on bare
-        // Enable, so the initial (Enable-default) page would stay blank. Seed the Lap
-        // Info handle→param map — the firmware accepts these on its default page, and
-        // its first page-change push replaces them. Only seeds when nothing's subscribed.
+        // Bring-up forces page 1 via SetPage(3,1), which makes the firmware push page 1's
+        // subscription — but that push takes ~tens of ms to arrive, and a bare Enable
+        // announces nothing. Pre-seed the Lap Info handle→param map so values flow in that
+        // gap; the firmware's push then confirms/replaces it. Only seeds when nothing's subscribed.
         private void SeedInitialSubscriptions()
         {
             if (_subs.Count > 0)

--- a/FanaBridge/Protocol/ItmEncoder.cs
+++ b/FanaBridge/Protocol/ItmEncoder.cs
@@ -147,13 +147,13 @@ namespace FanaBridge.Protocol
     /// Encodes and sends ITM (telemetry display) control reports for Fanatec wheels
     /// over the col03 interface. Covers the four ITM frames documented in the protocol
     /// reference: Enable (<c>FF 02 02</c>), ParamDefs (<c>FF 05 03</c>), ValueUpdate
-    /// (<c>FF 05 01</c>), and the PageSet/Keepalive config frame (<c>FF 05 04</c>).
+    /// (<c>FF 05 01</c>), and the PageSet frame (<c>FF 05 04</c>).
     ///
     /// This is a pure framing layer — like <see cref="LedEncoder"/> and
     /// <see cref="DisplayEncoder"/>, it builds and writes reports but holds no display
-    /// state. Page selection, keepalive scheduling, telemetry-to-parameter mapping, and
-    /// the firmware-safety rate limits (e.g. don't call <see cref="EnableItm"/> in a tight
-    /// loop) are the caller's responsibility.
+    /// state. Page selection, telemetry-to-parameter mapping, and the firmware-safety rate
+    /// limits (e.g. value-update pacing) are the caller's
+    /// responsibility.
     /// </summary>
     public class ItmEncoder
     {
@@ -164,29 +164,25 @@ namespace FanaBridge.Protocol
 
         // Command classes (byte[1])
         private const byte CMD_ITM_ENABLE = 0x02;   // ITM enable lives on its own class
-        private const byte CMD_ITM_DISPLAY = 0x05;  // ParamDefs / ValueUpdate / config
+        private const byte CMD_ITM_DISPLAY = 0x05;  // ITM display: mode gate / ParamDefs / ValueUpdate / PageSet
 
         // Sub-commands (byte[2])
         private const byte SUBCMD_ENABLE = 0x02;
         private const byte SUBCMD_VALUE_UPDATE = 0x01;
         private const byte SUBCMD_ITM_MODE = 0x02;   // under FF 05: firmware ITM on/off gate
         private const byte SUBCMD_PARAM_DEFS = 0x03;
-        private const byte SUBCMD_CONFIG = 0x04;     // PageSet + Keepalive
+        private const byte SUBCMD_PAGESET = 0x04;    // PageSet: byte[3]=display-device id, byte[4]=page
 
-        // Per-entry markers. BOTH ValueUpdate and ParamDefs entries use 0x03 — this
-        // is confirmed against an official-software USB capture. (The protocol
-        // reference claims ValueUpdate entries use 0x01; that is wrong, and entries
-        // marked 0x01 are silently ignored by the firmware.)
-        private const byte MARKER_VALUE = 0x03;
-        private const byte MARKER_PARAM_DEF = 0x03;
+        // First byte of every ValueUpdate/ParamDefs entry: the display-device id (which
+        // display the entry targets), not a marker. FanaBridge only drives the PBME/GTSWX
+        // (device 3), so it is hardcoded to 3; base (1) / Bentley (4) support would derive
+        // it per identity (#43).
+        private const byte ENTRY_DEVICE_ID = 0x03;
 
-        // Keepalive config selector (FF 05 04 02 0B)
-        private const byte KEEPALIVE_CONFIG_TYPE = 0x02;
-        private const byte KEEPALIVE_CONFIG_VALUE = 0x0B;
-
-        // Fixed-size prefixes of a single entry, before the variable tail.
-        // ValueUpdate:  marker, handle, idLo, idHi, size            (+ Size value bytes)
-        // ParamDefs:    marker, slotId, posLo, posHi, suffixLen     (+ suffix bytes)
+        // Fixed-size prefixes of a single entry, before the variable tail. The leading
+        // byte is the display-device id (see ENTRY_DEVICE_ID), not a marker.
+        // ValueUpdate:  deviceId, handle, idLo, idHi, size          (+ Size value bytes)
+        // ParamDefs:    deviceId, slotId, posLo, posHi, suffixLen   (+ suffix bytes)
         private const int VALUE_ENTRY_HEADER = 5;
         private const int PARAM_DEF_ENTRY_HEADER = 5;
 
@@ -227,18 +223,18 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
-        /// Activates ITM mode and selects the analysis page (0 = default/reset).
-        /// Resets the firmware's slot table, so <see cref="SetParamDefs"/> must be
-        /// re-sent after every enable. Do NOT call in a tight loop — rapid repeated
-        /// enables can crash the PBME firmware; the caller must rate-limit.
+        /// Sends the ITM session enable frame (<c>FF 02 02 00</c>) — command class 0x02,
+        /// separate from the <c>FF 05 02</c> ITM-mode gate (<see cref="SetItmMode"/>).
+        /// byte[3] is always <c>0x00</c> (no page semantics; paging is done via <c>SetPage</c>).
+        /// Send once at session start (as the official Fanatec app does).
         /// </summary>
-        public bool EnableItm(byte page = 0)
+        public bool EnableItm()
         {
             Array.Clear(_reportBuf, 0, REPORT_LENGTH);
             _reportBuf[0] = REPORT_PREFIX;
             _reportBuf[1] = CMD_ITM_ENABLE;
             _reportBuf[2] = SUBCMD_ENABLE;
-            _reportBuf[3] = page;
+            _reportBuf[3] = 0x00;   // not a page
             return _transport.SendCol03(_reportBuf);
         }
 
@@ -255,24 +251,9 @@ namespace FanaBridge.Protocol
             Array.Clear(_reportBuf, 0, REPORT_LENGTH);
             _reportBuf[0] = REPORT_PREFIX;
             _reportBuf[1] = CMD_ITM_DISPLAY;
-            _reportBuf[2] = SUBCMD_CONFIG;
+            _reportBuf[2] = SUBCMD_PAGESET;
             _reportBuf[3] = deviceId;
             _reportBuf[4] = page;
-            return _transport.SendCol03(_reportBuf);
-        }
-
-        /// <summary>
-        /// Sends the ITM keepalive. Must be sent roughly every 100&#160;ms to keep the
-        /// display awake — the caller owns the scheduling.
-        /// </summary>
-        public bool SendKeepalive()
-        {
-            Array.Clear(_reportBuf, 0, REPORT_LENGTH);
-            _reportBuf[0] = REPORT_PREFIX;
-            _reportBuf[1] = CMD_ITM_DISPLAY;
-            _reportBuf[2] = SUBCMD_CONFIG;
-            _reportBuf[3] = KEEPALIVE_CONFIG_TYPE;
-            _reportBuf[4] = KEEPALIVE_CONFIG_VALUE;
             return _transport.SendCol03(_reportBuf);
         }
 
@@ -313,7 +294,7 @@ namespace FanaBridge.Protocol
                         if (pos + entryLen > REPORT_LENGTH)
                             break;
 
-                        _reportBuf[pos++] = MARKER_PARAM_DEF;
+                        _reportBuf[pos++] = ENTRY_DEVICE_ID;
                         _reportBuf[pos++] = d.SlotId;
                         _reportBuf[pos++] = (byte)(d.Position & 0xFF);
                         _reportBuf[pos++] = (byte)((d.Position >> 8) & 0xFF);
@@ -365,7 +346,7 @@ namespace FanaBridge.Protocol
                         if (pos + entryLen > REPORT_LENGTH)
                             break;
 
-                        _reportBuf[pos++] = MARKER_VALUE;
+                        _reportBuf[pos++] = ENTRY_DEVICE_ID;
                         _reportBuf[pos++] = v.Handle;
                         _reportBuf[pos++] = (byte)(v.ParamId & 0xFF);
                         _reportBuf[pos++] = (byte)((v.ParamId >> 8) & 0xFF);

--- a/FanaBridge/Protocol/ItmTelemetry.cs
+++ b/FanaBridge/Protocol/ItmTelemetry.cs
@@ -257,34 +257,51 @@ namespace FanaBridge.Protocol
             return ids;
         }
 
-        // ASCII unit suffixes the display appends to a parameter's value, sent via
-        // ParamDefs. Matches the official software's suffixes from the capture
-        // ('C' on temperatures, 'L' on fuel). Temperatures assume Celsius.
-        private static readonly Dictionary<ushort, string> UnitSuffixes = new Dictionary<ushort, string>
+        // Temperatures whose value carries a unit label. SimHub delivers both the converted
+        // value AND its unit in the same frame (StatusDataBase.TemperatureUnit), so we read the
+        // label from that snapshot — no out-of-band settings lookup, always consistent with the
+        // value. (Fuel is NOT unit-labeled; it uses a "/capacity" total, with the unit only as a
+        // no-capacity fallback.)
+        private static readonly HashSet<ushort> TempParams = new HashSet<ushort>
         {
-            { ItmParam.OilTemp, "C" },
-            { ItmParam.TyreFlTemp, "C" },
-            { ItmParam.TyreFrTemp, "C" },
-            { ItmParam.TyreRlTemp, "C" },
-            { ItmParam.TyreRrTemp, "C" },
-            { ItmParam.Fuel, "L" },
+            ItmParam.OilTemp, ItmParam.TyreFlTemp, ItmParam.TyreFrTemp,
+            ItmParam.TyreRlTemp, ItmParam.TyreRrTemp,
         };
 
         /// <summary>
-        /// The ASCII unit suffix a parameter's value should display (e.g. "C" for a
-        /// temperature), or false if it has none. Used to build ParamDefs entries.
+        /// The unit suffix a temperature's value should display (single char, e.g. "C"/"F"/"K"),
+        /// or false if the parameter isn't a temperature. Read from the frame's
+        /// <c>TemperatureUnit</c> so it stays consistent with the already-converted value.
         /// </summary>
-        public static bool TryGetUnitSuffix(ushort paramId, out string suffix)
-            => UnitSuffixes.TryGetValue(paramId, out suffix);
+        public static bool TryGetUnitSuffix(ushort paramId, GameData data, out string suffix)
+        {
+            if (TempParams.Contains(paramId)) { suffix = UnitLabel(data?.NewData?.TemperatureUnit, "C"); return true; }
+            suffix = null;
+            return false;
+        }
 
-        /// <summary>Whether a parameter can carry a dynamic "/total" suffix (lap, position).</summary>
+        /// <summary>The fuel unit as a single-char label (e.g. "L"/"G"), from the frame's
+        /// <c>FuelUnit</c>. Used only as a fallback when no tank capacity is available.</summary>
+        public static string FuelUnitLabel(GameData data) => UnitLabel(data?.NewData?.FuelUnit, "L");
+
+        // A unit string's first letter, uppercased — a single char for the display's tight space,
+        // robust to formats like "C" / "°C" / "Celsius" / "gal". Falls back when empty.
+        private static string UnitLabel(string raw, string fallback)
+        {
+            if (!string.IsNullOrEmpty(raw))
+                foreach (var c in raw)
+                    if (char.IsLetter(c)) return char.ToUpperInvariant(c).ToString();
+            return fallback;
+        }
+
+        /// <summary>Whether a parameter carries a "/total" suffix (lap, position, or fuel/capacity).</summary>
         public static bool IsTotalParam(ushort paramId)
-            => paramId == ItmParam.Lap || paramId == ItmParam.Position;
+            => paramId == ItmParam.Lap || paramId == ItmParam.Position || paramId == ItmParam.Fuel;
 
         /// <summary>
-        /// The dynamic "/total" suffix for a parameter that has one — lap of total laps
-        /// ("/34") and position of field size ("/20") — computed from the current
-        /// telemetry. The firmware cannot know these, so the host supplies them.
+        /// The "/total" suffix for a parameter that has one — lap of total laps ("/34"),
+        /// position of field size ("/20"), fuel of tank capacity ("/23") — computed from the
+        /// current telemetry. The firmware cannot know these, so the host supplies them.
         ///
         /// Returns false (no suffix) when the parameter has no total, there is no
         /// telemetry frame, or the game does not report a plausible total — i.e. the
@@ -308,6 +325,12 @@ namespace FanaBridge.Protocol
                     int field = s.OpponentsCount;   // SimHub's opponents list already includes the player
                     if (field > 1 && field >= s.Position)
                         suffix = "/" + field;
+                    return suffix != null;
+                case ItmParam.Fuel:
+                    // Fuel of tank capacity (e.g. "/90"), in the user's SimHub unit. Suppress
+                    // when no capacity is reported so we never show a bare "/0".
+                    if (s.MaxFuel > 0 && s.MaxFuel >= s.Fuel)
+                        suffix = "/" + (int)System.Math.Round(s.MaxFuel);
                     return suffix != null;
                 default:
                     return false;

--- a/FanaBridge/Protocol/ItmTelemetry.cs
+++ b/FanaBridge/Protocol/ItmTelemetry.cs
@@ -8,6 +8,8 @@ namespace FanaBridge.Protocol
     /// ITM telemetry page. Each page is a fixed parameter layout the firmware
     /// renders; SPEED and GEAR appear on every page as persistent headers. Values
     /// match the Base/BME page numbering in the protocol reference, "ITM Page Layouts".
+    /// The numbering is Base/BME-specific — a Bentley display has no Car Settings page
+    /// and a different legacy page (5, not 6), so this enum does not map to a Bentley.
     /// </summary>
     public enum ItmPage : byte
     {
@@ -92,8 +94,8 @@ namespace FanaBridge.Protocol
     ///
     /// This is the pure, per-frame translation step — the ITM analogue of
     /// <c>FanatecDisplayDriver</c>'s telemetry reads. It holds no state and does
-    /// no I/O; page selection, keepalive scheduling, and the enable/ParamDefs
-    /// sequence belong to the (future) ITM display driver above it.
+    /// no I/O; page selection and the enable/ParamDefs sequence belong to the
+    /// (future) ITM display driver above it.
     ///
     /// Handles are assigned sequentially (0..N-1) in page-field order. That mirrors
     /// a straightforward ParamDefs slot layout; if the on-hardware slot/handle
@@ -356,8 +358,9 @@ namespace FanaBridge.Protocol
 
         /// <summary>
         /// Parses a firmware ITM subscription report (col03-IN, <c>FF 05 01</c>) into its
-        /// entries. Each entry is <c>[03][fwHandle][paramId-LE][unit]</c>; the host handle
-        /// is <c>fwHandle &amp; 0x7F</c> and <c>paramId == 0xFFFF</c> means unsubscribe.
+        /// entries. Each entry is <c>[deviceId][fwHandle][paramId-LE][dataType]</c> — the leading
+        /// byte is the display-device id (which display the entry is for), not a marker; the host
+        /// handle is <c>fwHandle &amp; 0x7F</c> and <c>paramId == 0xFFFF</c> means unsubscribe.
         /// Returns an empty list if the report carries no recognizable entries.
         /// </summary>
         public static IReadOnlyList<ItmSubscription> ParseSubscriptionReport(byte[] report, int len)
@@ -376,10 +379,12 @@ namespace FanaBridge.Protocol
                 }
             if (start < 0) return result;
 
-            // Entries: [03][fwHandle][idLo][idHi][unit], 5 bytes each, until a non-0x03 marker.
+            // Entries: [deviceId][fwHandle][idLo][idHi][dataType], 5 bytes each. Byte 0 is the
+            // display-device id. We only drive the PBME/GTSWX (device 3), so stop at the first
+            // entry for any other display (base/Bentley multi-device support isn't wired up yet).
             for (int i = start; i + 5 <= len; i += 5)
             {
-                if (report[i] != 0x03) break;
+                if (report[i] != 0x03) break;   // device 3 = PBME/GTSWX (the only display we handle)
                 byte fwHandle = report[i + 1];
                 ushort pid = (ushort)(report[i + 2] | (report[i + 3] << 8));
                 result.Add(new ItmSubscription(fwHandle, pid));

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -47,12 +47,12 @@ Fanatec wheelbases communicate with the host PC over USB HID (Human Interface De
     - [Live Change Notifications](#live-change-notifications)
     - [CBP in Tuning Context](#cbp-in-tuning-context)
   - [0x05 — ITM Display](#0x05--itm-display)
-    - [0x02 — ITM Mode (Enable Gate)](#0x02--itm-mode-enable-gate)
     - [0x01 — ValueUpdate](#0x01--valueupdate)
+    - [0x02 — ITM Mode (Enable Gate)](#0x02--itm-mode-enable-gate)
     - [0x03 — ParamDefs](#0x03--paramdefs)
+    - [0x04 — PageSet](#0x04--pageset)
+    - [Control Model](#control-model)
     - [Firmware Subscription Pushes (Device → Host)](#firmware-subscription-pushes-device--host)
-    - [0x04 — PageSet / Keepalive / Config](#0x04--pageset--keepalive--config)
-    - [Control Model (Firmware-Driven)](#control-model-firmware-driven)
     - [Timing & Rate Limiting](#timing--rate-limiting)
     - [Automatic Page Changes (Alerts)](#automatic-page-changes-alerts)
   - [0x08 — System Report (Identity)](#0x08--system-report-identity)
@@ -523,7 +523,7 @@ When only one has changed, send that report alone with commit = `0x01`.
 
 ### 0x02 — ITM Enable
 
-Activates ITM mode on the wheel display. Note this uses command class `0x02`, not `0x05`.
+Conventionally the ITM session **enable** (command class `0x02`, not `0x05`). It is separate from the persistent [ITM Mode gate](#0x02--itm-mode-enable-gate) (`FF 05 02`); a full bring-up uses both — see [Control Model](#control-model).
 
 ```
 FF 02 02 00 [00 x60]
@@ -534,11 +534,11 @@ FF 02 02 00 [00 x60]
 | 0 | `0xFF` | Report ID |
 | 1 | `0x02` | Command class |
 | 2 | `0x02` | Sub-command |
-| 3 | `0x00` | Page (0 = default/reset) |
+| 3 | `0x00` | Always `0x00`. Not a page selector — paging is [PageSet](#0x04--pageset). |
 
 **Important:**
-- Enable once, then keep the display alive with the [keepalive](#0x04--pageset--keepalive--config); do not call Enable in a tight loop — rapid repeated calls can crash the PBME firmware.
-- After Enable the display sits on the default page (Lap Info). Page selection is firmware-driven (the wheel button) — see [Control Model](#control-model-firmware-driven). Byte[3] nudges the displayed page but does **not** change which page's values the firmware accepts, so it is not a substitute for the firmware's [subscription pushes](#firmware-subscription-pushes-device--host).
+- Send Enable **once** at session start (as the official app does), then keep sending [value updates](#0x01--valueupdate). (Repeating it appears harmless in testing.)
+- On its own, Enable shows nothing new. What the display shows is governed by the [ITM Mode gate](#0x02--itm-mode-enable-gate) and [PageSet](#0x04--pageset) — see [Control Model](#control-model) for the bring-up.
 
 ### 0x03 — Tuning Menu
 
@@ -777,21 +777,6 @@ Byte:  [0]   [1]   [2]      [3..63]
        0xFF  0x05  subcmd   payload
 ```
 
-#### 0x02 — ITM Mode (Enable Gate)
-
-Turns ITM on or off at the firmware level — the same persistent state the Fanatec software's "ITM" switch sets. **ITM must be gated on here before anything else works**: with it off, the firmware ignores the [session enable](#0x02--itm-enable), pushes no [subscriptions](#firmware-subscription-pushes-device--host), and the wheel shows no ITM indicator or pages.
-
-```
-Enable:   FF 05 02 01 [00 x60]
-Disable:  FF 05 02 00 [00 x60]
-```
-
-| Byte | Value | Description |
-|------|-------|-------------|
-| 3 | `0x01` / `0x00` | ITM on / off |
-
-The setting is **persistent** (survives power cycles). A host bring-up should be: `FF 05 02 01` (gate on) → [`FF 02 02`](#0x02--itm-enable) (session enable) → keepalive + values. Confirmed against a capture of the official software toggling its ITM switch on/off/on/off.
-
 #### 0x01 — ValueUpdate
 
 Sends telemetry values for display. Each entry contains a handle, parameter ID, and value:
@@ -804,13 +789,35 @@ Each entry:
 
 | Offset | Size | Field | Description |
 |--------|------|-------|-------------|
-| 0 | 1 | Marker | Always `0x03` |
+| 0 | 1 | Device ID | Which display this entry is for (values as in [PageSet](#0x04--pageset)) |
 | 1 | 1 | Handle | Parameter handle (dictated by the firmware — see [Firmware Subscription Pushes](#firmware-subscription-pushes-device--host)) |
 | 2–3 | 2 | Param ID | Parameter ID (little-endian). See [ITM Parameter IDs](#itm-parameter-ids). |
 | 4 | 1 | Size | Value size in bytes (1, 2, or 4) |
 | 5+ | N | Value | Parameter value (little-endian, size from above) |
 
-> **The entry marker is `0x03`, not `0x01`.** Confirmed against a USB capture of the official software on a PBME: entries marked `0x01` are silently ignored by the firmware. Multiple entries may be packed into one report; the firmware accepts batched updates.
+> **The leading byte is the display-device id** — which display the entry is for, using the same values as [PageSet](#0x04--pageset). FanaBridge only drives the PBME/GTSWX, so every entry uses device 3; entries addressed to a display that isn't attached are silently ignored.
+>
+> Multiple entries may be packed into one report; the firmware accepts batched updates.
+
+#### 0x02 — ITM Mode (Enable Gate)
+
+Turns ITM on or off at the firmware level — the same persistent state the Fanatec software's "ITM" switch sets; the on-screen "ITM" indicator (corner text) reflects it. This is the persistent `FF 05 02` gate, **not** the session [Enable](#0x02--itm-enable) (`FF 02 02`); a full bring-up uses both — see [Control Model](#control-model).
+
+- **`FF 05 02 00` (off):** the display drops to the true [legacy](#col01--legacy-control-8-bytes) 7-segment view and the "ITM" indicator disappears (any cached 7-seg value already on screen persists).
+- **`FF 05 02 01` (on):** ITM turns on and shows the page from the most recent [PageSet](#0x04--pageset) since the gate-off — **or the legacy page (6) if none** — emitting that page's subscription push (an **unsubscribe-all** clearing the old handles, then the new page's handles; a legacy target shows only the unsubscribe-all).
+
+A [PageSet](#0x04--pageset) works **even while gated off**: it's recorded (no visual, ITM is off) and applied on the next gate-on. So `gate off → PageSet(N) → gate on` lands directly on page N, whereas a bare `gate off → gate on` lands on legacy. There is always a current page — the legacy page (6) is the fallback, never "no page." (Hardware-confirmed.)
+
+```
+Enable:   FF 05 02 01 [00 x60]
+Disable:  FF 05 02 00 [00 x60]
+```
+
+| Byte | Value | Description |
+|------|-------|-------------|
+| 3 | `0x01` / `0x00` | ITM on / off |
+
+The setting is **persistent** (survives power cycles).
 
 #### 0x03 — ParamDefs
 
@@ -824,7 +831,7 @@ Each entry:
 
 | Offset | Size | Field | Description |
 |--------|------|-------|-------------|
-| 0 | 1 | Marker | Always `0x03` |
+| 0 | 1 | Device ID | Which display this entry is for (values as in [PageSet](#0x04--pageset)) |
 | 1 | 1 | Slot ID | Display layout identifier (e.g., `0x82`, `0x85`, `0x88`) |
 | 2 | 1 | Position Lo | Low byte of position (typically `0x00`) |
 | 3 | 1 | Position Hi | High byte of position (typically `0x00`) |
@@ -841,20 +848,66 @@ The suffix system attaches a unit/total to a slot (e.g. `2F 30` = "/0" total den
 
 Maximum subscribed parameters per device: **16**.
 
+#### 0x04 — PageSet
+
+Selects which ITM page is active on a specific display device. Byte[3] is always the
+display-device id; byte[4] is the page:
+
+```
+FF 05 04 <deviceId> <page> [00 x59]
+```
+
+| Byte | Field | Description |
+|------|-------|-------------|
+| 3 | Device ID | Target display (1=Base, 2=not present on tested hardware, 3=BME/GTSWX, 4=Bentley) |
+| 4 | Page number | Page to display (1–6, device-dependent). See [ITM Page Layouts](#itm-page-layouts). |
+
+Page change commands should be spaced at least 100ms apart. The firmware needs time to reconfigure its internal display state between pages.
+
+**We've observed `PageSet` commands being ignored, but the root cause isn't understood.** In testing, some `PageSet` commands produced no page change and no [subscription push](#firmware-subscription-pushes-device--host) — intermittently, and *regardless* of spacing (failures happened seconds apart, far beyond the 100 ms floor). Re-sending the identical command then worked.
+
+What makes this genuinely hard to detect is that there is an **expected** case that looks identical to a dropped command: **the firmware only pushes on an actual page *change*. A `PageSet` for the page the display is already on correctly produces no push.** So the absence of a push is ambiguous — the host cannot tell "already on this page, nothing to do" from "the command was ignored." (Observed directly: a first `PageSet(5)` pushes page 5's subscription; three further `PageSet(5)` in a row push nothing, because the display is already there; a following `PageSet(6)` pushes again as it switches.)
+
+Practical guidance for host-driven paging: track the page you believe is current, and treat a missing push as a *possible* failure only when you targeted a *different* page — then retry. Even so, whether such a miss is a firmware drop or a page switch that wasn't re-announced is still open, and needs a display-vs-push cross-check to resolve.
+
+**The legacy "keepalive" is just a PageSet.** `FF 05 04 02 0B` decodes as `PageSet(device 2, page 11)` — addressed to a display not present on the tested hardware, so it does nothing visible, and it appears in zero live captures. No periodic frame is needed to keep the display fed by [ValueUpdate](#0x01--valueupdate)s: the display has **no idle timeout** (see [Control Model](#control-model)), and FanaBridge sends no keepalive.
+
+#### Control Model
+
+Control of the ITM display is **split** between the host and the firmware — neither drives it alone:
+
+- **The host selects the page.** A host [PageSet](#0x04--pageset) chooses which page is shown; the wheel's display button does the same thing. The two are equivalent triggers, and either can change the page at any time.
+- **The firmware assigns the handles.** On every page change it *pushes* the new page's parameter subscriptions (see [Firmware Subscription Pushes](#firmware-subscription-pushes-device--host)); the host echoes [ValueUpdate](#0x01--valueupdate)s only at the handles the firmware pushed. Values sent at *guessed* handles — for a page the firmware hasn't announced — are ignored.
+
+So the host chooses *what page*; the firmware chooses *which handles*.
+
+**Bring-up sequence** (hardware-verified on a PBME):
+
+```
+1. FF 05 02 01 ...        ← ITM Mode gate ON (persistent — 0x02 above)
+2. FF 02 02 00 ...        ← session Enable (once — never in a loop; see 0x02 — ITM Enable)
+3. FF 05 04 <dev> <page>  ← PageSet to establish a page
+4. FF 05 01 <entries>     ← ValueUpdates at the handles the PageSet pushes back
+```
+
+Step 3 is what actually brings a page up: in testing, a bare [`FF 02 02`](#0x02--itm-enable) enable with no PageSet produced no push and no page. Once the gate is on (it is persistent) and enable has run, a [PageSet](#0x04--pageset) — or a wheel-button press — is all that's needed to make the firmware push a page's subscription.
+
+**No keepalive.** The display has no idle timeout: it holds its content indefinitely, and the value stream isn't even required to keep it lit. FanaBridge sends no keepalive, and the official software sends none either. (Hardware-confirmed.)
+
 #### Firmware Subscription Pushes (Device → Host)
 
-This is the key to multi-page support. **The wheel — not the host — owns page selection** (the wheel's display button cycles pages). On every page change the firmware *pushes* one or more `FF 05 01` reports on the col03 **input** endpoint telling the host exactly which parameters to display at which handles for the new page. The host then echoes [ValueUpdate](#0x01--valueupdate)s for those subscriptions. There is no working host page-select command — `PageSet` and the Enable page byte change the layout but do **not** make the firmware accept a page's values; only the firmware's own (button-driven) page state does.
+This is the mechanism behind the [Control Model](#control-model) above. When the page changes — from a host [PageSet](#0x04--pageset) or the wheel button — the firmware *pushes* one or more `FF 05 01` reports on the col03 **input** endpoint, telling the host exactly which parameters to display at which handles. A host `PageSet` makes the firmware push the new page's subscription ~10–40 ms later; the host then echoes [ValueUpdate](#0x01--valueupdate)s for those subscriptions.
 
 Each pushed report uses the same `FF 05 01` framing, with 5-byte entries:
 
 | Offset | Size | Field | Description |
 |--------|------|-------|-------------|
-| 0 | 1 | Marker | Always `0x03` |
+| 0 | 1 | Device ID | Which display this entry is for (values as in [PageSet](#0x04--pageset)) |
 | 1 | 1 | Handle | Firmware handle. The `0x80` bit marks a "slot" param (one with a ParamDefs unit). **Host ValueUpdate handle = handle `& 0x7F`.** |
 | 2–3 | 2 | Param ID | Subscribed parameter (little-endian), or `0xFFFF` = **unsubscribe** that handle. |
-| 4 | 1 | Unit | Unit/format hint (see [ITM Unit System](#itm-unit-system)). |
+| 4 | 1 | Type | Value data-type/size selector (1/2/4-byte int, float, or text) — not the display unit. |
 
-A page change arrives as an UNSUBSCRIBE report (old params, `0xFFFF`) followed by the new page's subscriptions. Example — switching to the Tyre Temps page:
+A page change arrives across **several** reports — an unsubscribe of the old handles (`0xFFFF`), plus one or more (often overlapping / partial) reports listing the new page's handles. **The host must accumulate them** — apply each entry as it arrives (subscribe, or `0xFFFF` = unsubscribe) — never treating a single report as the complete set. (E.g. page 3's 7 handles arrive as two reports sharing `h1–h5`, one adding `h6=BRAKE_BIAS`, the other `h0=SPEED`.) Example — switching to the Tyre Temps page:
 
 ```
 FF 05 01  03 00 0001 34  03 01 0004 12  03 82 002A 32  03 83 0030 32 ...
@@ -863,46 +916,9 @@ FF 05 01  03 00 0001 34  03 01 0004 12  03 82 002A 32  03 83 0030 32 ...
 
 (`0x82 & 0x7F = 2`, so the host sends TYRE_FL at handle 2.)
 
-**Initial page.** The firmware pushes a subscription only on a *change*, not on the initial [Enable](#0x02--itm-enable). After Enable the display sits on its default page (Lap Info), which the host can populate directly by sending that page's ValueUpdates — the firmware accepts the default page's params without a push. Subsequent button presses then drive the subscription pushes.
+**Handles are double-buffered — never assume a fixed page→handle map.** The firmware alternates the handle *base* between two regions (≈`h0–h5` and `h6–h11`) on every page change: it subscribes the new page's params on the currently-free region, then unsubscribes the old region. So the *same* page appears at different handles on successive visits — Lap Info is `h0=SPEED …` one time and `h6=SPEED …` the next. This is why every page change carries an unsubscribe of the old region alongside the new subscriptions, and why **the host must follow the pushed handles each time** rather than caching a map. (Confirmed by strict base alternation across a full page cycle: `6, 0, 6, 0, 6 …`.)
 
-#### 0x04 — PageSet / Keepalive / Config
-
-Subcmd `0x04` is overloaded for several functions based on byte[3]:
-
-**PageSet** — selects which ITM page is active on a specific display device:
-
-```
-FF 05 04 <deviceId> <page> [00 x59]
-```
-
-| Byte | Field | Description |
-|------|-------|-------------|
-| 3 | Device ID | Target display (1=Base, 3=BME/GTSWX, 4=Bentley) |
-| 4 | Page number | Page to display (1–6, device-dependent). See [ITM Page Layouts](#itm-page-layouts). |
-
-Page change commands should be spaced at least 100ms apart. The firmware needs time to reconfigure its internal display state between pages.
-
-**Keepalive** — must be sent every ~100ms to keep the ITM display alive:
-
-```
-FF 05 04 02 0B [00 x59]
-```
-
-| Byte | Value | Description |
-|------|-------|-------------|
-| 3 | `0x02` | Config type |
-| 4 | `0x0B` | Config value |
-
-#### Control Model (Firmware-Driven)
-
-The working model — verified on a PBME — is firmware-driven:
-
-1. **Enable** ITM once (`FF 02 02 00`).
-2. **Keepalive** every ~100&#160;ms (`FF 05 04 02 0B`) to keep the display awake.
-3. The firmware owns page selection (wheel button) and **pushes** the current page's [subscriptions](#firmware-subscription-pushes-device--host) on col03-IN.
-4. The host **reads** those pushes and sends [ValueUpdate](#0x01--valueupdate)s at the firmware-dictated handles, for the subscribed params only.
-
-The host does not choose the page or the handles. A purely host-driven approach (PageSet / ParamDefs / guessed handles) was tried and does **not** work — the firmware ignores values for a page it has not announced. The [page layouts](#itm-page-layouts) below are still useful for seeding the default page and as a reference for what each page contains, but the authoritative handle→param map for any page is whatever the firmware pushes.
+**Getting the first page.** The firmware pushes a subscription only when a page is *established or changed*. So after enabling, send a [PageSet](#0x04--pageset) (or wait for a wheel-button press) and populate the handles it pushes back; values sent before that push, at guessed handles, are ignored. See [Control Model](#control-model) for the full bring-up.
 
 #### Timing & Rate Limiting
 
@@ -917,7 +933,7 @@ Not all parameters need to be sent at full rate. Recommended minimum intervals:
 
 #### Automatic Page Changes (Alerts)
 
-The official software supports automatic page switching based on telemetry events:
+The official software supports automatic page switching based on telemetry events (page contents are in [ITM Page Layouts](#itm-page-layouts)):
 
 **Value-Change Triggers:**
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -95,7 +95,7 @@ The modern 64-byte HID collection. Used for: modern LED control (RGB565), ITM di
 col01 and col03 are separate HID interfaces. The host opens and writes to each independently. The Fanatec SDK provides a single send path that uses the first byte of the application buffer as a routing hint (`0xFF` → col03, anything else → col01), but this is an SDK convenience — on the wire, the collection is determined by which interface the host writes to.
 
 ### Command Class
-The second byte of a col03 report, identifying the protocol domain: `0x01` = LED control, `0x02` = ITM enable / analysis page, `0x03` = tuning menu, `0x05` = ITM display (page set, param defs, value updates, keepalive), `0x08` = system report (identity).
+The second byte of a col03 report, identifying the protocol domain: `0x01` = LED control, `0x02` = ITM enable, `0x03` = tuning menu, `0x05` = ITM display (mode gate, page set, param defs, value updates, display reset), `0x08` = system report (identity).
 
 ### Report Trigger
 A general-purpose, SubId-parameterized notification mechanism using col01 reports — not specific to any single function. Sends an ON/OFF pair: `[RID, F8, 09, 01, 06, FF, <SubId>, 00]` followed by `[RID, F8, 09, 01, 06, 00, 00, 00]`. The SubId selects the purpose: 1 = button-module re-detect, 2 = clutch bite point, 3 = legacy hardware-identity (superseded by the system report on modern bases). See [Report Trigger](reference/protocol.md#0x06--report-trigger--ack).
@@ -139,7 +139,7 @@ Parameter definition reports (`FF 05 03 ...`) that tell the firmware what parame
 Parameter value reports (`FF 05 01 ...`) that send actual telemetry data for display. Each entry contains a handle, parameter ID, size, and value.
 
 ### Keepalive
-A periodic packet (`FF 05 04 02 0B ...`) that must be sent every ~100ms to keep the ITM display alive.
+Historically a periodic `FF 05 04 02 0B` packet thought to keep the ITM display alive. It is actually a [PageSet](reference/protocol.md#0x04--pageset) to 'device 2' (seemingly absent on current hardware); captures show the official software does not send it, and the ValueUpdate stream is what keeps the display fed. Hardware testing indicates the display has no idle timeout, so no keepalive is needed; FanaBridge no longer sends one.
 
 ### Page
 An ITM display layout showing a specific set of telemetry parameters. Most devices have 6 pages (page 6 = legacy), some have 5 (page 5 = legacy). Pages contain SPEED and GEAR as persistent headers plus page-specific parameters. See [Page Layouts](reference/protocol.md#itm-page-layouts).


### PR DESCRIPTION
## Summary

Corrects the ITM (telemetry display) output so on-screen values read properly, fixes the ITM enable/keepalive semantics to match hardware-confirmed behavior, and reworks the ITM protocol reference for cohesion.

## Display output

- **Fuel** now renders as value/capacity (e.g. `142/90`) from `MaxFuel`, instead of a bare unit label; falls back to the fuel unit (`L`/`G`) only when no capacity is reported.
- **Temperature units** (`C`/`F`/`K`) are read from the telemetry frame (`StatusDataBase.TemperatureUnit`), so the label always matches the already-converted value. Removes the `PluginManager`/`GameUnitSettings` lookup and the `ItmUnitLabels` helper.
- **Graceful blanks** — lap/position/fuel totals clear with a space rather than a stale `/0` (a zero-length suffix doesn't always overwrite the firmware default).
- **Retry on failure** — last-sent values are recorded only after a successful send, so a transport hiccup retries instead of leaving the display stale.
- **Startup** forces ITM page 1 (Lap Info) to match the bring-up seed, so values are correct immediately; the wheel button navigates from there.

## Enable / keepalive correctness

- **Enable semantics corrected.** `FF 02 02` byte[3] is a fixed `0x00`, not a page — the misnamed `page` parameter is removed from `EnableItm()`. The session enable (`FF 02 02`) is now clearly distinguished from the persistent ITM-mode gate (`FF 05 02`); a bring-up uses both. Enable is confirmed as a real, needed command and kept.
- **Removed unsupported claims** (both disproven on hardware): "enable resets the slot table, so ParamDefs must be re-sent after each enable" (the unit suffix survives an enable), and "looping enable crashes the PBME" (misattributed — the real crash risk is page-3 data formats, documented at the encoders).
- **Keepalive removed.** The display has no idle timeout (hardware-confirmed), so no keepalive is sent anywhere — `SendKeepalive`/`KeepaliveInterval` and their tests are gone. **Settles #42.**

## Docs

- Reworked the `0x05 — ITM Display` protocol chapter: subcommands in numeric order, merged the duplicated Control Model / Firmware Subscription Pushes prose, and fixed dangling `#legacy-mode` links.
- Dropped the "analysis page" misreading of `FF 02 02` byte[3] from the docs and code comments.

## Testing

- Full test suite green; ITM encoder/telemetry/driver tests updated to match (removed the keepalive and `EnableItm` page-byte tests).
- Enable, keepalive, and no-idle-timeout behavior verified on a PBME.