### PR TITLE
feat: active SRM-converter identity probe in the detection report

### DIFF
--- a/FanaBridge.Tests/ConverterCaptureProbeTests.cs
+++ b/FanaBridge.Tests/ConverterCaptureProbeTests.cs
@@ -1,0 +1,90 @@
+using FanaBridge.Protocol;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// Unit tests for the pure decoders of the converter capture probe — the col01 tail classifier
+    /// and the SRM DE FA -> 0xDD reply decoder. The live I/O (engage + reads) is not exercised here.
+    /// </summary>
+    public class ConverterCaptureProbeTests
+    {
+        // A 34-byte col01 report with the given identity tail.
+        private static byte[] Col01(byte wire, byte type = 0, byte b1 = 0, byte b2 = 0)
+        {
+            var b = new byte[34];
+            b[0] = 0x01;
+            b[34 - 5] = 0x81; // SystemConfig
+            b[34 - 4] = wire;
+            b[34 - 3] = type;
+            b[34 - 2] = b1;
+            b[34 - 1] = b2;
+            return b;
+        }
+
+        [Fact]
+        public void Col01Tail_DirectRim_NamesTheHub()
+        {
+            var r = ConverterCaptureProbe.DescribeCol01Tail(Col01(0x0C), 34);
+            Assert.Contains("rim 0x0C", r);
+            Assert.Contains("PHUB", r);
+        }
+
+        [Fact]
+        public void Col01Tail_ZeroRim_IsNothingAttached()
+        {
+            Assert.Contains("nothing attached", ConverterCaptureProbe.DescribeCol01Tail(Col01(0x00), 34));
+        }
+
+        [Fact]
+        public void Col01Tail_ExtInfoType1_ShowsRawB1AndModule()
+        {
+            // EXT_INFO type-1, b1=0x15 -> PBME (0x15 - 0x14 = 0x01). The RAW b1 is always shown so a
+            // future 0x16 (PBMR) is visible even though this hardware only ever emits 0x15.
+            var r = ConverterCaptureProbe.DescribeCol01Tail(Col01(0xFF, type: 0x01, b1: 0x15, b2: 0x06), 34);
+            Assert.Contains("EXT_INFO type=1", r);
+            Assert.Contains("b1=0x15", r);
+            Assert.Contains("PBME", r);
+        }
+
+        [Fact]
+        public void Col01Tail_ExtInfoType2_IsAccessories()
+        {
+            var r = ConverterCaptureProbe.DescribeCol01Tail(Col01(0xFF, type: 0x02), 34);
+            Assert.Contains("EXT_INFO type=2", r);
+            Assert.Contains("accessories", r);
+        }
+
+        [Theory]
+        [InlineData((byte)0x15, "PBME")]
+        [InlineData((byte)0x16, "PBMR")]
+        public void Col01ModuleName_MapsViaMinus0x14(byte b1, string expected)
+        {
+            Assert.Equal(expected, ConverterCaptureProbe.Col01ModuleName(b1));
+        }
+
+        [Fact]
+        public void Col01ModuleName_Zero_IsNone()
+        {
+            Assert.Equal("none", ConverterCaptureProbe.Col01ModuleName(0x00));
+        }
+
+        [Fact]
+        public void DeFa_DecodesKitFwWheelIdAndModule()
+        {
+            // DD [kitMaj=0x04] [kitMin=0x10] [wheelId=0x0E] [wheelFw=0x03] [module=0x02 -> PBMR]
+            var buf = new byte[] { 0xDD, 0x04, 0x10, 0x0E, 0x03, 0x02, 0x00, 0x00 };
+            var line = ConverterCaptureProbe.DescribeDeFa(buf, 0, 0x00);
+            Assert.Contains("wheelId=0x0E", line);
+            Assert.Contains("PBMR", line);
+            Assert.Contains("kit fw 4.10", line);
+        }
+
+        [Fact]
+        public void DeFa_WheelIdZero_ReportsNoRim()
+        {
+            var buf = new byte[] { 0xDD, 0x04, 0x10, 0x00, 0x00, 0x01, 0x00, 0x00 };
+            Assert.Contains("no rim attached", ConverterCaptureProbe.DescribeDeFa(buf, 0, 0x00));
+        }
+    }
+}

--- a/FanaBridge.Tests/FanatecDisplayDriverTests.cs
+++ b/FanaBridge.Tests/FanatecDisplayDriverTests.cs
@@ -33,6 +33,8 @@ namespace FanaBridge.Tests
 
             public bool SendCol03(byte[] data) => true;
             public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOpDisposable();
 
             private sealed class NoOpDisposable : IDisposable

--- a/FanaBridge.Tests/FanatecLedDriverTests.cs
+++ b/FanaBridge.Tests/FanatecLedDriverTests.cs
@@ -32,6 +32,8 @@ namespace FanaBridge.Tests
             public bool SendCol01(byte[] data) { lock (_lock) { _col01.Add((byte[])data.Clone()); } return true; }
             public bool SendCol03(byte[] data) { lock (_lock) { _col03.Add((byte[])data.Clone()); } return true; }
             public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOp();
             private sealed class NoOp : IDisposable { public void Dispose() { } }
 

--- a/FanaBridge.Tests/FanatecTuningControllerTests.cs
+++ b/FanaBridge.Tests/FanatecTuningControllerTests.cs
@@ -15,6 +15,8 @@ namespace FanaBridge.Tests
         {
             public bool IsConnected { get; set; } = true;
             public int Col03MaxInputReportLength { get; set; } = 64;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
 
             public List<byte[]> SentCol03Reports { get; } = new List<byte[]>();
             public List<byte[]> SentCol01Reports { get; } = new List<byte[]>();

--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -30,6 +30,8 @@ namespace FanaBridge.Tests
 
             public bool SendCol01(byte[] data) => true;
             public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOp();
             private sealed class NoOp : IDisposable { public void Dispose() { } }
         }

--- a/FanaBridge.Tests/ItmEncoderTests.cs
+++ b/FanaBridge.Tests/ItmEncoderTests.cs
@@ -33,6 +33,8 @@ namespace FanaBridge.Tests
 
             public bool SendCol01(byte[] data) => true;
             public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
 
             public IDisposable BeginBatch()
             {

--- a/FanaBridge.Tests/LegacyLedEncoderTests.cs
+++ b/FanaBridge.Tests/LegacyLedEncoderTests.cs
@@ -30,6 +30,8 @@ namespace FanaBridge.Tests
             }
 
             public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOpDisposable();
 
             private class NoOpDisposable : IDisposable

--- a/FanaBridge/Protocol/ConverterCaptureProbe.cs
+++ b/FanaBridge/Protocol/ConverterCaptureProbe.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using FanaBridge.Transport;
 
 namespace FanaBridge.Protocol
@@ -9,22 +10,28 @@ namespace FanaBridge.Protocol
     /// an SRM Conversion Kit user contains everything we need to build/validate driverless identity —
     /// no external USB capture, no Fanatec software.
     ///
-    /// It replicates the kernel filter's ENGAGE handshake, then records what the device emits on BOTH
-    /// surfaces plus the SRM config channel:
-    ///   1. the engage result (which of the 5 sends the transport accepted),
-    ///   2. every distinct col01 input record (the rim byte, and each EXT_INFO sub-record),
+    /// It replicates the kernel filter's ENGAGE handshake for the wired SRM classes (id 8 = PID 0x0005,
+    /// id 14 = PID 0x0020): the col03 <c>FF 08</c> enable+trigger, then the col01 SubId triggers. Per
+    /// the RE (command-protocol §3), the SubId triggers are a timed <b>ON(SubId)/OFF(0) pulse with a
+    /// ~100 ms gap</b>, read BETWEEN pulses — so this pulses each SubId and drains col01 in the gap,
+    /// rather than firing them back-to-back, to give a converter's firmware time to volunteer its
+    /// module/rim records. (HostHello/ACQUIRE are NOT part of these classes' engage.)
+    ///
+    /// It records, from a single run:
+    ///   1. the engage result (which sends the transport accepted),
+    ///   2. every DISTINCT col01 input record (the rim byte, and each EXT_INFO sub-record),
     ///   3. the col03 <c>FF 08</c> system report, if the device answers one,
     ///   4. the SRM <c>DE FA AD</c> → <c>0xDD</c> identity reply, if it is a Conversion Kit.
     ///
     /// Nothing here writes tuning/config: the engage is the identity handshake, and <c>DE FA AD</c> is
-    /// the SRM config app's "get wheel" query. See the Fanatec-RE converter-support + command-protocol
-    /// docs. Genuine (non-SRM) devices simply return no <c>0xDD</c> reply — the query is harmless.
+    /// the SRM config app's "get wheel" query. Genuine (non-SRM) devices answer no <c>0xDD</c>.
     /// </summary>
     public sealed class ConverterCaptureProbe
     {
         private const int MinCol01Len = 33;         // identity reports are report-id 1, len in {33,34}
-        private const int Col01MaxFrames = 40;      // enough to surface every EXT_INFO record variant
-        private const int Col01ReadTimeoutMs = 25;
+        private const int PulseWindowMs = 110;      // per-SubId col01 read window (~ native Sleep(100) pulse gap)
+        private const int FinalDrainMs = 160;       // trailing drain for anything still streaming
+        private const int Col01ReadTimeoutMs = 20;
         private const int Col03MaxReads = 12;
         private const int Col03ReadTimeoutMs = 40;
 
@@ -40,8 +47,6 @@ namespace FanaBridge.Protocol
             public string DeFaLine;
         }
 
-        private readonly WheelEngage _engage = new WheelEngage();
-
         public Result Run(IDeviceTransport io)
         {
             var r = new Result();
@@ -51,30 +56,52 @@ namespace FanaBridge.Protocol
                 return r;
             }
 
+            var seen = new HashSet<string>();
+            var engage = new List<string>();
+            var sw = new Stopwatch();
+
             // Hold the transport for the whole capture so the runtime's frames don't interleave ours.
             using (io.BeginBatch())
             {
-                try { r.Engage = FormatEngage(_engage.Engage(io)); }
-                catch (Exception ex) { r.Engage = "engage FAILED: " + ex.Message; }
+                // col03 FF 08 enable + trigger.
+                engage.Add("FF08 enable:" + Ok(() => io.SendCol03(Ff08(0x01, 0xFF))));
+                engage.Add("FF08 trigger:" + Ok(() => io.SendCol03(Ff08(0x02, 0x00))));
 
-                CaptureCol01(io, r);
+                // col01 SubId pulses. Each ON is followed by a read window (the native ON/Sleep(100)/OFF
+                // pulse) so the device has time to respond and we capture the response in-line.
+                Pulse(io, 0x01, "SubId=1 module", engage, seen, r, sw);
+                Pulse(io, 0x00, "SubId=0 input", engage, seen, r, sw);
+                Pulse(io, 0x04, "SubId=4", engage, seen, r, sw);
+                Pulse(io, 0x00, "SubId=0 deassert", engage, seen, r, sw);
+
+                // Trailing drain for anything still streaming after the pulses.
+                DrainCol01(io, FinalDrainMs, seen, r, sw);
+                r.Engage = "engage[" + string.Join("  ", engage) + "]";
+
                 CaptureFf08(io, r);
                 CaptureDeFa(io, r);
             }
             return r;
         }
 
-        // Read a burst of col01 frames and record each DISTINCT tail record (deduped by decoded
-        // meaning, not raw bytes — the axis fields change every frame). A representative frame's hex
-        // is kept with each record so the exact wire bytes are reportable.
-        private static void CaptureCol01(IDeviceTransport io, Result r)
+        private static void Pulse(IDeviceTransport io, byte subId, string label,
+            List<string> engage, HashSet<string> seen, Result r, Stopwatch sw)
+        {
+            engage.Add(label + ":" + Ok(() => io.SendCol01(WheelEngage.SubId(subId))));
+            DrainCol01(io, PulseWindowMs, seen, r, sw);
+        }
+
+        // Read col01 for ~windowMs, recording each DISTINCT tail record (deduped by decoded meaning,
+        // not raw bytes — the axis fields change every frame). A representative frame's hex is kept
+        // with each record so the exact wire bytes are reportable.
+        private static void DrainCol01(IDeviceTransport io, int windowMs, HashSet<string> seen, Result r, Stopwatch sw)
         {
             int len = io.Col01MaxInputReportLength;
             if (len < MinCol01Len) len = 34;
             var buf = new byte[len];
-            var seen = new HashSet<string>();
 
-            for (int i = 0; i < Col01MaxFrames; i++)
+            sw.Restart();
+            while (sw.ElapsedMilliseconds < windowMs)
             {
                 int n = io.ReadCol01(buf, Col01ReadTimeoutMs);
                 if (n <= 0) continue;
@@ -187,11 +214,18 @@ namespace FanaBridge.Protocol
                 wheelId == 0 ? "   (no rim attached)" : "");
         }
 
-        private static string FormatEngage(WheelEngage.Step[] steps)
+        private static string Ok(Func<bool> send)
         {
-            var parts = new List<string>(steps.Length);
-            foreach (var s in steps) parts.Add(s.Label + ":" + (s.Sent ? "ok" : "FAIL"));
-            return "engage[" + string.Join("  ", parts) + "]";
+            try { return send() ? "ok" : "FAIL"; }
+            catch { return "ERR"; }
+        }
+
+        // FF 08 <b2> <b3> control report (64-byte): FF 08 01 FF = enable, FF 08 02 00 = trigger.
+        private static byte[] Ff08(byte b2, byte b3)
+        {
+            var b = new byte[64];
+            b[0] = 0xFF; b[1] = 0x08; b[2] = b2; b[3] = b3;
+            return b;
         }
 
         // FF 08-style signature scan (tolerates a leading report-id byte).

--- a/FanaBridge/Protocol/ConverterCaptureProbe.cs
+++ b/FanaBridge/Protocol/ConverterCaptureProbe.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using FanaBridge.Transport;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// One-shot, read-only identity capture run at diagnostics time so a SINGLE detection report from
+    /// an SRM Conversion Kit user contains everything we need to build/validate driverless identity —
+    /// no external USB capture, no Fanatec software.
+    ///
+    /// It replicates the kernel filter's ENGAGE handshake, then records what the device emits on BOTH
+    /// surfaces plus the SRM config channel:
+    ///   1. the engage result (which of the 5 sends the transport accepted),
+    ///   2. every distinct col01 input record (the rim byte, and each EXT_INFO sub-record),
+    ///   3. the col03 <c>FF 08</c> system report, if the device answers one,
+    ///   4. the SRM <c>DE FA AD</c> → <c>0xDD</c> identity reply, if it is a Conversion Kit.
+    ///
+    /// Nothing here writes tuning/config: the engage is the identity handshake, and <c>DE FA AD</c> is
+    /// the SRM config app's "get wheel" query. See the Fanatec-RE converter-support + command-protocol
+    /// docs. Genuine (non-SRM) devices simply return no <c>0xDD</c> reply — the query is harmless.
+    /// </summary>
+    public sealed class ConverterCaptureProbe
+    {
+        private const int MinCol01Len = 33;         // identity reports are report-id 1, len in {33,34}
+        private const int Col01MaxFrames = 40;      // enough to surface every EXT_INFO record variant
+        private const int Col01ReadTimeoutMs = 25;
+        private const int Col03MaxReads = 12;
+        private const int Col03ReadTimeoutMs = 40;
+
+        /// <summary>The captured surfaces. Any field may be null when that surface stayed silent.</summary>
+        public sealed class Result
+        {
+            public string Engage;
+            public readonly List<string> Col01Records = new List<string>();
+            public int Col01FramesRead;
+            public string Ff08Raw;
+            public string Ff08Line;
+            public string DeFaRaw;
+            public string DeFaLine;
+        }
+
+        private readonly WheelEngage _engage = new WheelEngage();
+
+        public Result Run(IDeviceTransport io)
+        {
+            var r = new Result();
+            if (io == null || !io.IsConnected)
+            {
+                r.Engage = "(not connected)";
+                return r;
+            }
+
+            // Hold the transport for the whole capture so the runtime's frames don't interleave ours.
+            using (io.BeginBatch())
+            {
+                try { r.Engage = FormatEngage(_engage.Engage(io)); }
+                catch (Exception ex) { r.Engage = "engage FAILED: " + ex.Message; }
+
+                CaptureCol01(io, r);
+                CaptureFf08(io, r);
+                CaptureDeFa(io, r);
+            }
+            return r;
+        }
+
+        // Read a burst of col01 frames and record each DISTINCT tail record (deduped by decoded
+        // meaning, not raw bytes — the axis fields change every frame). A representative frame's hex
+        // is kept with each record so the exact wire bytes are reportable.
+        private static void CaptureCol01(IDeviceTransport io, Result r)
+        {
+            int len = io.Col01MaxInputReportLength;
+            if (len < MinCol01Len) len = 34;
+            var buf = new byte[len];
+            var seen = new HashSet<string>();
+
+            for (int i = 0; i < Col01MaxFrames; i++)
+            {
+                int n = io.ReadCol01(buf, Col01ReadTimeoutMs);
+                if (n <= 0) continue;
+                r.Col01FramesRead++;
+                if (n < MinCol01Len || buf[0] != 0x01) continue; // report-id 1 = the identity report
+
+                string decode = DescribeCol01Tail(buf, n);
+                if (decode != null && seen.Add(decode))
+                    r.Col01Records.Add(Hex(buf, n) + "  -> " + decode);
+            }
+        }
+
+        // Classify a col01 report by its identity tail. [len-4] is the rim/EXT_INFO byte; under
+        // EXT_INFO the 4-byte tail is [len-4]=FF | [len-3]=type | [len-2]=b1 | [len-1]=b2.
+        internal static string DescribeCol01Tail(byte[] buf, int n)
+        {
+            if (buf == null || n < MinCol01Len) return null;
+            byte wire = buf[n - 4];
+
+            if (wire == 0xFF)
+            {
+                byte type = buf[n - 3], b1 = buf[n - 2], b2 = buf[n - 1];
+                string note =
+                    type == 0x01 ? "  (button module: " + Col01ModuleName(b1) + ")" :
+                    type == 0x02 ? "  (accessories)" : "";
+                return string.Format("EXT_INFO type={0} b1=0x{1:X2} b2=0x{2:X2}{3}", type, b1, b2, note);
+            }
+            if (wire == 0x00) return "rim: (nothing attached)";
+            return string.Format("rim 0x{0:X2} {1}", wire, FanatecIdentity.DecodeCode(wire) ?? "unrecognized");
+        }
+
+        // col01 type-1 DeviceModule byte = FF 08 0x1F raw + 0x14 (FWFUUtilDeviceModulePresenceGet):
+        // 0x15 -> PBME, 0x16 -> PBMR. NOTE: observed COARSE on genuine hardware — both PBMR and PBME
+        // emit 0x15; only FF 08 0x1F carries the fine split. Report the raw b1 regardless.
+        internal static string Col01ModuleName(byte b1)
+        {
+            if (b1 == 0x00) return "none";
+            if (b1 < 0x15) return "?";
+            return FanatecIdentity.DecodeModule((byte)(b1 - 0x14)) ?? "unrecognized";
+        }
+
+        // Read col03 for an FF 08 system report (the engage already enabled+triggered it).
+        private static void CaptureFf08(IDeviceTransport io, Result r)
+        {
+            int len = io.Col03MaxInputReportLength;
+            if (len < 64) len = 64;
+            var buf = new byte[len];
+
+            for (int i = 0; i < Col03MaxReads; i++)
+            {
+                int n = io.ReadCol03(buf, Col03ReadTimeoutMs);
+                if (n <= 0) break;
+
+                int sig = FindPair(buf, n, 0xFF, 0x08);
+                if (sig < 0 || n < sig + 0x20) continue;
+
+                r.Ff08Raw = Hex(buf, n);
+                byte baseType = buf[sig + 0x02], wire = buf[sig + 0x18], mod = buf[sig + 0x1F];
+                r.Ff08Line = string.Format(
+                    "base [0x02]=0x{0:X2} {1}   rim [0x18]=0x{2:X2} {3}   module [0x1F]=0x{4:X2} {5}",
+                    baseType, FanatecIdentity.DecodeBaseCode(baseType) ?? "unrecognized",
+                    wire, FanatecIdentity.DecodeCode(wire) ?? "unrecognized",
+                    mod, FanatecIdentity.DecodeModule(mod) ?? "none");
+                return;
+            }
+        }
+
+        // Query the SRM Conversion Kit's DE FA AD -> 0xDD channel on col03. Tries both report-ids
+        // (0xFF emulation gen, 0x00 native/interim); a genuine base answers neither. See converter-
+        // support §3: OUT data = 00 DE FA AD; IN = DD [kitMaj] [kitMin] [wheelId] [wheelFw] [module].
+        private static void CaptureDeFa(IDeviceTransport io, Result r)
+        {
+            foreach (byte reportId in new byte[] { 0xFF, 0x00 })
+            {
+                var outRep = new byte[64];
+                outRep[0] = reportId;                       // report-id
+                outRep[1] = 0x00;                           // data[0] = channel/sub byte
+                outRep[2] = 0xDE; outRep[3] = 0xFA; outRep[4] = 0xAD; // magic + cmd AD (get-wheel)
+                try { if (!io.SendCol03(outRep)) continue; }
+                catch { continue; }
+
+                int len = io.Col03MaxInputReportLength;
+                if (len < 64) len = 64;
+                var buf = new byte[len];
+
+                for (int i = 0; i < Col03MaxReads; i++)
+                {
+                    int n = io.ReadCol03(buf, Col03ReadTimeoutMs);
+                    if (n <= 0) break;
+
+                    int sig = FindByte(buf, n, 0xDD, 3); // scan first 3 bytes for the 0xDD signature
+                    if (sig < 0 || n < sig + 6) continue;
+
+                    r.DeFaRaw = Hex(buf, n);
+                    r.DeFaLine = DescribeDeFa(buf, sig, reportId);
+                    return;
+                }
+            }
+            r.DeFaLine = "(no 0xDD reply — not an SRM Conversion Kit, or a gen that doesn't answer DE FA AD)";
+        }
+
+        // Decode a 0xDD identity reply: DD [kitMaj] [kitMin(BCD)] [wheelId] [wheelFw] [module 1=PBME,2=PBMR].
+        internal static string DescribeDeFa(byte[] buf, int sig, byte reportId)
+        {
+            byte kitMaj = buf[sig + 1], kitMin = buf[sig + 2], wheelId = buf[sig + 3], wheelFw = buf[sig + 4], module = buf[sig + 5];
+            string mod = module == 1 ? "PBME" : module == 2 ? "PBMR" : module == 0 ? "none" : "0x" + module.ToString("X2");
+            return string.Format(
+                "SRM Conversion Kit (report-id 0x{0:X2}): kit fw {1}.{2:X2}   wheelId=0x{3:X2}   wheel fw={4}   module={5}{6}",
+                reportId, kitMaj, kitMin, wheelId, wheelFw, mod,
+                wheelId == 0 ? "   (no rim attached)" : "");
+        }
+
+        private static string FormatEngage(WheelEngage.Step[] steps)
+        {
+            var parts = new List<string>(steps.Length);
+            foreach (var s in steps) parts.Add(s.Label + ":" + (s.Sent ? "ok" : "FAIL"));
+            return "engage[" + string.Join("  ", parts) + "]";
+        }
+
+        // FF 08-style signature scan (tolerates a leading report-id byte).
+        private static int FindPair(byte[] buf, int n, byte a, byte b)
+        {
+            for (int i = 0; i <= 2 && i + 1 < n; i++)
+                if (buf[i] == a && buf[i + 1] == b) return i;
+            return -1;
+        }
+
+        private static int FindByte(byte[] buf, int n, byte val, int within)
+        {
+            for (int i = 0; i < within && i < n; i++)
+                if (buf[i] == val) return i;
+            return -1;
+        }
+
+        private static string Hex(byte[] buf, int n)
+            => BitConverter.ToString(buf, 0, n).Replace('-', ' ');
+    }
+}

--- a/FanaBridge/Protocol/DiagnosticsReport.cs
+++ b/FanaBridge/Protocol/DiagnosticsReport.cs
@@ -12,11 +12,13 @@ namespace FanaBridge.Protocol
     /// live transport FanaBridge already holds open (so there is no need to close
     /// SimHub or run an external tool).
     ///
-    /// Read-only: it re-enumerates the HID bus, decodes the last FF 08 system report
+    /// Mostly read-only: it re-enumerates the HID bus, decodes the last FF 08 system report
     /// FanaBridge already drained (identity + firmware versions), flags the col03 control
     /// interface the same way the transport selects it (the &amp;col03 path token, else a
-    /// 64-byte OUTPUT report), and takes one best-effort, motion-gated col01 input
-    /// snapshot. It never writes to the device.
+    /// 64-byte OUTPUT report), and takes a col01 input snapshot. It also runs one ACTIVE
+    /// "converter identity probe" — the kernel filter's engage handshake plus the SRM
+    /// <c>DE FA AD</c> query — then dumps what the device volunteers on both surfaces and the
+    /// SRM <c>0xDD</c> channel. The only writes are identity handshakes, never tuning/config.
     ///
     /// The output is a fenced Markdown block ready to paste into a GitHub issue,
     /// emitting the same wire bytes (raw FF 08 hex + the 0x02/0x18/0x1F key bytes)
@@ -33,7 +35,8 @@ namespace FanaBridge.Protocol
 
             sb.AppendLine("### FanaBridge detection report");
             sb.AppendLine();
-            sb.AppendLine("> Describe what's physically attached (wheelbase, wheel/hub, button module).");
+            sb.AppendLine("> Describe what's physically attached: wheelbase **or SRM converter** (model + firmware),");
+            sb.AppendLine("> the wheel/hub (+ button module), and — for a converter — what the SRM software shows.");
             sb.AppendLine();
             sb.AppendLine("```");
             sb.AppendLine(string.Format("{0,-13}{1}", "FanaBridge:", string.IsNullOrEmpty(buildInfo) ? "unknown" : buildInfo));
@@ -47,6 +50,8 @@ namespace FanaBridge.Protocol
             AppendInterfaceInventory(sb);
             sb.AppendLine();
             AppendSystemReport(sb, wheelbase, connected, statusDetail);
+            sb.AppendLine();
+            AppendConverterProbe(sb, wheelbase, connected);
             sb.AppendLine();
             AppendInputProbe(sb);
             sb.AppendLine();
@@ -66,6 +71,44 @@ namespace FanaBridge.Protocol
 
             sb.AppendLine("```");
             return sb.ToString();
+        }
+
+        // ── Converter identity probe (active engage) ─────────────────────
+        // The passive FF 08 section above is the device's RESTING state. This actively runs the
+        // kernel filter's engage handshake and dumps what the device volunteers on BOTH surfaces
+        // (col01 records + the col03 FF 08 report) plus the SRM DE FA AD -> 0xDD channel — so a
+        // SINGLE report from an SRM Conversion Kit user carries everything needed to build and
+        // validate driverless identity, with no external USB capture. Read-only; a genuine base
+        // just answers no 0xDD.
+        private static void AppendConverterProbe(StringBuilder sb, FanatecWheelbase wb, bool connected)
+        {
+            sb.AppendLine("Converter identity probe (active engage — read-only):");
+            if (!connected || wb?.Transport == null || !wb.Transport.IsConnected)
+            {
+                sb.AppendLine("  (not connected — connect the device and re-capture)");
+                return;
+            }
+
+            ConverterCaptureProbe.Result r;
+            try { r = new ConverterCaptureProbe().Run(wb.Transport); }
+            catch (Exception ex) { sb.AppendLine("  (probe failed: " + ex.Message + ")"); return; }
+
+            sb.AppendLine(Kv("Engage", r.Engage ?? "(none)"));
+
+            sb.AppendLine(Kv("col01 records", r.Col01Records.Count + " distinct in " + r.Col01FramesRead + " frame(s):"));
+            if (r.Col01Records.Count == 0)
+                sb.AppendLine("      (no col01 input reports arrived)");
+            else
+                foreach (var rec in r.Col01Records)
+                    sb.AppendLine("      " + rec);
+
+            sb.AppendLine(Kv("col03 FF 08", r.Ff08Line ?? "(no FF 08 report — SRM converter or under-engaged)"));
+            if (r.Ff08Raw != null)
+                sb.AppendLine("      raw: " + r.Ff08Raw);
+
+            sb.AppendLine(Kv("SRM DE FA AD", r.DeFaLine ?? "(no reply)"));
+            if (r.DeFaRaw != null)
+                sb.AppendLine("      raw: " + r.DeFaRaw);
         }
 
         // ── HID interface inventory ──────────────────────────────────────

--- a/FanaBridge/Protocol/WheelEngage.cs
+++ b/FanaBridge/Protocol/WheelEngage.cs
@@ -1,0 +1,60 @@
+using FanaBridge.Transport;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// Replicates the kernel filter's engage sequence (FWFUProtocolUsbBulkOrInterruptTransfer)
+    /// for a Fanatec-class device: enable + trigger the col03 <c>FF 08</c> system report, then the
+    /// col01 SubId triggers — SubId=1 (module-detection refresh), SubId=0 (input-report trigger),
+    /// and SubId=4 (undocumented, sent for parity). This is what makes a device — a genuine base
+    /// OR an SRM converter — volunteer its identity on whichever surface it uses.
+    ///
+    /// FanaBridge 0.4.0 sent only the <c>FF 08</c> pair on col03, once — a fraction of the filter's
+    /// handshake — which is why a converter (that needs the fuller engage to emit its rim/module)
+    /// came back empty. All sends here are usermode-legal HID output reports; the col01 SubId frames
+    /// are the same 8-byte shape FanaBridge already writes for LEDs.
+    ///
+    /// Read/identify-only — none of these commands write tuning/config to the device.
+    /// </summary>
+    internal sealed class WheelEngage
+    {
+        private const int Col03Length = 64;
+
+        // col03 FF 08 system-report enable + one-shot trigger.
+        private static byte[] Ff08Enable()  { var b = new byte[Col03Length]; b[0] = 0xFF; b[1] = 0x08; b[2] = 0x01; b[3] = 0xFF; return b; }
+        private static byte[] Ff08Trigger() { var b = new byte[Col03Length]; b[0] = 0xFF; b[1] = 0x08; b[2] = 0x02; return b; }
+
+        // col01 SubId trigger: [report-id 01] F8 09 01 06 FF &lt;SubId&gt; 00.
+        internal static byte[] SubId(byte subId) => new byte[8] { 0x01, 0xF8, 0x09, 0x01, 0x06, 0xFF, subId, 0x00 };
+
+        /// <summary>One engage send and whether the transport accepted it.</summary>
+        public struct Step
+        {
+            public string Label;
+            public bool Sent;
+            public Step(string label, bool sent) { Label = label; Sent = sent; }
+        }
+
+        /// <summary>
+        /// Sends the full engage in the filter's order — <c>FF 08</c> enable, <c>FF 08</c> trigger
+        /// (col03), then SubId=1 (module refresh), SubId=0 (input trigger), SubId=4 (col01). Held
+        /// under one batch so no other write interleaves the sequence. Returns each send and whether
+        /// the transport accepted it, so callers can prove the SubId=1 module refresh actually went
+        /// out (vs. a closed col01 handle silently dropping it).
+        /// </summary>
+        public Step[] Engage(IDeviceTransport io)
+        {
+            using (io.BeginBatch())
+            {
+                return new[]
+                {
+                    new Step("FF08 enable",   io.SendCol03(Ff08Enable())),
+                    new Step("FF08 trigger",  io.SendCol03(Ff08Trigger())),
+                    new Step("SubId=1 module", io.SendCol01(SubId(0x01))), // -> col01 type-1 module record
+                    new Step("SubId=0 input",  io.SendCol01(SubId(0x00))), // -> col01 identity report
+                    new Step("SubId=4",        io.SendCol01(SubId(0x04))), // parity with the filter
+                };
+            }
+        }
+    }
+}

--- a/FanaBridge/Transport/FanatecTransport.cs
+++ b/FanaBridge/Transport/FanatecTransport.cs
@@ -367,6 +367,42 @@ namespace FanaBridge.Transport
             }
         }
 
+        int IDeviceTransport.ReadCol01(byte[] buffer, int timeoutMs)
+        {
+            lock (_writeLock)
+            {
+                // Capture under the lock, mirroring ReadCol03: Disconnect() nulls/disposes
+                // the stream under the same lock, so a non-null local stays valid here.
+                var stream = _displayStream;
+                if (stream == null) return -1;
+
+                int saved = stream.ReadTimeout;
+                try
+                {
+                    stream.ReadTimeout = timeoutMs;
+                    return stream.Read(buffer, 0, buffer.Length);
+                }
+                catch
+                {
+                    return -1;
+                }
+                finally
+                {
+                    try { stream.ReadTimeout = saved; } catch { }
+                }
+            }
+        }
+
+        int IDeviceTransport.Col01MaxInputReportLength
+        {
+            get
+            {
+                if (_displayDevice == null) return 34;
+                int len = SafeMaxInput(_displayDevice);
+                return len > 0 ? len : 34;
+            }
+        }
+
         IDisposable IDeviceTransport.BeginBatch()
         {
             Monitor.Enter(_writeLock);

--- a/FanaBridge/Transport/IDeviceTransport.cs
+++ b/FanaBridge/Transport/IDeviceTransport.cs
@@ -41,6 +41,18 @@ namespace FanaBridge.Transport
         bool SendCol01(byte[] data);
 
         /// <summary>
+        /// Reads a report from the display/input interface (col01). Returns the number
+        /// of bytes read, or -1 on failure/timeout. The <paramref name="timeoutMs"/>
+        /// applies to this call only. Used to read the col01 input report that carries
+        /// the native rim identity (byte <c>[len-4]</c>) when the col03 FF 08 report is
+        /// unavailable.
+        /// </summary>
+        int ReadCol01(byte[] buffer, int timeoutMs);
+
+        /// <summary>Maximum input report length for the col01 interface.</summary>
+        int Col01MaxInputReportLength { get; }
+
+        /// <summary>
         /// Acquires exclusive access to the transport for multi-report
         /// atomic sequences (e.g. staged LED commit, tuning read-modify-write).
         /// Dispose the returned token to release.


### PR DESCRIPTION
Purpose-built to capture, from a SINGLE FanaBridge detection report, everything needed to build + validate driverless identity for SRM Conversion Kit users — no external USB capture, no Fanatec software required.

The report now runs one ACTIVE "converter identity probe": it replicates the kernel filter's engage handshake (FF08 enable/trigger + col01 SubId=1/0/4) and dumps what the device volunteers on BOTH surfaces plus the SRM config channel:
- engage result (which of the 5 sends the transport accepted);
- every DISTINCT col01 input record (rim byte + each EXT_INFO sub-record, decoded);
- the col03 FF 08 system report, if the device answers one;
- the SRM DE FA AD -> 0xDD identity reply, if it is a Conversion Kit (kit fw, wheel id, wheel fw, module) — tried at report-id 0xFF and 0x00.

Genuine (non-SRM) devices answer no 0xDD; the query is harmless. Read-only apart from the identity handshakes — no tuning/config writes.

Adds:
- ConverterCaptureProbe + unit tests for the col01-tail and DE FA decoders.
- col01 read capability on the transport (IDeviceTransport.ReadCol01 + Col01MaxInputReportLength) and the engage byte patterns (WheelEngage), brought from the experiment/srm-converter-identity snapshot.
- DiagnosticsReport: the active probe section + a converter-aware capture prompt.

Branched clean from 3f3d56c; the full (experimental) identity solution is preserved on branch experiment/srm-converter-identity.


Claude-Session: https://claude.ai/code/session_01A8iTm7e4PCqWeV7qYhwbL9