### PR TITLE
fix: detect SRM Conversion Kit wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.0 - Unreleased
+
+### Fixed
+- **SRM Conversion Kit wheels are detected again.** A Fanatec wheel/hub run through an SRM Conversion Kit no longer sits at "Connecting…" — FanaBridge recovers the wheel's identity from the conversion kit when the base doesn't emit the usual Fanatec system report (regressed in v0.4.0). The genuine-hardware detection path is unchanged. ([#47](https://github.com/kelchm/FanaBridge/pull/47), fixes [#52](https://github.com/kelchm/FanaBridge/issues/52))
+
 ## v0.4.0 - 2026-07-01
 
 ### Changed

--- a/FanaBridge.Tests/ConverterCaptureProbeTests.cs
+++ b/FanaBridge.Tests/ConverterCaptureProbeTests.cs
@@ -37,14 +37,15 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void Col01Tail_ExtInfoType1_ShowsRawB1AndModule()
+        public void Col01Tail_ExtInfoType1_ShowsRawBytesButNotAModuleClaim()
         {
-            // EXT_INFO type-1, b1=0x15 -> PBME (0x15 - 0x14 = 0x01). The RAW b1 is always shown so a
-            // future 0x16 (PBMR) is visible even though this hardware only ever emits 0x15.
+            // col01 is COARSE — a PBMR and a PBME both emit b1=0x15 — so we keep the RAW byte but must
+            // NOT present a "PBME"/"PBMR" label (that would be a guess). The module comes from FF 08 / DE FA.
             var r = ConverterCaptureProbe.DescribeCol01Tail(Col01(0xFF, type: 0x01, b1: 0x15, b2: 0x06), 34);
             Assert.Contains("EXT_INFO type=1", r);
-            Assert.Contains("b1=0x15", r);
-            Assert.Contains("PBME", r);
+            Assert.Contains("b1=0x15", r);                    // raw byte kept …
+            Assert.DoesNotContain("button module: PBME", r);  // … but no misleading interpretation
+            Assert.DoesNotContain("button module: PBMR", r);
         }
 
         [Fact]
@@ -53,20 +54,6 @@ namespace FanaBridge.Tests
             var r = ConverterCaptureProbe.DescribeCol01Tail(Col01(0xFF, type: 0x02), 34);
             Assert.Contains("EXT_INFO type=2", r);
             Assert.Contains("accessories", r);
-        }
-
-        [Theory]
-        [InlineData((byte)0x15, "PBME")]
-        [InlineData((byte)0x16, "PBMR")]
-        public void Col01ModuleName_MapsViaMinus0x14(byte b1, string expected)
-        {
-            Assert.Equal(expected, ConverterCaptureProbe.Col01ModuleName(b1));
-        }
-
-        [Fact]
-        public void Col01ModuleName_Zero_IsNone()
-        {
-            Assert.Equal("none", ConverterCaptureProbe.Col01ModuleName(0x00));
         }
 
         [Fact]

--- a/FanaBridge.Tests/ConverterCaptureProbeTests.cs
+++ b/FanaBridge.Tests/ConverterCaptureProbeTests.cs
@@ -1,0 +1,90 @@
+using FanaBridge.Protocol;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// Unit tests for the pure decoders of the converter capture probe — the col01 tail classifier
+    /// and the SRM DE FA -> 0xDD reply decoder. The live I/O (engage + reads) is not exercised here.
+    /// </summary>
+    public class ConverterCaptureProbeTests
+    {
+        // A 34-byte col01 report with the given identity tail.
+        private static byte[] Col01(byte wire, byte type = 0, byte b1 = 0, byte b2 = 0)
+        {
+            var b = new byte[34];
+            b[0] = 0x01;
+            b[34 - 5] = 0x81; // SystemConfig
+            b[34 - 4] = wire;
+            b[34 - 3] = type;
+            b[34 - 2] = b1;
+            b[34 - 1] = b2;
+            return b;
+        }
+
+        [Fact]
+        public void Col01Tail_DirectRim_NamesTheHub()
+        {
+            var r = ConverterCaptureProbe.DescribeCol01Tail(Col01(0x0C), 34);
+            Assert.Contains("rim 0x0C", r);
+            Assert.Contains("PHUB", r);
+        }
+
+        [Fact]
+        public void Col01Tail_ZeroRim_IsNothingAttached()
+        {
+            Assert.Contains("nothing attached", ConverterCaptureProbe.DescribeCol01Tail(Col01(0x00), 34));
+        }
+
+        [Fact]
+        public void Col01Tail_ExtInfoType1_ShowsRawB1AndModule()
+        {
+            // EXT_INFO type-1, b1=0x15 -> PBME (0x15 - 0x14 = 0x01). The RAW b1 is always shown so a
+            // future 0x16 (PBMR) is visible even though this hardware only ever emits 0x15.
+            var r = ConverterCaptureProbe.DescribeCol01Tail(Col01(0xFF, type: 0x01, b1: 0x15, b2: 0x06), 34);
+            Assert.Contains("EXT_INFO type=1", r);
+            Assert.Contains("b1=0x15", r);
+            Assert.Contains("PBME", r);
+        }
+
+        [Fact]
+        public void Col01Tail_ExtInfoType2_IsAccessories()
+        {
+            var r = ConverterCaptureProbe.DescribeCol01Tail(Col01(0xFF, type: 0x02), 34);
+            Assert.Contains("EXT_INFO type=2", r);
+            Assert.Contains("accessories", r);
+        }
+
+        [Theory]
+        [InlineData((byte)0x15, "PBME")]
+        [InlineData((byte)0x16, "PBMR")]
+        public void Col01ModuleName_MapsViaMinus0x14(byte b1, string expected)
+        {
+            Assert.Equal(expected, ConverterCaptureProbe.Col01ModuleName(b1));
+        }
+
+        [Fact]
+        public void Col01ModuleName_Zero_IsNone()
+        {
+            Assert.Equal("none", ConverterCaptureProbe.Col01ModuleName(0x00));
+        }
+
+        [Fact]
+        public void DeFa_DecodesKitFwWheelIdAndModule()
+        {
+            // DD [kitMaj=0x04] [kitMin=0x10] [wheelId=0x0E] [wheelFw=0x03] [module=0x02 -> PBMR]
+            var buf = new byte[] { 0xDD, 0x04, 0x10, 0x0E, 0x03, 0x02, 0x00, 0x00 };
+            var line = ConverterCaptureProbe.DescribeDeFa(buf, 0, 0x00);
+            Assert.Contains("wheelId=0x0E", line);
+            Assert.Contains("PBMR", line);
+            Assert.Contains("kit fw 4.10", line);
+        }
+
+        [Fact]
+        public void DeFa_WheelIdZero_ReportsNoRim()
+        {
+            var buf = new byte[] { 0xDD, 0x04, 0x10, 0x00, 0x00, 0x01, 0x00, 0x00 };
+            Assert.Contains("no rim attached", ConverterCaptureProbe.DescribeDeFa(buf, 0, 0x00));
+        }
+    }
+}

--- a/FanaBridge.Tests/FanatecDisplayDriverTests.cs
+++ b/FanaBridge.Tests/FanatecDisplayDriverTests.cs
@@ -33,6 +33,8 @@ namespace FanaBridge.Tests
 
             public bool SendCol03(byte[] data) => true;
             public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOpDisposable();
 
             private sealed class NoOpDisposable : IDisposable

--- a/FanaBridge.Tests/FanatecLedDriverTests.cs
+++ b/FanaBridge.Tests/FanatecLedDriverTests.cs
@@ -32,6 +32,8 @@ namespace FanaBridge.Tests
             public bool SendCol01(byte[] data) { lock (_lock) { _col01.Add((byte[])data.Clone()); } return true; }
             public bool SendCol03(byte[] data) { lock (_lock) { _col03.Add((byte[])data.Clone()); } return true; }
             public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOp();
             private sealed class NoOp : IDisposable { public void Dispose() { } }
 

--- a/FanaBridge.Tests/FanatecTuningControllerTests.cs
+++ b/FanaBridge.Tests/FanatecTuningControllerTests.cs
@@ -15,6 +15,8 @@ namespace FanaBridge.Tests
         {
             public bool IsConnected { get; set; } = true;
             public int Col03MaxInputReportLength { get; set; } = 64;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
 
             public List<byte[]> SentCol03Reports { get; } = new List<byte[]>();
             public List<byte[]> SentCol01Reports { get; } = new List<byte[]>();

--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -32,6 +32,8 @@ namespace FanaBridge.Tests
 
             public bool SendCol01(byte[] data) => true;
             public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOp();
             private sealed class NoOp : IDisposable { public void Dispose() { } }
         }

--- a/FanaBridge.Tests/ItmEncoderTests.cs
+++ b/FanaBridge.Tests/ItmEncoderTests.cs
@@ -33,6 +33,8 @@ namespace FanaBridge.Tests
 
             public bool SendCol01(byte[] data) => true;
             public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
 
             public IDisposable BeginBatch()
             {

--- a/FanaBridge.Tests/LegacyLedEncoderTests.cs
+++ b/FanaBridge.Tests/LegacyLedEncoderTests.cs
@@ -30,6 +30,8 @@ namespace FanaBridge.Tests
             }
 
             public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOpDisposable();
 
             private class NoOpDisposable : IDisposable

--- a/FanaBridge.Tests/SrmConverterIdentityTests.cs
+++ b/FanaBridge.Tests/SrmConverterIdentityTests.cs
@@ -1,0 +1,61 @@
+using FanaBridge.Protocol;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// Unit tests for the SRM Conversion Kit <c>0xDD</c> identity decode. The wire bytes in
+    /// <see cref="Decode_RealCapture_Run1"/> are the actual reply simanthrop's kit returned, so this
+    /// pins the decoder to validated hardware. The I/O (DE FA send/read) is not exercised here.
+    /// </summary>
+    public class SrmConverterIdentityTests
+    {
+        [Fact]
+        public void Decode_RealCapture_Run1_CSSWFORMV2()
+        {
+            // simanthrop, kit fw 6.12 — verbatim: FF DD 06 12 0A 2F 00 …  (0xDD at index 1)
+            var buf = new byte[] { 0xFF, 0xDD, 0x06, 0x12, 0x0A, 0x2F, 0x00, 0x00 };
+            var r = SrmConverterIdentity.Decode(buf, 1, buf.Length);
+            Assert.Equal(0x0A, r.WheelId);
+            Assert.Equal("CSSWFORMV2", r.WheelCode);
+            Assert.Equal("6.12", r.KitFirmware);
+            Assert.Equal(0, r.ModuleRaw);
+            Assert.Null(r.ModuleCode);
+        }
+
+        [Fact]
+        public void Decode_HubWithModule_ResolvesBoth()
+        {
+            // Documented (converter-support §5/§6) but UNVALIDATED: PHUB (0x0C) + PBMR (module 2).
+            // DE FA carries hub and module as separate bytes, so this decodes cleanly.
+            var buf = new byte[] { 0x00, 0xDD, 0x07, 0x00, 0x0C, 0x00, 0x02, 0x00 };
+            var r = SrmConverterIdentity.Decode(buf, 1, buf.Length);
+            Assert.Equal("PHUB", r.WheelCode);
+            Assert.Equal(2, r.ModuleRaw);
+            Assert.Equal("PBMR", r.ModuleCode);
+        }
+
+        [Fact]
+        public void DecodeSrmWheel_0x17_IsWrcNotPswbmw()
+        {
+            // The one collision: SRM 0x17 = CSL WRC V2, NOT the Fanatec wire 0x17 alias (PSWBMW).
+            Assert.Equal("CSLESWWRC", SrmConverterIdentity.DecodeSrmWheel(0x17));
+            Assert.Equal("PSWBMW", SrmConverterIdentity.DecodeSrmWheel(0x0F)); // the real PSWBMW id
+        }
+
+        [Fact]
+        public void DecodeSrmWheel_ZeroIsNoRim_UnknownIsNull()
+        {
+            Assert.Null(SrmConverterIdentity.DecodeSrmWheel(0x00)); // no rim attached
+            Assert.Null(SrmConverterIdentity.DecodeSrmWheel(0xEE)); // unmapped id
+        }
+
+        [Fact]
+        public void DecodeSrmWheel_Hubs_ResolveToHubCodes()
+        {
+            Assert.Equal("PHUB", SrmConverterIdentity.DecodeSrmWheel(0x0C));
+            Assert.Equal("CSLSWUH", SrmConverterIdentity.DecodeSrmWheel(0x11));
+            Assert.Equal("CSUHV2", SrmConverterIdentity.DecodeSrmWheel(0x15));
+        }
+    }
+}

--- a/FanaBridge.Tests/SrmConverterIdentityTests.cs
+++ b/FanaBridge.Tests/SrmConverterIdentityTests.cs
@@ -26,8 +26,8 @@ namespace FanaBridge.Tests
         [Fact]
         public void Decode_HubWithModule_ResolvesBoth()
         {
-            // Documented (converter-support §5/§6) but UNVALIDATED: PHUB (0x0C) + PBMR (module 2).
-            // DE FA carries hub and module as separate bytes, so this decodes cleanly.
+            // Documented but UNVALIDATED for SRM converters: PHUB (0x0C) + PBMR (module 2).
+            // DE FA carries the hub and the module as separate bytes, so this decodes cleanly.
             var buf = new byte[] { 0x00, 0xDD, 0x07, 0x00, 0x0C, 0x00, 0x02, 0x00 };
             var r = SrmConverterIdentity.Decode(buf, 1, buf.Length);
             Assert.Equal("PHUB", r.WheelCode);
@@ -56,6 +56,25 @@ namespace FanaBridge.Tests
             Assert.Equal("PHUB", SrmConverterIdentity.DecodeSrmWheel(0x0C));
             Assert.Equal("CSLSWUH", SrmConverterIdentity.DecodeSrmWheel(0x11));
             Assert.Equal("CSUHV2", SrmConverterIdentity.DecodeSrmWheel(0x15));
+        }
+
+        [Fact]
+        public void DecodeSrmWheel_UniversalHubRows_MatchTheWireTable()
+        {
+            // 0x04=CSSWUH, 0x06=CSSWUHX, 0x05=gap — straight from the shared wire table.
+            Assert.Equal("CSSWUH", SrmConverterIdentity.DecodeSrmWheel(0x04));
+            Assert.Equal("CSSWUHX", SrmConverterIdentity.DecodeSrmWheel(0x06));
+            Assert.Null(SrmConverterIdentity.DecodeSrmWheel(0x05)); // gap — no wheel
+        }
+
+        [Fact]
+        public void DecodeSrmWheel_NewerWheels_ResolveViaSharedTable()
+        {
+            // Delegating to the wire table means wheels added there resolve for converters too —
+            // no separate SRM map to drift out of sync.
+            Assert.Equal("CSSWFORMV3", SrmConverterIdentity.DecodeSrmWheel(0x1C));
+            Assert.Equal("GTSWX", SrmConverterIdentity.DecodeSrmWheel(0x18));
+            Assert.Equal("CSLSWGT3", SrmConverterIdentity.DecodeSrmWheel(0x1D));
         }
     }
 }

--- a/FanaBridge/Protocol/ConverterCaptureProbe.cs
+++ b/FanaBridge/Protocol/ConverterCaptureProbe.cs
@@ -10,12 +10,10 @@ namespace FanaBridge.Protocol
     /// an SRM Conversion Kit user contains everything we need to build/validate driverless identity —
     /// no external USB capture, no Fanatec software.
     ///
-    /// It replicates the kernel filter's ENGAGE handshake for the wired SRM classes (id 8 = PID 0x0005,
-    /// id 14 = PID 0x0020): the col03 <c>FF 08</c> enable+trigger, then the col01 SubId triggers. Per
-    /// the RE (command-protocol §3), the SubId triggers are a timed <b>ON(SubId)/OFF(0) pulse with a
-    /// ~100 ms gap</b>, read BETWEEN pulses — so this pulses each SubId and drains col01 in the gap,
-    /// rather than firing them back-to-back, to give a converter's firmware time to volunteer its
-    /// module/rim records. (HostHello/ACQUIRE are NOT part of these classes' engage.)
+    /// It replicates the ENGAGE handshake for the wired SRM classes (PID 0x0005 / 0x0020): the col03
+    /// <c>FF 08</c> enable+trigger, then the col01 SubId triggers. Each SubId is a timed ON/OFF pulse
+    /// with a ~100 ms gap, read between pulses, so a converter's firmware has time to volunteer its
+    /// module/rim records.
     ///
     /// It records, from a single run:
     ///   1. the engage result (which sends the transport accepted),
@@ -124,23 +122,16 @@ namespace FanaBridge.Protocol
             if (wire == 0xFF)
             {
                 byte type = buf[n - 3], b1 = buf[n - 2], b2 = buf[n - 1];
+                // Show the RAW record only — do not interpret the type-1 module byte. col01 is coarse
+                // here (a PBMR and a PBME seemingly both emit b1=0x15), so a "PBME"/"PBMR" label would be
+                // misleading; the module must come from FF 08 / DE FA instead.
                 string note =
-                    type == 0x01 ? "  (button module: " + Col01ModuleName(b1) + ")" :
+                    type == 0x01 ? "  (button-module record — raw; col01 cannot distinguish PBME/PBMR)" :
                     type == 0x02 ? "  (accessories)" : "";
                 return string.Format("EXT_INFO type={0} b1=0x{1:X2} b2=0x{2:X2}{3}", type, b1, b2, note);
             }
             if (wire == 0x00) return "rim: (nothing attached)";
             return string.Format("rim 0x{0:X2} {1}", wire, FanatecIdentity.DecodeCode(wire) ?? "unrecognized");
-        }
-
-        // col01 type-1 DeviceModule byte = FF 08 0x1F raw + 0x14 (FWFUUtilDeviceModulePresenceGet):
-        // 0x15 -> PBME, 0x16 -> PBMR. NOTE: observed COARSE on genuine hardware — both PBMR and PBME
-        // emit 0x15; only FF 08 0x1F carries the fine split. Report the raw b1 regardless.
-        internal static string Col01ModuleName(byte b1)
-        {
-            if (b1 == 0x00) return "none";
-            if (b1 < 0x15) return "?";
-            return FanatecIdentity.DecodeModule((byte)(b1 - 0x14)) ?? "unrecognized";
         }
 
         // Read col03 for an FF 08 system report (the engage already enabled+triggered it).
@@ -170,8 +161,8 @@ namespace FanaBridge.Protocol
         }
 
         // Query the SRM Conversion Kit's DE FA AD -> 0xDD channel on col03. Tries both report-ids
-        // (0xFF emulation gen, 0x00 native/interim); a genuine base answers neither. See converter-
-        // support §3: OUT data = 00 DE FA AD; IN = DD [kitMaj] [kitMin] [wheelId] [wheelFw] [module].
+        // (0xFF and 0x00); a genuine base answers neither. OUT data = 00 DE FA AD;
+        // IN = DD [kitMaj] [kitMin] [wheelId] [wheelFw] [module].
         private static void CaptureDeFa(IDeviceTransport io, Result r)
         {
             foreach (byte reportId in new byte[] { 0xFF, 0x00 })

--- a/FanaBridge/Protocol/ConverterCaptureProbe.cs
+++ b/FanaBridge/Protocol/ConverterCaptureProbe.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using FanaBridge.Transport;
 
 namespace FanaBridge.Protocol
@@ -9,22 +10,28 @@ namespace FanaBridge.Protocol
     /// an SRM Conversion Kit user contains everything we need to build/validate driverless identity —
     /// no external USB capture, no Fanatec software.
     ///
-    /// It replicates the kernel filter's ENGAGE handshake, then records what the device emits on BOTH
-    /// surfaces plus the SRM config channel:
-    ///   1. the engage result (which of the 5 sends the transport accepted),
-    ///   2. every distinct col01 input record (the rim byte, and each EXT_INFO sub-record),
+    /// It replicates the kernel filter's ENGAGE handshake for the wired SRM classes (id 8 = PID 0x0005,
+    /// id 14 = PID 0x0020): the col03 <c>FF 08</c> enable+trigger, then the col01 SubId triggers. Per
+    /// the RE (command-protocol §3), the SubId triggers are a timed <b>ON(SubId)/OFF(0) pulse with a
+    /// ~100 ms gap</b>, read BETWEEN pulses — so this pulses each SubId and drains col01 in the gap,
+    /// rather than firing them back-to-back, to give a converter's firmware time to volunteer its
+    /// module/rim records. (HostHello/ACQUIRE are NOT part of these classes' engage.)
+    ///
+    /// It records, from a single run:
+    ///   1. the engage result (which sends the transport accepted),
+    ///   2. every DISTINCT col01 input record (the rim byte, and each EXT_INFO sub-record),
     ///   3. the col03 <c>FF 08</c> system report, if the device answers one,
     ///   4. the SRM <c>DE FA AD</c> → <c>0xDD</c> identity reply, if it is a Conversion Kit.
     ///
     /// Nothing here writes tuning/config: the engage is the identity handshake, and <c>DE FA AD</c> is
-    /// the SRM config app's "get wheel" query. See the Fanatec-RE converter-support + command-protocol
-    /// docs. Genuine (non-SRM) devices simply return no <c>0xDD</c> reply — the query is harmless.
+    /// the SRM config app's "get wheel" query. Genuine (non-SRM) devices answer no <c>0xDD</c>.
     /// </summary>
     public sealed class ConverterCaptureProbe
     {
         private const int MinCol01Len = 33;         // identity reports are report-id 1, len in {33,34}
-        private const int Col01MaxFrames = 40;      // enough to surface every EXT_INFO record variant
-        private const int Col01ReadTimeoutMs = 25;
+        private const int PulseWindowMs = 110;      // per-SubId col01 read window (~ native Sleep(100) pulse gap)
+        private const int FinalDrainMs = 160;       // trailing drain for anything still streaming
+        private const int Col01ReadTimeoutMs = 20;
         private const int Col03MaxReads = 12;
         private const int Col03ReadTimeoutMs = 40;
 
@@ -40,8 +47,6 @@ namespace FanaBridge.Protocol
             public string DeFaLine;
         }
 
-        private readonly WheelEngage _engage = new WheelEngage();
-
         public Result Run(IDeviceTransport io)
         {
             var r = new Result();
@@ -51,30 +56,52 @@ namespace FanaBridge.Protocol
                 return r;
             }
 
+            var seen = new HashSet<string>();
+            var engage = new List<string>();
+            var sw = new Stopwatch();
+
             // Hold the transport for the whole capture so the runtime's frames don't interleave ours.
             using (io.BeginBatch())
             {
-                try { r.Engage = FormatEngage(_engage.Engage(io)); }
-                catch (Exception ex) { r.Engage = "engage FAILED: " + ex.Message; }
+                // col03 FF 08 enable + trigger.
+                engage.Add("FF08 enable:" + Ok(() => io.SendCol03(Ff08(0x01, 0xFF))));
+                engage.Add("FF08 trigger:" + Ok(() => io.SendCol03(Ff08(0x02, 0x00))));
 
-                CaptureCol01(io, r);
+                // col01 SubId pulses. Each ON is followed by a read window (the native ON/Sleep(100)/OFF
+                // pulse) so the device has time to respond and we capture the response in-line.
+                Pulse(io, 0x01, "SubId=1 module", engage, seen, r, sw);
+                Pulse(io, 0x00, "SubId=0 input", engage, seen, r, sw);
+                Pulse(io, 0x04, "SubId=4", engage, seen, r, sw);
+                Pulse(io, 0x00, "SubId=0 deassert", engage, seen, r, sw);
+
+                // Trailing drain for anything still streaming after the pulses.
+                DrainCol01(io, FinalDrainMs, seen, r, sw);
+                r.Engage = "engage[" + string.Join("  ", engage) + "]";
+
                 CaptureFf08(io, r);
                 CaptureDeFa(io, r);
             }
             return r;
         }
 
-        // Read a burst of col01 frames and record each DISTINCT tail record (deduped by decoded
-        // meaning, not raw bytes — the axis fields change every frame). A representative frame's hex
-        // is kept with each record so the exact wire bytes are reportable.
-        private static void CaptureCol01(IDeviceTransport io, Result r)
+        private static void Pulse(IDeviceTransport io, byte subId, string label,
+            List<string> engage, HashSet<string> seen, Result r, Stopwatch sw)
+        {
+            engage.Add(label + ":" + Ok(() => io.SendCol01(WheelEngage.SubId(subId))));
+            DrainCol01(io, PulseWindowMs, seen, r, sw);
+        }
+
+        // Read col01 for ~windowMs, recording each DISTINCT tail record (deduped by decoded meaning,
+        // not raw bytes — the axis fields change every frame). A representative frame's hex is kept
+        // with each record so the exact wire bytes are reportable.
+        private static void DrainCol01(IDeviceTransport io, int windowMs, HashSet<string> seen, Result r, Stopwatch sw)
         {
             int len = io.Col01MaxInputReportLength;
             if (len < MinCol01Len) len = 34;
             var buf = new byte[len];
-            var seen = new HashSet<string>();
 
-            for (int i = 0; i < Col01MaxFrames; i++)
+            sw.Restart();
+            while (sw.ElapsedMilliseconds < windowMs)
             {
                 int n = io.ReadCol01(buf, Col01ReadTimeoutMs);
                 if (n <= 0) continue;
@@ -187,11 +214,18 @@ namespace FanaBridge.Protocol
                 wheelId == 0 ? "   (no rim attached)" : "");
         }
 
-        private static string FormatEngage(WheelEngage.Step[] steps)
+        private static string Ok(Func<bool> send)
         {
-            var parts = new List<string>(steps.Length);
-            foreach (var s in steps) parts.Add(s.Label + ":" + (s.Sent ? "ok" : "FAIL"));
-            return "engage[" + string.Join("  ", parts) + "]";
+            try { return send() ? "ok" : "FAIL"; }
+            catch { return "ERR"; }
+        }
+
+        // FF 08 <b2> <b3> control report (64-byte): FF 08 01 FF = enable, FF 08 02 00 = trigger.
+        private static byte[] Ff08(byte b2, byte b3)
+        {
+            var b = new byte[64];
+            b[0] = 0xFF; b[1] = 0x08; b[2] = b2; b[3] = b3;
+            return b;
         }
 
         // FF 08-style signature scan (tolerates a leading report-id byte).

--- a/FanaBridge/Protocol/ConverterCaptureProbe.cs
+++ b/FanaBridge/Protocol/ConverterCaptureProbe.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using FanaBridge.Transport;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// One-shot, read-only identity capture run at diagnostics time so a SINGLE detection report from
+    /// an SRM Conversion Kit user contains everything we need to build/validate driverless identity —
+    /// no external USB capture, no Fanatec software.
+    ///
+    /// It replicates the kernel filter's ENGAGE handshake, then records what the device emits on BOTH
+    /// surfaces plus the SRM config channel:
+    ///   1. the engage result (which of the 5 sends the transport accepted),
+    ///   2. every distinct col01 input record (the rim byte, and each EXT_INFO sub-record),
+    ///   3. the col03 <c>FF 08</c> system report, if the device answers one,
+    ///   4. the SRM <c>DE FA AD</c> → <c>0xDD</c> identity reply, if it is a Conversion Kit.
+    ///
+    /// Nothing here writes tuning/config: the engage is the identity handshake, and <c>DE FA AD</c> is
+    /// the SRM config app's "get wheel" query. See the Fanatec-RE converter-support + command-protocol
+    /// docs. Genuine (non-SRM) devices simply return no <c>0xDD</c> reply — the query is harmless.
+    /// </summary>
+    public sealed class ConverterCaptureProbe
+    {
+        private const int MinCol01Len = 33;         // identity reports are report-id 1, len in {33,34}
+        private const int Col01MaxFrames = 40;      // enough to surface every EXT_INFO record variant
+        private const int Col01ReadTimeoutMs = 25;
+        private const int Col03MaxReads = 12;
+        private const int Col03ReadTimeoutMs = 40;
+
+        /// <summary>The captured surfaces. Any field may be null when that surface stayed silent.</summary>
+        public sealed class Result
+        {
+            public string Engage;
+            public readonly List<string> Col01Records = new List<string>();
+            public int Col01FramesRead;
+            public string Ff08Raw;
+            public string Ff08Line;
+            public string DeFaRaw;
+            public string DeFaLine;
+        }
+
+        private readonly WheelEngage _engage = new WheelEngage();
+
+        public Result Run(IDeviceTransport io)
+        {
+            var r = new Result();
+            if (io == null || !io.IsConnected)
+            {
+                r.Engage = "(not connected)";
+                return r;
+            }
+
+            // Hold the transport for the whole capture so the runtime's frames don't interleave ours.
+            using (io.BeginBatch())
+            {
+                try { r.Engage = FormatEngage(_engage.Engage(io)); }
+                catch (Exception ex) { r.Engage = "engage FAILED: " + ex.Message; }
+
+                CaptureCol01(io, r);
+                CaptureFf08(io, r);
+                CaptureDeFa(io, r);
+            }
+            return r;
+        }
+
+        // Read a burst of col01 frames and record each DISTINCT tail record (deduped by decoded
+        // meaning, not raw bytes — the axis fields change every frame). A representative frame's hex
+        // is kept with each record so the exact wire bytes are reportable.
+        private static void CaptureCol01(IDeviceTransport io, Result r)
+        {
+            int len = io.Col01MaxInputReportLength;
+            if (len < MinCol01Len) len = 34;
+            var buf = new byte[len];
+            var seen = new HashSet<string>();
+
+            for (int i = 0; i < Col01MaxFrames; i++)
+            {
+                int n = io.ReadCol01(buf, Col01ReadTimeoutMs);
+                if (n <= 0) continue;
+                r.Col01FramesRead++;
+                if (n < MinCol01Len || buf[0] != 0x01) continue; // report-id 1 = the identity report
+
+                string decode = DescribeCol01Tail(buf, n);
+                if (decode != null && seen.Add(decode))
+                    r.Col01Records.Add(Hex(buf, n) + "  -> " + decode);
+            }
+        }
+
+        // Classify a col01 report by its identity tail. [len-4] is the rim/EXT_INFO byte; under
+        // EXT_INFO the 4-byte tail is [len-4]=FF | [len-3]=type | [len-2]=b1 | [len-1]=b2.
+        internal static string DescribeCol01Tail(byte[] buf, int n)
+        {
+            if (buf == null || n < MinCol01Len) return null;
+            byte wire = buf[n - 4];
+
+            if (wire == 0xFF)
+            {
+                byte type = buf[n - 3], b1 = buf[n - 2], b2 = buf[n - 1];
+                string note =
+                    type == 0x01 ? "  (button module: " + Col01ModuleName(b1) + ")" :
+                    type == 0x02 ? "  (accessories)" : "";
+                return string.Format("EXT_INFO type={0} b1=0x{1:X2} b2=0x{2:X2}{3}", type, b1, b2, note);
+            }
+            if (wire == 0x00) return "rim: (nothing attached)";
+            return string.Format("rim 0x{0:X2} {1}", wire, FanatecIdentity.DecodeCode(wire) ?? "unrecognized");
+        }
+
+        // col01 type-1 DeviceModule byte = FF 08 0x1F raw + 0x14 (FWFUUtilDeviceModulePresenceGet):
+        // 0x15 -> PBME, 0x16 -> PBMR. NOTE: observed COARSE on genuine hardware — both PBMR and PBME
+        // emit 0x15; only FF 08 0x1F carries the fine split. Report the raw b1 regardless.
+        internal static string Col01ModuleName(byte b1)
+        {
+            if (b1 == 0x00) return "none";
+            if (b1 < 0x15) return "?";
+            return FanatecIdentity.DecodeModule((byte)(b1 - 0x14)) ?? "unrecognized";
+        }
+
+        // Read col03 for an FF 08 system report (the engage already enabled+triggered it).
+        private static void CaptureFf08(IDeviceTransport io, Result r)
+        {
+            int len = io.Col03MaxInputReportLength;
+            if (len < 64) len = 64;
+            var buf = new byte[len];
+
+            for (int i = 0; i < Col03MaxReads; i++)
+            {
+                int n = io.ReadCol03(buf, Col03ReadTimeoutMs);
+                if (n <= 0) break;
+
+                int sig = FindPair(buf, n, 0xFF, 0x08);
+                if (sig < 0 || n < sig + 0x20) continue;
+
+                r.Ff08Raw = Hex(buf, n);
+                byte baseType = buf[sig + 0x02], wire = buf[sig + 0x18], mod = buf[sig + 0x1F];
+                r.Ff08Line = string.Format(
+                    "base [0x02]=0x{0:X2} {1}   rim [0x18]=0x{2:X2} {3}   module [0x1F]=0x{4:X2} {5}",
+                    baseType, FanatecIdentity.DecodeBaseCode(baseType) ?? "unrecognized",
+                    wire, FanatecIdentity.DecodeCode(wire) ?? "unrecognized",
+                    mod, FanatecIdentity.DecodeModule(mod) ?? "none");
+                return;
+            }
+        }
+
+        // Query the SRM Conversion Kit's DE FA AD -> 0xDD channel on col03. Tries both report-ids
+        // (0xFF emulation gen, 0x00 native/interim); a genuine base answers neither. See converter-
+        // support §3: OUT data = 00 DE FA AD; IN = DD [kitMaj] [kitMin] [wheelId] [wheelFw] [module].
+        private static void CaptureDeFa(IDeviceTransport io, Result r)
+        {
+            foreach (byte reportId in new byte[] { 0xFF, 0x00 })
+            {
+                var outRep = new byte[64];
+                outRep[0] = reportId;                       // report-id
+                outRep[1] = 0x00;                           // data[0] = channel/sub byte
+                outRep[2] = 0xDE; outRep[3] = 0xFA; outRep[4] = 0xAD; // magic + cmd AD (get-wheel)
+                try { if (!io.SendCol03(outRep)) continue; }
+                catch { continue; }
+
+                int len = io.Col03MaxInputReportLength;
+                if (len < 64) len = 64;
+                var buf = new byte[len];
+
+                for (int i = 0; i < Col03MaxReads; i++)
+                {
+                    int n = io.ReadCol03(buf, Col03ReadTimeoutMs);
+                    if (n <= 0) break;
+
+                    int sig = FindByte(buf, n, 0xDD, 3); // scan first 3 bytes for the 0xDD signature
+                    if (sig < 0 || n < sig + 6) continue;
+
+                    r.DeFaRaw = Hex(buf, n);
+                    r.DeFaLine = DescribeDeFa(buf, sig, reportId);
+                    return;
+                }
+            }
+            r.DeFaLine = "(no 0xDD reply — not an SRM Conversion Kit, or a gen that doesn't answer DE FA AD)";
+        }
+
+        // Decode a 0xDD identity reply: DD [kitMaj] [kitMin(BCD)] [wheelId] [wheelFw] [module 1=PBME,2=PBMR].
+        internal static string DescribeDeFa(byte[] buf, int sig, byte reportId)
+        {
+            byte kitMaj = buf[sig + 1], kitMin = buf[sig + 2], wheelId = buf[sig + 3], wheelFw = buf[sig + 4], module = buf[sig + 5];
+            string mod = module == 1 ? "PBME" : module == 2 ? "PBMR" : module == 0 ? "none" : "0x" + module.ToString("X2");
+            return string.Format(
+                "SRM Conversion Kit (report-id 0x{0:X2}): kit fw {1}.{2:X2}   wheelId=0x{3:X2}   wheel fw={4}   module={5}{6}",
+                reportId, kitMaj, kitMin, wheelId, wheelFw, mod,
+                wheelId == 0 ? "   (no rim attached)" : "");
+        }
+
+        private static string FormatEngage(WheelEngage.Step[] steps)
+        {
+            var parts = new List<string>(steps.Length);
+            foreach (var s in steps) parts.Add(s.Label + ":" + (s.Sent ? "ok" : "FAIL"));
+            return "engage[" + string.Join("  ", parts) + "]";
+        }
+
+        // FF 08-style signature scan (tolerates a leading report-id byte).
+        private static int FindPair(byte[] buf, int n, byte a, byte b)
+        {
+            for (int i = 0; i <= 2 && i + 1 < n; i++)
+                if (buf[i] == a && buf[i + 1] == b) return i;
+            return -1;
+        }
+
+        private static int FindByte(byte[] buf, int n, byte val, int within)
+        {
+            for (int i = 0; i < within && i < n; i++)
+                if (buf[i] == val) return i;
+            return -1;
+        }
+
+        private static string Hex(byte[] buf, int n)
+            => BitConverter.ToString(buf, 0, n).Replace('-', ' ');
+    }
+}

--- a/FanaBridge/Protocol/DiagnosticsReport.cs
+++ b/FanaBridge/Protocol/DiagnosticsReport.cs
@@ -16,14 +16,14 @@ namespace FanaBridge.Protocol
     /// FanaBridge already drained (identity + firmware versions), flags the col03 control
     /// interface the same way the transport selects it (the &amp;col03 path token, else a
     /// 64-byte OUTPUT report), and takes a col01 input snapshot. It also runs one ACTIVE
-    /// "converter identity probe" — the kernel filter's engage handshake plus the SRM
-    /// <c>DE FA AD</c> query — then dumps what the device volunteers on both surfaces and the
-    /// SRM <c>0xDD</c> channel. The only writes are identity handshakes, never tuning/config.
+    /// "converter identity probe" — the engage handshake plus the SRM <c>DE FA AD</c> query —
+    /// then dumps what the device volunteers on both surfaces and the SRM <c>0xDD</c> channel.
+    /// The only writes are identity handshakes, never tuning/config.
     ///
     /// The output is a fenced Markdown block ready to paste into a GitHub issue,
     /// emitting the same wire bytes (raw FF 08 hex + the 0x02/0x18/0x1F key bytes)
-    /// as every existing RE capture, so an unrecognized wheel/hub/module is
-    /// byte-comparable and directly reportable.
+    /// as a raw USB capture, so an unrecognized wheel/hub/module is byte-comparable
+    /// and directly reportable.
     /// </summary>
     public static class DiagnosticsReport
     {
@@ -74,12 +74,10 @@ namespace FanaBridge.Protocol
         }
 
         // ── Converter identity probe (active engage) ─────────────────────
-        // The passive FF 08 section above is the device's RESTING state. This actively runs the
-        // kernel filter's engage handshake and dumps what the device volunteers on BOTH surfaces
-        // (col01 records + the col03 FF 08 report) plus the SRM DE FA AD -> 0xDD channel — so a
-        // SINGLE report from an SRM Conversion Kit user carries everything needed to build and
-        // validate driverless identity, with no external USB capture. Read-only; a genuine base
-        // just answers no 0xDD.
+        // The passive FF 08 section above is the device's resting state. This actively runs the engage
+        // handshake and dumps what the device volunteers on both surfaces (col01 records + the col03
+        // FF 08 report) plus the SRM DE FA AD -> 0xDD channel, so a single report from an SRM Conversion
+        // Kit user carries everything needed to identify it. Read-only; a genuine base answers no 0xDD.
         private static void AppendConverterProbe(StringBuilder sb, FanatecWheelbase wb, bool connected)
         {
             sb.AppendLine("Converter identity probe (active engage — read-only):");

--- a/FanaBridge/Protocol/DiagnosticsReport.cs
+++ b/FanaBridge/Protocol/DiagnosticsReport.cs
@@ -12,11 +12,13 @@ namespace FanaBridge.Protocol
     /// live transport FanaBridge already holds open (so there is no need to close
     /// SimHub or run an external tool).
     ///
-    /// Read-only: it re-enumerates the HID bus, decodes the last FF 08 system report
+    /// Mostly read-only: it re-enumerates the HID bus, decodes the last FF 08 system report
     /// FanaBridge already drained (identity + firmware versions), flags the col03 control
     /// interface the same way the transport selects it (the &amp;col03 path token, else a
-    /// 64-byte OUTPUT report), and takes one best-effort, motion-gated col01 input
-    /// snapshot. It never writes to the device.
+    /// 64-byte OUTPUT report), and takes a col01 input snapshot. It also runs one ACTIVE
+    /// "converter identity probe" — the kernel filter's engage handshake plus the SRM
+    /// <c>DE FA AD</c> query — then dumps what the device volunteers on both surfaces and the
+    /// SRM <c>0xDD</c> channel. The only writes are identity handshakes, never tuning/config.
     ///
     /// The output is a fenced Markdown block ready to paste into a GitHub issue,
     /// emitting the same wire bytes (raw FF 08 hex + the 0x02/0x18/0x1F key bytes)
@@ -33,7 +35,8 @@ namespace FanaBridge.Protocol
 
             sb.AppendLine("### FanaBridge detection report");
             sb.AppendLine();
-            sb.AppendLine("> Describe what's physically attached (wheelbase, wheel/hub, button module).");
+            sb.AppendLine("> Describe what's physically attached: wheelbase **or SRM converter** (model + firmware),");
+            sb.AppendLine("> the wheel/hub (+ button module), and — for a converter — what the SRM software shows.");
             sb.AppendLine();
             sb.AppendLine("```");
             sb.AppendLine(string.Format("{0,-13}{1}", "FanaBridge:", string.IsNullOrEmpty(buildInfo) ? "unknown" : buildInfo));
@@ -47,6 +50,8 @@ namespace FanaBridge.Protocol
             AppendInterfaceInventory(sb);
             sb.AppendLine();
             AppendSystemReport(sb, wheelbase, connected, statusDetail);
+            sb.AppendLine();
+            AppendConverterProbe(sb, wheelbase, connected);
             sb.AppendLine();
             AppendInputProbe(sb);
             sb.AppendLine();
@@ -66,6 +71,44 @@ namespace FanaBridge.Protocol
 
             sb.AppendLine("```");
             return sb.ToString();
+        }
+
+        // ── Converter identity probe (active engage) ─────────────────────
+        // The passive FF 08 section above is the device's RESTING state. This actively runs the
+        // kernel filter's engage handshake and dumps what the device volunteers on BOTH surfaces
+        // (col01 records + the col03 FF 08 report) plus the SRM DE FA AD -> 0xDD channel — so a
+        // SINGLE report from an SRM Conversion Kit user carries everything needed to build and
+        // validate driverless identity, with no external USB capture. Read-only; a genuine base
+        // just answers no 0xDD.
+        private static void AppendConverterProbe(StringBuilder sb, FanatecWheelbase wb, bool connected)
+        {
+            sb.AppendLine("Converter identity probe (active engage — read-only):");
+            if (!connected || wb?.Transport == null || !wb.Transport.IsConnected)
+            {
+                sb.AppendLine("  (not connected — connect the device and re-capture)");
+                return;
+            }
+
+            ConverterCaptureProbe.Result r;
+            try { r = new ConverterCaptureProbe().Run(wb.Transport); }
+            catch (Exception ex) { sb.AppendLine("  (probe failed: " + ex.Message + ")"); return; }
+
+            sb.AppendLine(Kv("Engage", r.Engage ?? "(none)"));
+
+            sb.AppendLine(Kv("col01 records", r.Col01Records.Count + " distinct in " + r.Col01FramesRead + " frame(s):"));
+            if (r.Col01Records.Count == 0)
+                sb.AppendLine("      (no col01 input reports arrived)");
+            else
+                foreach (var rec in r.Col01Records)
+                    sb.AppendLine("      " + rec);
+
+            sb.AppendLine(Kv("col03 FF 08", r.Ff08Line ?? "(no FF 08 report — SRM converter or under-engaged)"));
+            if (r.Ff08Raw != null)
+                sb.AppendLine("      raw: " + r.Ff08Raw);
+
+            sb.AppendLine(Kv("SRM DE FA AD", r.DeFaLine ?? "(no reply)"));
+            if (r.DeFaRaw != null)
+                sb.AppendLine("      raw: " + r.DeFaRaw);
         }
 
         // ── HID interface inventory ──────────────────────────────────────

--- a/FanaBridge/Protocol/DiagnosticsReport.cs
+++ b/FanaBridge/Protocol/DiagnosticsReport.cs
@@ -411,6 +411,23 @@ namespace FanaBridge.Protocol
             byte[] raw = wb?.LastRawReport;
             if (!connected || wb == null || raw == null || raw.Length == 0)
             {
+                // A committed SRM converter identity has no FF 08 frame (it came from the DE FA
+                // channel) — surface it so the report doesn't read as "unidentified".
+                if (wb != null && wb.IsSrmConverter)
+                {
+                    sb.AppendLine(Kv("Identity source", "SRM Conversion Kit (DE FA channel — no FF 08)"));
+                    sb.AppendLine(Kv("Steering wheel", wb.WheelDetected
+                        ? (wb.WheelCode ?? string.Format("Unknown (id 0x{0:X2})", wb.WheelWireCode))
+                            + (wb.IsHub ? " [hub]" : "")
+                        : "(nothing attached)"));
+                    if (wb.IsHub)
+                        sb.AppendLine(Kv("Button module", (wb.ModuleCode
+                            ?? (wb.ModuleWireCode != 0 ? string.Format("Unknown (0x{0:X2})", wb.ModuleWireCode) : "(none)"))
+                            + (wb.ModuleWireCode != 0 ? "   [converter-module decode UNVALIDATED — please report]" : "")));
+                    sb.AppendLine(Kv("Kit firmware", wb.SrmKitFirmware ?? "?"));
+                    return;
+                }
+
                 sb.AppendLine("  (no FF 08 captured — not connected, no col03 interface, or no wheel");
                 sb.AppendLine("   attached. If a wheel IS attached, a full USB capture may be needed —");
                 sb.AppendLine("   see the Fanatec-RE capture-fanatec-usb.ps1 workflow.)");

--- a/FanaBridge/Protocol/SrmConverterIdentity.cs
+++ b/FanaBridge/Protocol/SrmConverterIdentity.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using FanaBridge.Transport;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// SRM Conversion Kit identity, recovered from the kit's private <c>DE FA AD</c> → <c>0xDD</c>
+    /// channel on col03. A converter emulates a Fanatec base but does NOT reliably emit <c>FF 08</c>,
+    /// and its wheel is hard-wired (there is no wheel-swap), so identity is a ONE-SHOT resolved at
+    /// connect and held fixed until the unit is unplugged.
+    ///
+    /// The caller gates this behind <c>FF 08</c> SILENCE: a genuine base answers <c>FF 08</c> and
+    /// never answers <c>0xDD</c>, so it never reaches this path — the converter support cannot affect
+    /// normal hardware. Read/identify-only: <c>DE FA AD</c> is the SRM config app's "get wheel" query;
+    /// it never writes tuning/flash (never <c>DE FA AC/CE</c>). Validated against real hardware
+    /// (simanthrop, kit fw 6.12 / 7.06 → wheelId 0x0A). See fanabridge-converter-support.md §3/§5/§6.
+    /// </summary>
+    internal sealed class SrmConverterIdentity
+    {
+        /// <summary>A decoded <c>0xDD</c> identity reply.</summary>
+        internal struct Result
+        {
+            public byte WheelId;       // == the Fanatec wire byte (except 0x17)
+            public string WheelCode;   // FanaBridge/SWTYPE code ("CSSWFORMV2", "PHUB", …), or null if unknown id
+            public byte ModuleRaw;     // 0/1/2 — the SAME encoding as FF 08 byte 0x1F
+            public string ModuleCode;  // "PBME"/"PBMR"/null
+            public string KitFirmware; // e.g. "6.12"
+            public byte[] Raw;         // the 0xDD reply frame, for diagnostics
+        }
+
+        private const int Col03Len = 64;
+        private const int MaxReads = 12;
+        private const int ReadTimeoutMs = 40;
+
+        /// <summary>
+        /// Sends <c>DE FA AD</c> (report-id 0xFF, then 0x00) and, on a <c>0xDD</c> reply, decodes the
+        /// converter identity. Returns false when no <c>0xDD</c> arrives (a genuine base, an 8x kit,
+        /// or kit fw &lt; 4.1).
+        /// </summary>
+        public bool TryProbe(IDeviceTransport io, out Result result)
+        {
+            result = default;
+            if (io == null || !io.IsConnected) return false;
+
+            using (io.BeginBatch())
+            {
+                foreach (byte reportId in new byte[] { 0xFF, 0x00 })
+                {
+                    var outRep = new byte[Col03Len];
+                    outRep[0] = reportId;                        // report-id
+                    outRep[1] = 0x00;                            // data[0] = channel/sub byte
+                    outRep[2] = 0xDE; outRep[3] = 0xFA; outRep[4] = 0xAD; // magic + cmd AD (get-wheel)
+                    try { if (!io.SendCol03(outRep)) continue; }
+                    catch { continue; }
+
+                    int len = io.Col03MaxInputReportLength;
+                    if (len < Col03Len) len = Col03Len;
+                    var buf = new byte[len];
+                    for (int i = 0; i < MaxReads; i++)
+                    {
+                        int n = io.ReadCol03(buf, ReadTimeoutMs);
+                        if (n <= 0) break;
+
+                        int sig = FindByte(buf, n, 0xDD, 3); // scan first 3 bytes for the 0xDD signature
+                        if (sig < 0 || n < sig + 6) continue;
+
+                        result = Decode(buf, sig, n);
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        // 0xDD reply: DD [kitMaj] [kitMin BCD] [wheelId] [wheelFw] [module 1=PBME,2=PBMR].
+        internal static Result Decode(byte[] buf, int sig, int n)
+        {
+            byte wheelId = buf[sig + 3], module = buf[sig + 5];
+            var raw = new byte[n];
+            Array.Copy(buf, raw, n);
+            return new Result
+            {
+                WheelId = wheelId,
+                WheelCode = DecodeSrmWheel(wheelId),
+                ModuleRaw = module,
+                ModuleCode = FanatecIdentity.DecodeModule(module), // 1=PBME, 2=PBMR (1:1 with FF 08 0x1F)
+                KitFirmware = buf[sig + 1] + "." + buf[sig + 2].ToString("X2"),
+                Raw = raw,
+            };
+        }
+
+        /// <summary>SRM wheelId → FanaBridge code, or null (0 = no rim attached; unmapped = unknown id).</summary>
+        internal static string DecodeSrmWheel(byte wheelId)
+            => wheelId == 0 ? null
+             : SrmWheelMap.TryGetValue(wheelId, out var code) ? code
+             : null;
+
+        // From fanabridge-converter-support.md §6 (SRM firmware #defines). Numerically identical to
+        // the Fanatec wire byte for every wheel EXCEPT 0x17 (SRM = CSLESWWRC; Fanatec wire 0x17 =
+        // PSWBMW). Rows 0x04/0x05/0x06 are flagged low-confidence pending hardware. Includes hubs
+        // (PHUB 0x0C, CSLSWUH 0x11, CSUHV2 0x15, …), so a hub+module through a kit resolves too.
+        internal static readonly IReadOnlyDictionary<byte, string> SrmWheelMap = new Dictionary<byte, string>
+        {
+            { 0x01, "CSSWBMW"     }, { 0x02, "CSSWFORM"    }, { 0x03, "CSSWPORSCHE" }, { 0x04, "CSSWUH"      },
+            { 0x05, "CSSWUHX"     }, { 0x06, "CSSWUH"      }, { 0x07, "CSLESWP1X"   }, { 0x08, "CSLESWP1PS4" },
+            { 0x09, "CSLESWMCL"   }, { 0x0A, "CSSWFORMV2"  }, { 0x0B, "CSLESWMCLV2" }, { 0x0C, "PHUB"        },
+            { 0x0E, "PSWBENT"     }, { 0x0F, "PSWBMW"      }, { 0x10, "GTSWPRO"     }, { 0x11, "CSLSWUH"     },
+            { 0x12, "CSLESWWRC"   }, { 0x13, "CSSWBMWV2"   }, { 0x14, "CSSWRS"      }, { 0x15, "CSUHV2"      },
+            { 0x16, "CSSWF1ESV2"  }, { 0x17, "CSLESWWRC"   },
+        };
+
+        private static int FindByte(byte[] buf, int n, byte val, int within)
+        {
+            for (int i = 0; i < within && i < n; i++)
+                if (buf[i] == val) return i;
+            return -1;
+        }
+    }
+}

--- a/FanaBridge/Protocol/SrmConverterIdentity.cs
+++ b/FanaBridge/Protocol/SrmConverterIdentity.cs
@@ -1,20 +1,14 @@
 using System;
-using System.Collections.Generic;
 using FanaBridge.Transport;
 
 namespace FanaBridge.Protocol
 {
     /// <summary>
     /// SRM Conversion Kit identity, recovered from the kit's private <c>DE FA AD</c> → <c>0xDD</c>
-    /// channel on col03. A converter emulates a Fanatec base but does NOT reliably emit <c>FF 08</c>,
-    /// and its wheel is hard-wired (there is no wheel-swap), so identity is a ONE-SHOT resolved at
-    /// connect and held fixed until the unit is unplugged.
-    ///
-    /// The caller gates this behind <c>FF 08</c> SILENCE: a genuine base answers <c>FF 08</c> and
-    /// never answers <c>0xDD</c>, so it never reaches this path — the converter support cannot affect
-    /// normal hardware. Read/identify-only: <c>DE FA AD</c> is the SRM config app's "get wheel" query;
-    /// it never writes tuning/flash (never <c>DE FA AC/CE</c>). Validated against real hardware
-    /// (simanthrop, kit fw 6.12 / 7.06 → wheelId 0x0A). See fanabridge-converter-support.md §3/§5/§6.
+    /// channel on col03. A converter emulates a Fanatec base but does not reliably emit <c>FF 08</c>,
+    /// and its wheel is hard-wired, so identity is a one-shot resolved at connect and held until the
+    /// unit is unplugged. Read/identify-only. The caller reaches this only when <c>FF 08</c> is silent;
+    /// a genuine base answers <c>FF 08</c> and never <c>0xDD</c>, so normal hardware is unaffected.
     /// </summary>
     internal sealed class SrmConverterIdentity
     {
@@ -30,47 +24,37 @@ namespace FanaBridge.Protocol
         }
 
         private const int Col03Len = 64;
-        private const int MaxReads = 12;
-        private const int ReadTimeoutMs = 40;
 
         /// <summary>
-        /// Sends <c>DE FA AD</c> (report-id 0xFF, then 0x00) and, on a <c>0xDD</c> reply, decodes the
-        /// converter identity. Returns false when no <c>0xDD</c> arrives (a genuine base, an 8x kit,
-        /// or kit fw &lt; 4.1).
+        /// Sends the <c>DE FA AD</c> query on col03 (report-id 0xFF, then 0x00). Send-only: the reply is
+        /// picked up by the shared col03 read dispatch, so it can never consume a genuine FF 08 frame.
+        /// Harmless to a genuine base (which does not answer).
         /// </summary>
-        public bool TryProbe(IDeviceTransport io, out Result result)
+        public void SendQuery(IDeviceTransport io)
+        {
+            if (io == null) return;
+            foreach (byte reportId in new byte[] { 0xFF, 0x00 })
+            {
+                var outRep = new byte[Col03Len];
+                outRep[0] = reportId;                        // report-id
+                outRep[1] = 0x00;                            // data[0] = channel/sub byte
+                outRep[2] = 0xDE; outRep[3] = 0xFA; outRep[4] = 0xAD; // magic + cmd AD (get-wheel)
+                try { io.SendCol03(outRep); } catch { /* transient */ }
+            }
+        }
+
+        /// <summary>
+        /// Decode a col03 frame if it is a <c>0xDD</c> reply. The signature sits at offset 0 or 1 only,
+        /// so an FF 08 / FF 05 frame can never be mistaken for a converter reply.
+        /// </summary>
+        public static bool TryDecodeFrame(byte[] buf, int n, out Result result)
         {
             result = default;
-            if (io == null || !io.IsConnected) return false;
-
-            using (io.BeginBatch())
-            {
-                foreach (byte reportId in new byte[] { 0xFF, 0x00 })
-                {
-                    var outRep = new byte[Col03Len];
-                    outRep[0] = reportId;                        // report-id
-                    outRep[1] = 0x00;                            // data[0] = channel/sub byte
-                    outRep[2] = 0xDE; outRep[3] = 0xFA; outRep[4] = 0xAD; // magic + cmd AD (get-wheel)
-                    try { if (!io.SendCol03(outRep)) continue; }
-                    catch { continue; }
-
-                    int len = io.Col03MaxInputReportLength;
-                    if (len < Col03Len) len = Col03Len;
-                    var buf = new byte[len];
-                    for (int i = 0; i < MaxReads; i++)
-                    {
-                        int n = io.ReadCol03(buf, ReadTimeoutMs);
-                        if (n <= 0) break;
-
-                        int sig = FindByte(buf, n, 0xDD, 3); // scan first 3 bytes for the 0xDD signature
-                        if (sig < 0 || n < sig + 6) continue;
-
-                        result = Decode(buf, sig, n);
-                        return true;
-                    }
-                }
-            }
-            return false;
+            if (buf == null) return false;
+            int sig = FindByte(buf, n, 0xDD, 2);
+            if (sig < 0 || n < sig + 6) return false;
+            result = Decode(buf, sig, n);
+            return true;
         }
 
         // 0xDD reply: DD [kitMaj] [kitMin BCD] [wheelId] [wheelFw] [module 1=PBME,2=PBMR].
@@ -90,25 +74,16 @@ namespace FanaBridge.Protocol
             };
         }
 
-        /// <summary>SRM wheelId → FanaBridge code, or null (0 = no rim attached; unmapped = unknown id).</summary>
+        /// <summary>
+        /// SRM wheelId → FanaBridge code, or null (0 = no rim; unmapped = unknown id). The SRM id is
+        /// the Fanatec wire byte, so this delegates to the shared wire table (wheels and hubs) — the
+        /// one exception is 0x17 (SRM = CSL WRC V2, where the Fanatec wire 0x17 = PSWBMW).
+        /// TODO: validate the SRM 0x17 = CSL WRC V2 claim; it is documented but untested.
+        /// </summary>
         internal static string DecodeSrmWheel(byte wheelId)
-            => wheelId == 0 ? null
-             : SrmWheelMap.TryGetValue(wheelId, out var code) ? code
-             : null;
-
-        // From fanabridge-converter-support.md §6 (SRM firmware #defines). Numerically identical to
-        // the Fanatec wire byte for every wheel EXCEPT 0x17 (SRM = CSLESWWRC; Fanatec wire 0x17 =
-        // PSWBMW). Rows 0x04/0x05/0x06 are flagged low-confidence pending hardware. Includes hubs
-        // (PHUB 0x0C, CSLSWUH 0x11, CSUHV2 0x15, …), so a hub+module through a kit resolves too.
-        internal static readonly IReadOnlyDictionary<byte, string> SrmWheelMap = new Dictionary<byte, string>
-        {
-            { 0x01, "CSSWBMW"     }, { 0x02, "CSSWFORM"    }, { 0x03, "CSSWPORSCHE" }, { 0x04, "CSSWUH"      },
-            { 0x05, "CSSWUHX"     }, { 0x06, "CSSWUH"      }, { 0x07, "CSLESWP1X"   }, { 0x08, "CSLESWP1PS4" },
-            { 0x09, "CSLESWMCL"   }, { 0x0A, "CSSWFORMV2"  }, { 0x0B, "CSLESWMCLV2" }, { 0x0C, "PHUB"        },
-            { 0x0E, "PSWBENT"     }, { 0x0F, "PSWBMW"      }, { 0x10, "GTSWPRO"     }, { 0x11, "CSLSWUH"     },
-            { 0x12, "CSLESWWRC"   }, { 0x13, "CSSWBMWV2"   }, { 0x14, "CSSWRS"      }, { 0x15, "CSUHV2"      },
-            { 0x16, "CSSWF1ESV2"  }, { 0x17, "CSLESWWRC"   },
-        };
+            => wheelId == 0x00 ? null
+             : wheelId == 0x17 ? "CSLESWWRC"
+             : FanatecIdentity.DecodeCode(wheelId);
 
         private static int FindByte(byte[] buf, int n, byte val, int within)
         {

--- a/FanaBridge/Protocol/SystemReportReader.cs
+++ b/FanaBridge/Protocol/SystemReportReader.cs
@@ -11,6 +11,8 @@ namespace FanaBridge.Protocol
     /// After a single <see cref="Enable"/> the base PUSHES this report on every
     /// attachment change and is otherwise silent, so steady-state reads are a
     /// non-blocking drain — no triggering.
+    ///
+    /// TODO: migrate to a general purpose Col03 input pump that consistently dispatches by signature
     /// </summary>
     internal sealed class SystemReportReader
     {
@@ -75,12 +77,12 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
-        /// Non-blocking drain of pushed reports. Every FF 08 identity report is passed
-        /// to <paramref name="onReading"/>; if <paramref name="onItmReport"/> is provided,
-        /// every FF 05 ITM report (the firmware's subscription pushes) is passed to it as
-        /// a private copy. Returns the number of identity readings delivered.
+        /// Non-blocking drain of pushed col03 reports, dispatched by signature: FF 08 -> onReading,
+        /// SRM <c>0xDD</c> -> onSrmReport, FF 05 ITM -> onItmReport (each as a private copy). One read
+        /// loop routes all three, so nothing is stolen. Returns the number of FF 08 readings delivered.
         /// </summary>
-        public int DrainPushes(IDeviceTransport io, Action<Reading> onReading, Action<byte[]> onItmReport = null)
+        public int DrainPushes(IDeviceTransport io, Action<Reading> onReading,
+            Action<byte[]> onItmReport = null, Action<byte[]> onSrmReport = null)
         {
             int count = 0;
             using (io.BeginBatch())
@@ -96,6 +98,14 @@ namespace FanaBridge.Protocol
                     {
                         onReading(Decode(buf, sig, n));
                         count++;
+                        continue;
+                    }
+
+                    if (onSrmReport != null && IsSrmReport(buf, n))
+                    {
+                        var copy = new byte[n];
+                        Array.Copy(buf, copy, n);
+                        onSrmReport(copy);
                         continue;
                     }
 
@@ -117,6 +127,16 @@ namespace FanaBridge.Protocol
             for (int i = 0; i <= 2 && i + 1 < len; i++)
                 if (buf[i] == 0xFF && buf[i + 1] == 0x05)
                     return true;
+            return false;
+        }
+
+        // True if the report is an SRM DE FA 0xDD identity reply: 0xDD at offset 0 (raw) or 1 (behind
+        // a report-id) — NOT deeper, so an FF 08 / FF 05 frame is never mistaken for one.
+        private static bool IsSrmReport(byte[] buf, int len)
+        {
+            for (int i = 0; i <= 1 && i < len; i++)
+                if (buf[i] == 0xDD)
+                    return len >= i + 6;
             return false;
         }
 

--- a/FanaBridge/Protocol/WheelEngage.cs
+++ b/FanaBridge/Protocol/WheelEngage.cs
@@ -1,0 +1,60 @@
+using FanaBridge.Transport;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// Replicates the kernel filter's engage sequence (FWFUProtocolUsbBulkOrInterruptTransfer)
+    /// for a Fanatec-class device: enable + trigger the col03 <c>FF 08</c> system report, then the
+    /// col01 SubId triggers — SubId=1 (module-detection refresh), SubId=0 (input-report trigger),
+    /// and SubId=4 (undocumented, sent for parity). This is what makes a device — a genuine base
+    /// OR an SRM converter — volunteer its identity on whichever surface it uses.
+    ///
+    /// FanaBridge 0.4.0 sent only the <c>FF 08</c> pair on col03, once — a fraction of the filter's
+    /// handshake — which is why a converter (that needs the fuller engage to emit its rim/module)
+    /// came back empty. All sends here are usermode-legal HID output reports; the col01 SubId frames
+    /// are the same 8-byte shape FanaBridge already writes for LEDs.
+    ///
+    /// Read/identify-only — none of these commands write tuning/config to the device.
+    /// </summary>
+    internal sealed class WheelEngage
+    {
+        private const int Col03Length = 64;
+
+        // col03 FF 08 system-report enable + one-shot trigger.
+        private static byte[] Ff08Enable()  { var b = new byte[Col03Length]; b[0] = 0xFF; b[1] = 0x08; b[2] = 0x01; b[3] = 0xFF; return b; }
+        private static byte[] Ff08Trigger() { var b = new byte[Col03Length]; b[0] = 0xFF; b[1] = 0x08; b[2] = 0x02; return b; }
+
+        // col01 SubId trigger: [report-id 01] F8 09 01 06 FF &lt;SubId&gt; 00.
+        internal static byte[] SubId(byte subId) => new byte[8] { 0x01, 0xF8, 0x09, 0x01, 0x06, 0xFF, subId, 0x00 };
+
+        /// <summary>One engage send and whether the transport accepted it.</summary>
+        public struct Step
+        {
+            public string Label;
+            public bool Sent;
+            public Step(string label, bool sent) { Label = label; Sent = sent; }
+        }
+
+        /// <summary>
+        /// Sends the full engage in the filter's order — <c>FF 08</c> enable, <c>FF 08</c> trigger
+        /// (col03), then SubId=1 (module refresh), SubId=0 (input trigger), SubId=4 (col01). Held
+        /// under one batch so no other write interleaves the sequence. Returns each send and whether
+        /// the transport accepted it, so callers can prove the SubId=1 module refresh actually went
+        /// out (vs. a closed col01 handle silently dropping it).
+        /// </summary>
+        public Step[] Engage(IDeviceTransport io)
+        {
+            using (io.BeginBatch())
+            {
+                return new[]
+                {
+                    new Step("FF08 enable",   io.SendCol03(Ff08Enable())),
+                    new Step("FF08 trigger",  io.SendCol03(Ff08Trigger())),
+                    new Step("SubId=1 module", io.SendCol01(SubId(0x01))), // -> col01 type-1 module record
+                    new Step("SubId=0 input",  io.SendCol01(SubId(0x00))), // -> col01 identity report
+                    new Step("SubId=4",        io.SendCol01(SubId(0x04))), // parity with the filter
+                };
+            }
+        }
+    }
+}

--- a/FanaBridge/Transport/FanatecTransport.cs
+++ b/FanaBridge/Transport/FanatecTransport.cs
@@ -367,6 +367,42 @@ namespace FanaBridge.Transport
             }
         }
 
+        int IDeviceTransport.ReadCol01(byte[] buffer, int timeoutMs)
+        {
+            lock (_writeLock)
+            {
+                // Capture under the lock, mirroring ReadCol03: Disconnect() nulls/disposes
+                // the stream under the same lock, so a non-null local stays valid here.
+                var stream = _displayStream;
+                if (stream == null) return -1;
+
+                int saved = stream.ReadTimeout;
+                try
+                {
+                    stream.ReadTimeout = timeoutMs;
+                    return stream.Read(buffer, 0, buffer.Length);
+                }
+                catch
+                {
+                    return -1;
+                }
+                finally
+                {
+                    try { stream.ReadTimeout = saved; } catch { }
+                }
+            }
+        }
+
+        int IDeviceTransport.Col01MaxInputReportLength
+        {
+            get
+            {
+                if (_displayDevice == null) return 34;
+                int len = SafeMaxInput(_displayDevice);
+                return len > 0 ? len : 34;
+            }
+        }
+
         IDisposable IDeviceTransport.BeginBatch()
         {
             Monitor.Enter(_writeLock);

--- a/FanaBridge/Transport/FanatecWheelbase.cs
+++ b/FanaBridge/Transport/FanatecWheelbase.cs
@@ -59,6 +59,7 @@ namespace FanaBridge.Transport
         private const int IdentityReEnableMs = 10000;   // keep the push subscription alive
 
         private readonly SystemReportReader _reportReader = new SystemReportReader();
+        private readonly SrmConverterIdentity _srmReader = new SrmConverterIdentity();
         private readonly IdentitySettler _settler = new IdentitySettler(IdentitySettleMs);
         private readonly System.Diagnostics.Stopwatch _clock = System.Diagnostics.Stopwatch.StartNew();
         private readonly Action<SystemReportReader.Reading> _ingest;
@@ -137,6 +138,16 @@ namespace FanaBridge.Transport
         /// present but not in the decode table (report it). 0 when no module.
         /// </summary>
         public byte ModuleWireCode { get; private set; }
+
+        /// <summary>
+        /// Whether the connected device is an SRM Conversion Kit (a wheel-side base impersonator),
+        /// identified via its <c>DE FA</c> channel rather than <c>FF 08</c>. Its wheel is hard-wired,
+        /// so this identity is fixed for the connection. False for a genuine Fanatec base.
+        /// </summary>
+        public bool IsSrmConverter { get; private set; }
+
+        /// <summary>SRM Conversion Kit firmware (e.g. "6.12") when <see cref="IsSrmConverter"/>, else null.</summary>
+        public string SrmKitFirmware { get; private set; }
 
         /// <summary>Resolved capability profile for the current wheel + module combination.</summary>
         public WheelCapabilities CurrentCapabilities { get; private set; }
@@ -331,6 +342,11 @@ namespace FanaBridge.Transport
                 _lastEnableMs = _clock.ElapsedMilliseconds;
                 if (_reportReader.ReadInitial(_transport, out var reading))
                     IngestReading(reading, _clock.ElapsedMilliseconds);
+                // FF 08 was silent — this may be an SRM Conversion Kit (which emulates a base but
+                // does not reliably emit FF 08). Probe its DE FA channel. A genuine base never
+                // reaches here (its FF 08 answered), so converter support cannot touch normal hardware.
+                else if (_srmReader.TryProbe(_transport, out var srm))
+                    CommitSrmIdentity(srm);
 
                 // Confirm the per-frame drain is non-blocking on this hardware — a
                 // blocking ReadCol03(buf, 0) would stall the frame thread. Done once
@@ -421,6 +437,11 @@ namespace FanaBridge.Transport
         public bool UpdateIdentity()
         {
             if (!IsConnected)
+                return false;
+
+            // An SRM converter's wheel is hard-wired — the identity is fixed at connect, so there is
+            // nothing to drain or re-settle here. Genuine bases fall through to the unchanged FF 08 path.
+            if (IsSrmConverter)
                 return false;
 
             long now = _clock.ElapsedMilliseconds;
@@ -517,6 +538,34 @@ namespace FanaBridge.Transport
             WheelChanged?.Invoke(this);
         }
 
+        // Commit a fixed SRM converter identity from the DE FA channel. The wheel is hard-wired, so
+        // this is a one-shot (no settler, no re-drain). Rim + module come from DE FA, not FF 08;
+        // BaseType stays 0 — the converter's emulated base is not a trustworthy model to surface.
+        private void CommitSrmIdentity(SrmConverterIdentity.Result srm)
+        {
+            IsSrmConverter = true;
+            SrmKitFirmware = srm.KitFirmware;
+
+            byte wire = srm.WheelId;
+            bool isHub = FanatecIdentity.IsHub(wire);
+
+            WheelDetected = wire != 0;
+            WheelCode = srm.WheelCode;                       // SRM map (handles 0x17); null when unknown id
+            WheelWireCode = wire;
+            IsHub = isHub;
+            ModuleCode = isHub ? srm.ModuleCode : null;      // module only meaningful on a hub
+            ModuleWireCode = isHub ? srm.ModuleRaw : (byte)0;
+            BaseType = 0;
+            BaseCode = null;
+            _identityStable = true;                          // fixed identity — always settled
+
+            ResolveCapabilities("SRM converter identified");
+            WheelChanged?.Invoke(this);
+            SimHub.Logging.Current.Info(string.Format(
+                "FanatecWheelbase: SRM Conversion Kit — Wheel={0} (id 0x{1:X2}), Module={2}, KitFw={3}",
+                WheelCode ?? "unknown", wire, ModuleCode ?? "(none)", SrmKitFirmware ?? "?"));
+        }
+
         /// <summary>
         /// Forces a re-evaluation of capabilities against the current profile store.
         /// Call after <see cref="WheelProfileStore.Reload"/> to pick up newly-saved
@@ -600,6 +649,8 @@ namespace FanaBridge.Transport
             ModuleWireCode = 0;
             BaseType = 0;
             BaseCode = null;
+            IsSrmConverter = false;
+            SrmKitFirmware = null;
             CurrentCapabilities = WheelCapabilities.None;
             LastRawReport = null;
             // LastConnectError is intentionally left intact — it reflects the most

--- a/FanaBridge/Transport/FanatecWheelbase.cs
+++ b/FanaBridge/Transport/FanatecWheelbase.cs
@@ -43,6 +43,7 @@ namespace FanaBridge.Transport
         public FanatecWheelbase()
         {
             _ingest = OnDrainReading;
+            _ingestSrm = OnDrainSrm;
             _bufferItm = BufferItmReport;
         }
 
@@ -60,9 +61,15 @@ namespace FanaBridge.Transport
 
         private readonly SystemReportReader _reportReader = new SystemReportReader();
         private readonly SrmConverterIdentity _srmReader = new SrmConverterIdentity();
+        // Converter identity: while unidentified we ping the SRM DE FA channel (harmless — a genuine
+        // base does not answer). Its 0xDD reply arrives via the shared col03 drain into _ingestSrm.
+        private const int SrmQueryMs = 1000;              // re-ping cadence while unidentified
+        private long _lastSrmQueryMs;
+        private SrmConverterIdentity.Result? _pendingSrm;  // a 0xDD reply seen in the drain, committed after it
         private readonly IdentitySettler _settler = new IdentitySettler(IdentitySettleMs);
         private readonly System.Diagnostics.Stopwatch _clock = System.Diagnostics.Stopwatch.StartNew();
         private readonly Action<SystemReportReader.Reading> _ingest;
+        private readonly Action<byte[]> _ingestSrm;
         private long _lastEnableMs;
         private long _drainNow;
 
@@ -173,7 +180,7 @@ namespace FanaBridge.Transport
         /// <see cref="BaseType"/> (0 until the first commit, reset to 0 on
         /// disconnect), so there is no separate flag to keep in sync.
         /// </summary>
-        public bool HasIdentity => BaseType != 0;
+        public bool HasIdentity => BaseType != 0 || IsSrmConverter;
 
         /// <summary>
         /// Display name for the current wheel/hub: the matched profile's name, else
@@ -339,14 +346,14 @@ namespace FanaBridge.Transport
             // listens for pushes — no triggering.
             try
             {
-                _lastEnableMs = _clock.ElapsedMilliseconds;
+                long connectNow = _clock.ElapsedMilliseconds;
+                _lastEnableMs = connectNow;
+                _lastSrmQueryMs = connectNow - SrmQueryMs;   // allow an immediate SRM ping if FF 08 is silent
+                _pendingSrm = null;
                 if (_reportReader.ReadInitial(_transport, out var reading))
-                    IngestReading(reading, _clock.ElapsedMilliseconds);
-                // FF 08 was silent — this may be an SRM Conversion Kit (which emulates a base but
-                // does not reliably emit FF 08). Probe its DE FA channel. A genuine base never
-                // reaches here (its FF 08 answered), so converter support cannot touch normal hardware.
-                else if (_srmReader.TryProbe(_transport, out var srm))
-                    CommitSrmIdentity(srm);
+                    IngestReading(reading, connectNow);
+                // If FF 08 was silent this might be an SRM kit (or a slow genuine base). No probe here:
+                // UpdateIdentity keeps reading FF 08 and pings DE FA while unidentified; whichever wins.
 
                 // Confirm the per-frame drain is non-blocking on this hardware — a
                 // blocking ReadCol03(buf, 0) would stall the frame thread. Done once
@@ -439,8 +446,8 @@ namespace FanaBridge.Transport
             if (!IsConnected)
                 return false;
 
-            // An SRM converter's wheel is hard-wired — the identity is fixed at connect, so there is
-            // nothing to drain or re-settle here. Genuine bases fall through to the unchanged FF 08 path.
+            // An SRM converter's identity is a fixed one-shot — nothing to drain or re-settle once
+            // committed. Genuine bases fall through to the unchanged FF 08 path.
             if (IsSrmConverter)
                 return false;
 
@@ -454,19 +461,47 @@ namespace FanaBridge.Transport
                 catch { /* transient; the next tick retries */ }
             }
 
+            // One col03 read loop, dispatched by signature: FF 08 -> _ingest, 0xDD -> _ingestSrm, FF 05 -> ITM.
             _drainNow = now;
-            _reportReader.DrainPushes(_transport, _ingest, _bufferItm);
+            _reportReader.DrainPushes(_transport, _ingest, _bufferItm, _ingestSrm);
+
+            // Commit a converter identity the drain routed to us — after the batch, so WheelChanged
+            // isn't raised under the transport write lock.
+            if (_pendingSrm.HasValue)
+            {
+                var srm = _pendingSrm.Value;
+                _pendingSrm = null;
+                CommitSrmIdentity(srm);
+            }
 
             bool changed = _settler.Tick(now, out _, out _);
             _identityStable = _settler.IsStable;
-            if (changed)
+            if (changed && !IsSrmConverter)
                 CommitIdentity();
+
+            // Still unidentified and idle? Ping the DE FA channel (harmless to a genuine base). Any 0xDD
+            // reply is picked up by the next drain. Once FF 08 identifies a base, we never get here.
+            if (!WheelDetected && _identityStable && !IsSrmConverter && now - _lastSrmQueryMs >= SrmQueryMs)
+            {
+                _lastSrmQueryMs = now;
+                try { _srmReader.SendQuery(_transport); }
+                catch { /* transient */ }
+            }
+
             return changed;
         }
 
         // Drain callback: record the reading and offer it to the settler. _drainNow
         // carries the current clock so the cached delegate needs no per-frame closure.
         private void OnDrainReading(SystemReportReader.Reading r) => IngestReading(r, _drainNow);
+
+        // Drain callback for a 0xDD frame: decode + stash; UpdateIdentity commits it after the batch.
+        private void OnDrainSrm(byte[] frame)
+        {
+            if (IsSrmConverter || _pendingSrm.HasValue) return;
+            if (SrmConverterIdentity.TryDecodeFrame(frame, frame.Length, out var srm))
+                _pendingSrm = srm;
+        }
 
         // Drain callback for ITM subscription reports: buffer them for the ITM driver.
         private void BufferItmReport(byte[] report)
@@ -538,9 +573,8 @@ namespace FanaBridge.Transport
             WheelChanged?.Invoke(this);
         }
 
-        // Commit a fixed SRM converter identity from the DE FA channel. The wheel is hard-wired, so
-        // this is a one-shot (no settler, no re-drain). Rim + module come from DE FA, not FF 08;
-        // BaseType stays 0 — the converter's emulated base is not a trustworthy model to surface.
+        // Commit a fixed SRM converter identity from the DE FA channel (a one-shot — no settler). Rim +
+        // module come from DE FA, not FF 08; BaseType stays 0 (the emulated base is not a real model).
         private void CommitSrmIdentity(SrmConverterIdentity.Result srm)
         {
             IsSrmConverter = true;
@@ -651,6 +685,7 @@ namespace FanaBridge.Transport
             BaseCode = null;
             IsSrmConverter = false;
             SrmKitFirmware = null;
+            _pendingSrm = null;
             CurrentCapabilities = WheelCapabilities.None;
             LastRawReport = null;
             // LastConnectError is intentionally left intact — it reflects the most

--- a/FanaBridge/Transport/IDeviceTransport.cs
+++ b/FanaBridge/Transport/IDeviceTransport.cs
@@ -41,6 +41,18 @@ namespace FanaBridge.Transport
         bool SendCol01(byte[] data);
 
         /// <summary>
+        /// Reads a report from the display/input interface (col01). Returns the number
+        /// of bytes read, or -1 on failure/timeout. The <paramref name="timeoutMs"/>
+        /// applies to this call only. Used to read the col01 input report that carries
+        /// the native rim identity (byte <c>[len-4]</c>) when the col03 FF 08 report is
+        /// unavailable.
+        /// </summary>
+        int ReadCol01(byte[] buffer, int timeoutMs);
+
+        /// <summary>Maximum input report length for the col01 interface.</summary>
+        int Col01MaxInputReportLength { get; }
+
+        /// <summary>
         /// Acquires exclusive access to the transport for multi-report
         /// atomic sequences (e.g. staged LED commit, tuning read-modify-write).
         /// Dispose the returned token to release.


### PR DESCRIPTION
Fixes #52

## Summary

**Fixes a v0.4.0 regression:** Fanatec wheels/hubs run through an **SRM Conversion Kit** no longer connect — the wheelbase sits at "Connecting…" indefinitely and never appears in Devices, so LED/display/tuning integration can't attach. These wheels worked before v0.4.0; this restores them.

**Why it broke:** v0.4.0 replaced the SimHub-provided Fanatec SDK wrapper with FanaBridge's own device-identity logic, which resolves the attached wheel from the Fanatec `FF 08` system report. An SRM Conversion Kit (a third-party adapter that runs a Fanatec wheel/hub on a non-Fanatec base by emulating a Fanatec wheelbase) doesn't reliably emit `FF 08`, so identity is never resolved. Under the old SDK-wrapper path a converter user could work around this by installing the Fanatec App; that path no longer applies.

**The fix:** when `FF 08` is silent, recover the wheel identity from the kit's own identity channel — with **no change to the genuine-hardware path**.

## How it works

- A converter answers a private `DE FA AD` → `0xDD` identity query on col03 that a genuine Fanatec base never answers.
- While a base is unidentified, `UpdateIdentity` sends that query (harmless to a genuine base — it doesn't reply). A **single col03 read loop dispatches by signature**: `FF 08` → genuine identity, `0xDD` → converter identity, `FF 05` → ITM. So the `FF 08` path is never stopped, and never has a frame stolen by the converter path.
- A converter's wheel is hard-wired (no wheel-swap), so its identity is a fixed one-shot committed at connect (`IsSrmConverter`), not re-polled.
- The reported wheel id **is** the Fanatec wire byte, so it decodes through the existing `FanatecDeviceTables` — no duplicate table. The one exception is `0x17` (SRM = CSL WRC V2, where the Fanatec wire `0x17` = PSWBMW).

## No-regression guarantee

The genuine `FF 08` identity path is byte-for-byte unchanged:
- Converter detection only runs when `FF 08` is silent.
- The `DE FA` query is **send-only** — a genuine base ignores it, and the reply is routed by the shared drain, so it can't consume a genuine `FF 08` frame.
- The `0xDD` signature is matched at offset 0–1 only, so an `FF 08` / `FF 05` frame can never be mistaken for a converter.

An adversarial multi-agent review pass verified the genuine path is untouched and drove the fixes in this branch (the "Connecting…" freeze on identified converters, the signature tightening, the map de-duplication).

## Diagnostics

The detection report gains an active "converter identity probe" that runs the identity handshake once and dumps the col01 records + `FF 08` report (if any) + the `DE FA` `0xDD` reply. A single report from a converter user — or from any device with a wheel/hub/module FanaBridge doesn't recognize — now carries everything needed to identify it. Read-only (identity handshake + a get-wheel query; never tuning/config).

## Testing

- 325 unit tests; the decode is pinned to a real converter's reply bytes.
- **Hardware-validated:** the reporter confirmed both converted wheels (kit fw 6.12 and 7.00) are detected and working on this build.

## Follow-ups (non-blocking)

- Capture a converter + button module to validate the `DE FA` module byte before advertising converter-module support. The diagnostics already flag a converter's module as UNVALIDATED and never guess it from col01, so this is a validation step, not a correctness gate.
- Multi-converter (two kits plugged in at once) is a deferred edge case; one device is picked by the existing selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
