### PR TITLE
ITM: multi-device display support

### DIFF
--- a/FanaBridge.Tests/ItmDeviceCatalogTests.cs
+++ b/FanaBridge.Tests/ItmDeviceCatalogTests.cs
@@ -10,7 +10,7 @@ namespace FanaBridge.Tests
         [Fact]
         public void Standard_HasSixPagesInOrder()
         {
-            var pages = ItmDeviceCatalog.PagesFor((byte)ItmDevice.BmeOrGtswx);
+            var pages = ItmDeviceCatalog.PagesFor((byte)3);
 
             Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6 }, pages.Select(p => p.Number).ToArray());
             Assert.Equal("Lap Info", pages[0].Name);
@@ -21,14 +21,14 @@ namespace FanaBridge.Tests
         [Fact]
         public void BaseAndWheelOled_ShareTheStandardSet()
         {
-            Assert.Same(ItmDeviceCatalog.PagesFor((byte)ItmDevice.BmeOrGtswx),
-                        ItmDeviceCatalog.PagesFor((byte)ItmDevice.Base));
+            Assert.Same(ItmDeviceCatalog.PagesFor((byte)3),
+                        ItmDeviceCatalog.PagesFor((byte)1));
         }
 
         [Fact]
         public void Bentley_HasFivePages_NoCarSettings_Renumbered()
         {
-            var pages = ItmDeviceCatalog.PagesFor((byte)ItmDevice.Bentley);
+            var pages = ItmDeviceCatalog.PagesFor((byte)4);
 
             Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, pages.Select(p => p.Number).ToArray());
             Assert.DoesNotContain(pages, p => p.Name == "Car Settings");
@@ -39,7 +39,7 @@ namespace FanaBridge.Tests
         [Fact]
         public void UnknownDeviceId_FallsBackToStandard()
         {
-            Assert.Same(ItmDeviceCatalog.PagesFor((byte)ItmDevice.BmeOrGtswx),
+            Assert.Same(ItmDeviceCatalog.PagesFor((byte)3),
                         ItmDeviceCatalog.PagesFor(99));
         }
 
@@ -48,7 +48,7 @@ namespace FanaBridge.Tests
         {
             // Every param any device can show must be encodable (generalizes the Phase-1 guard
             // across all device page sets). All device sets are subsets of BME's, so this holds.
-            byte[] devices = { (byte)ItmDevice.Base, (byte)ItmDevice.BmeOrGtswx, (byte)ItmDevice.Bentley };
+            byte[] devices = { (byte)1, (byte)3, (byte)4 };
             foreach (var dev in devices)
                 foreach (var page in ItmDeviceCatalog.PagesFor(dev))
                     foreach (var id in page.Params)

--- a/FanaBridge.Tests/ItmDeviceCatalogTests.cs
+++ b/FanaBridge.Tests/ItmDeviceCatalogTests.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using FanaBridge.Adapters;
+using FanaBridge.Protocol;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class ItmDeviceCatalogTests
+    {
+        [Fact]
+        public void Standard_HasSixPagesInOrder()
+        {
+            var pages = ItmDeviceCatalog.PagesFor((byte)ItmDevice.BmeOrGtswx);
+
+            Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6 }, pages.Select(p => p.Number).ToArray());
+            Assert.Equal("Lap Info", pages[0].Name);
+            Assert.Equal("Car Settings", pages[2].Name);
+            Assert.True(pages[5].IsLegacy);   // page 6 = Legacy, no params
+        }
+
+        [Fact]
+        public void BaseAndWheelOled_ShareTheStandardSet()
+        {
+            Assert.Same(ItmDeviceCatalog.PagesFor((byte)ItmDevice.BmeOrGtswx),
+                        ItmDeviceCatalog.PagesFor((byte)ItmDevice.Base));
+        }
+
+        [Fact]
+        public void Bentley_HasFivePages_NoCarSettings_Renumbered()
+        {
+            var pages = ItmDeviceCatalog.PagesFor((byte)ItmDevice.Bentley);
+
+            Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, pages.Select(p => p.Number).ToArray());
+            Assert.DoesNotContain(pages, p => p.Name == "Car Settings");
+            Assert.Equal("Lap Times", pages[2].Name);   // page 3 is Lap Times, not Car Settings
+            Assert.True(pages[4].IsLegacy);              // page 5 = Legacy
+        }
+
+        [Fact]
+        public void UnknownDeviceId_FallsBackToStandard()
+        {
+            Assert.Same(ItmDeviceCatalog.PagesFor((byte)ItmDevice.BmeOrGtswx),
+                        ItmDeviceCatalog.PagesFor(99));
+        }
+
+        [Fact]
+        public void EveryCatalogParam_HasAMapperEncoder()
+        {
+            // Every param any device can show must be encodable (generalizes the Phase-1 guard
+            // across all device page sets). All device sets are subsets of BME's, so this holds.
+            byte[] devices = { (byte)ItmDevice.Base, (byte)ItmDevice.BmeOrGtswx, (byte)ItmDevice.Bentley };
+            foreach (var dev in devices)
+                foreach (var page in ItmDeviceCatalog.PagesFor(dev))
+                    foreach (var id in page.Params)
+                        Assert.True(ItmTelemetryMapper.HasEncoder(id),
+                            $"paramId {id} on device {dev} page {page.Number} ({page.Name}) has no mapper encoder");
+        }
+    }
+}

--- a/FanaBridge.Tests/ItmDeviceCatalogTests.cs
+++ b/FanaBridge.Tests/ItmDeviceCatalogTests.cs
@@ -13,8 +13,8 @@ namespace FanaBridge.Tests
             var pages = ItmDeviceCatalog.PagesFor((byte)3);
 
             Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6 }, pages.Select(p => p.Number).ToArray());
-            Assert.Equal("Lap Info", pages[0].Name);
-            Assert.Equal("Car Settings", pages[2].Name);
+            Assert.Equal(ItmPage.LapInfo, pages[0].Page);
+            Assert.Equal(ItmPage.CarSettings, pages[2].Page);
             Assert.True(pages[5].IsLegacy);   // page 6 = Legacy, no params
         }
 
@@ -31,8 +31,8 @@ namespace FanaBridge.Tests
             var pages = ItmDeviceCatalog.PagesFor((byte)4);
 
             Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, pages.Select(p => p.Number).ToArray());
-            Assert.DoesNotContain(pages, p => p.Name == "Car Settings");
-            Assert.Equal("Lap Times", pages[2].Name);   // page 3 is Lap Times, not Car Settings
+            Assert.DoesNotContain(pages, p => p.Page == ItmPage.CarSettings);
+            Assert.Equal(ItmPage.LapTimes, pages[2].Page);   // page 3 is Lap Times, not Car Settings
             Assert.True(pages[4].IsLegacy);              // page 5 = Legacy
         }
 
@@ -53,7 +53,7 @@ namespace FanaBridge.Tests
                 foreach (var page in ItmDeviceCatalog.PagesFor(dev))
                     foreach (var id in page.Params)
                         Assert.True(ItmTelemetryMapper.HasEncoder(id),
-                            $"paramId {id} on device {dev} page {page.Number} ({page.Name}) has no mapper encoder");
+                            $"paramId {id} on device {dev} page {page.Number} ({page.Page}) has no mapper encoder");
         }
     }
 }

--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -143,7 +143,7 @@ namespace FanaBridge.Tests
         {
             var t = new RecordingTransport();
             var clock = new Clock();
-            var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, deviceId: (byte)ItmDevice.Bentley);
+            var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, deviceId: 4);   // Bentley
 
             driver.Start();
             driver.Update(EmptyData());   // Enabling -> Running
@@ -157,7 +157,7 @@ namespace FanaBridge.Tests
         {
             var t = new RecordingTransport();
             var clock = new Clock();
-            var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, deviceId: (byte)ItmDevice.Bentley);
+            var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, deviceId: 4);   // Bentley
             driver.Start();
             driver.Update(EmptyData());   // bring-up + Lap Info seed
 

--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -139,6 +139,25 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void ChangingDefaultPageWhileRunning_DoesNotReseedSubscriptions()
+        {
+            var driver = MakeDriver(out _, out var clock);
+            driver.DefaultPage = 1;
+            Enable(driver, clock);
+            int before = driver.SubscriptionCount;   // page 1's seeded set
+
+            driver.DefaultPage = 3;   // switch page live
+            clock.T += 1000;
+            driver.Update(EmptyData());
+
+            // The PageSet is issued (see ChangingDefaultPageWhileRunning_ForcesItLive), but the
+            // subscriptions are NOT speculatively reseeded — we wait for the firmware's push. A flaked
+            // switch, or a switch to the page already shown (no push), must not strand the display on
+            // wrong-page handles, so the existing set is kept until the firmware replaces it.
+            Assert.Equal(before, driver.SubscriptionCount);
+        }
+
+        [Fact]
         public void BringUp_Bentley_TargetsDevice4()
         {
             var t = new RecordingTransport();

--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -111,6 +111,34 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void BringUp_ForcesConfiguredDefaultPage()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            driver.DefaultPage = 5;   // Tyre Temps
+            Enable(driver, clock);
+
+            // The forced-page PageSet uses the configured default page, not 1.
+            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[4] == 0x05);
+            // And the seed reflects that page (Tyre Temps = SPEED, GEAR + 4 tyre temps = 6 params).
+            Assert.Equal(6, driver.SubscriptionCount);
+        }
+
+        [Fact]
+        public void ChangingDefaultPageWhileRunning_ForcesItLive()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);   // bring-up on the default page (1)
+            t.Sent.Clear();          // ignore bring-up frames
+
+            driver.DefaultPage = 3;  // user picks a new default page in settings
+            clock.T += 1000;
+            driver.Update(EmptyData());
+
+            // A PageSet to the new page is issued live — no re-enable / reconnect needed.
+            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[4] == 0x03);
+        }
+
+        [Fact]
         public void BringUp_Bentley_TargetsDevice4()
         {
             var t = new RecordingTransport();

--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -111,6 +111,39 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void BringUp_Bentley_TargetsDevice4()
+        {
+            var t = new RecordingTransport();
+            var clock = new Clock();
+            var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, deviceId: (byte)ItmDevice.Bentley);
+
+            driver.Start();
+            driver.Update(EmptyData());   // Enabling -> Running
+
+            // The forced-page PageSet targets device 4 (Bentley), not the default 3.
+            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[3] == 0x04 && r[4] == 0x01);
+        }
+
+        [Fact]
+        public void Bentley_ValueUpdate_UsesDevice4()
+        {
+            var t = new RecordingTransport();
+            var clock = new Clock();
+            var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, deviceId: (byte)ItmDevice.Bentley);
+            driver.Start();
+            driver.Update(EmptyData());   // bring-up + Lap Info seed
+
+            var s = NewStatus();
+            Set(s, "SpeedLocal", 100.0);
+            clock.T += 1000;             // past the value interval
+            driver.Update(Data(s));
+
+            var vu = t.Sent.LastOrDefault(IsValueUpdate);
+            Assert.NotNull(vu);
+            Assert.Equal(0x04, vu[3]);   // per-entry device id = Bentley
+        }
+
+        [Fact]
         public void Enable_SeedsLapInfoSubscriptions()
         {
             var driver = MakeDriver(out _, out var clock);

--- a/FanaBridge.Tests/ItmEncoderTests.cs
+++ b/FanaBridge.Tests/ItmEncoderTests.cs
@@ -127,6 +127,32 @@ namespace FanaBridge.Tests
             Assert.Equal(0x04, t.Last[3]);
         }
 
+        // ── Per-entry device id ──────────────────────────────────────────
+
+        [Fact]
+        public void SendValues_DefaultsToDevice3()
+        {
+            var encoder = MakeEncoder(out var t);
+            Assert.True(encoder.SendValues(new[] { ItmValue.UInt8(0, 4, 1) }));
+            Assert.Equal(0x03, t.Last[3]);   // DefaultDeviceId = BmeOrGtswx
+        }
+
+        [Fact]
+        public void SendValues_WritesGivenDeviceId()
+        {
+            var encoder = MakeEncoder(out var t);
+            Assert.True(encoder.SendValues(new[] { ItmValue.UInt8(0, 4, 1) }, (byte)ItmDevice.Bentley));
+            Assert.Equal(0x04, t.Last[3]);   // per-entry device id = Bentley (4), not the default 3
+        }
+
+        [Fact]
+        public void SetParamDefs_WritesGivenDeviceId()
+        {
+            var encoder = MakeEncoder(out var t);
+            Assert.True(encoder.SetParamDefs(new[] { new ItmParamDef(0x82) }, (byte)ItmDevice.Bentley));
+            Assert.Equal(0x04, t.Last[3]);
+        }
+
         // ── ValueUpdate framing ──────────────────────────────────────────
 
         [Fact]

--- a/FanaBridge.Tests/ItmEncoderTests.cs
+++ b/FanaBridge.Tests/ItmEncoderTests.cs
@@ -105,7 +105,7 @@ namespace FanaBridge.Tests
         {
             var encoder = MakeEncoder(out var t);
 
-            encoder.SetPage(ItmDevice.BmeOrGtswx, 3);
+            encoder.SetPage(3, 3);
 
             var r = t.Last;
             Assert.Equal(0xFF, r[0]);
@@ -116,14 +116,14 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void SetPage_DeviceEnumMapsToWireId()
+        public void SetPage_WritesGivenDeviceId()
         {
             var encoder = MakeEncoder(out var t);
 
-            encoder.SetPage(ItmDevice.Base, 1);
+            encoder.SetPage(1, 1);
             Assert.Equal(0x01, t.Last[3]);
 
-            encoder.SetPage(ItmDevice.Bentley, 2);
+            encoder.SetPage(4, 2);
             Assert.Equal(0x04, t.Last[3]);
         }
 
@@ -141,7 +141,7 @@ namespace FanaBridge.Tests
         public void SendValues_WritesGivenDeviceId()
         {
             var encoder = MakeEncoder(out var t);
-            Assert.True(encoder.SendValues(new[] { ItmValue.UInt8(0, 4, 1) }, (byte)ItmDevice.Bentley));
+            Assert.True(encoder.SendValues(new[] { ItmValue.UInt8(0, 4, 1) }, 4));
             Assert.Equal(0x04, t.Last[3]);   // per-entry device id = Bentley (4), not the default 3
         }
 
@@ -149,7 +149,7 @@ namespace FanaBridge.Tests
         public void SetParamDefs_WritesGivenDeviceId()
         {
             var encoder = MakeEncoder(out var t);
-            Assert.True(encoder.SetParamDefs(new[] { new ItmParamDef(0x82) }, (byte)ItmDevice.Bentley));
+            Assert.True(encoder.SetParamDefs(new[] { new ItmParamDef(0x82) }, 4));
             Assert.Equal(0x04, t.Last[3]);
         }
 

--- a/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -338,7 +338,7 @@ namespace FanaBridge.Tests
             Assert.Empty(ItmTelemetry.ParseSubscriptionReport(report, report.Length));
 
             // Asking for device 4 accepts it.
-            var subs = ItmTelemetry.ParseSubscriptionReport(report, report.Length, (byte)ItmDevice.Bentley);
+            var subs = ItmTelemetry.ParseSubscriptionReport(report, report.Length, (byte)4);
             Assert.Single(subs);
             Assert.Equal(ItmParam.Speed, subs[0].ParamId);
             Assert.Equal(0, subs[0].Handle);

--- a/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -71,6 +71,17 @@ namespace FanaBridge.Tests
             Assert.Empty(ParamsArray(ItmPage.Legacy));
         }
 
+        // ── NameOf ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void NameOf_GivesEveryPageANonEmptyDisplayName()
+        {
+            Assert.Equal("Lap Info", ItmTelemetry.NameOf(ItmPage.LapInfo));
+            Assert.Equal("Car Settings", ItmTelemetry.NameOf(ItmPage.CarSettings));
+            foreach (ItmPage page in System.Enum.GetValues(typeof(ItmPage)))
+                Assert.False(string.IsNullOrEmpty(ItmTelemetry.NameOf(page)));
+        }
+
         private static ushort[] ParamsArray(ItmPage page)
         {
             var list = ItmTelemetry.ParamsFor(page);

--- a/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -329,6 +329,22 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void ParseSubscriptionReport_FiltersToGivenDevice()
+        {
+            // One entry for device 4 (Bentley): [04][h0][SPEED=0001][unit 34]
+            var report = HexToBytes("ff0501" + "0400010034");
+
+            // The default device (3) skips the device-4 entry.
+            Assert.Empty(ItmTelemetry.ParseSubscriptionReport(report, report.Length));
+
+            // Asking for device 4 accepts it.
+            var subs = ItmTelemetry.ParseSubscriptionReport(report, report.Length, (byte)ItmDevice.Bentley);
+            Assert.Single(subs);
+            Assert.Equal(ItmParam.Speed, subs[0].ParamId);
+            Assert.Equal(0, subs[0].Handle);
+        }
+
+        [Fact]
         public void TryEncodeParam_KnownParam_Encodes()
         {
             var s = NewStatus();

--- a/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using FanaBridge.Adapters;
 using FanaBridge.Protocol;
 using GameReaderCommon;
 using Xunit;
@@ -78,25 +79,38 @@ namespace FanaBridge.Tests
             return arr;
         }
 
+        // ── Catalog ↔ mapper guard ───────────────────────────────────────
+        // The Protocol/Adapters split puts the page catalog in ItmTelemetry and the value
+        // encoders in ItmTelemetryMapper. Every param a page can carry must be encodable, or a
+        // subscribed field would silently show dashes. This test is the drift guard.
+        [Fact]
+        public void EveryCatalogParam_HasAMapperEncoder()
+        {
+            foreach (ItmPage page in Enum.GetValues(typeof(ItmPage)))
+                foreach (var id in ItmTelemetry.ParamsFor(page))
+                    Assert.True(ItmTelemetryMapper.HasEncoder(id),
+                        $"paramId {id} on page {page} has no mapper encoder");
+        }
+
         // ── BuildValues guards ───────────────────────────────────────────
 
         [Fact]
         public void BuildValues_NullData_IsEmpty()
         {
-            Assert.Empty(ItmTelemetry.BuildValues(ItmPage.LapInfo, null));
-            Assert.Empty(ItmTelemetry.BuildValues(ItmPage.LapInfo, new GameData())); // NewData null
+            Assert.Empty(ItmTelemetryMapper.BuildValues(ItmPage.LapInfo, null));
+            Assert.Empty(ItmTelemetryMapper.BuildValues(ItmPage.LapInfo, new GameData())); // NewData null
         }
 
         [Fact]
         public void BuildValues_LegacyPage_IsEmpty()
         {
-            Assert.Empty(ItmTelemetry.BuildValues(ItmPage.Legacy, Wrap(NewStatus())));
+            Assert.Empty(ItmTelemetryMapper.BuildValues(ItmPage.Legacy, Wrap(NewStatus())));
         }
 
         [Fact]
         public void BuildValues_AssignsSequentialHandles()
         {
-            var values = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(NewStatus()));
+            var values = ItmTelemetryMapper.BuildValues(ItmPage.LapInfo, Wrap(NewStatus()));
 
             for (int i = 0; i < values.Count; i++)
                 Assert.Equal((byte)i, values[i].Handle);
@@ -105,7 +119,7 @@ namespace FanaBridge.Tests
         [Fact]
         public void BuildValues_HandleBase_OffsetsHandles()
         {
-            var values = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(NewStatus()), handleBase: 2);
+            var values = ItmTelemetryMapper.BuildValues(ItmPage.LapInfo, Wrap(NewStatus()), handleBase: 2);
 
             for (int i = 0; i < values.Count; i++)
                 Assert.Equal((byte)(2 + i), values[i].Handle);
@@ -124,7 +138,7 @@ namespace FanaBridge.Tests
             Set(s, "CurrentLapTime", TimeSpan.FromSeconds(83.5));
             Set(s, "LastLapTime", TimeSpan.FromSeconds(82.25));
 
-            var v = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(s));
+            var v = ItmTelemetryMapper.BuildValues(ItmPage.LapInfo, Wrap(s));
 
             Assert.Equal(ItmParam.Speed, v[0].ParamId);
             Assert.Equal((short)142, AsI16(v[0]));     // SpeedLocal rounded
@@ -150,13 +164,13 @@ namespace FanaBridge.Tests
             Set(s, "OilTemperature", double.PositiveInfinity);
             Set(s, "ERSPercent", double.NaN);
 
-            var lap = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(s));
+            var lap = ItmTelemetryMapper.BuildValues(ItmPage.LapInfo, Wrap(s));
             Assert.Equal((short)0, AsI16(lap[0]));   // ClampSpeed(NaN) -> 0
 
-            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.OilTemp, 5, Wrap(s), out var oil));
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.OilTemp, 5, Wrap(s), out var oil));
             Assert.Equal((byte)0, AsU8(oil));        // ClampByte(Inf) -> 0
 
-            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.ErsLevel, 3, Wrap(s), out var ers));
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.ErsLevel, 3, Wrap(s), out var ers));
             Assert.Equal(0, AsI32(ers));             // SafeRound(NaN) -> 0
         }
 
@@ -172,7 +186,7 @@ namespace FanaBridge.Tests
             var s = NewStatus();
             Set(s, "Gear", gear);
 
-            var v = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(s));
+            var v = ItmTelemetryMapper.BuildValues(ItmPage.LapInfo, Wrap(s));
 
             Assert.Equal((byte)expected, AsU8(v[1]));
         }
@@ -185,7 +199,7 @@ namespace FanaBridge.Tests
             var s = NewStatus();
             Set(s, "SpeedLocal", speedLocal);
 
-            var v = ItmTelemetry.BuildValues(ItmPage.LapInfo, Wrap(s));
+            var v = ItmTelemetryMapper.BuildValues(ItmPage.LapInfo, Wrap(s));
 
             Assert.Equal((short)expected, AsI16(v[0]));
         }
@@ -198,7 +212,7 @@ namespace FanaBridge.Tests
             var s = NewStatus();
             Set(s, "BrakeBias", 51.2);   // percentage from SimHub
 
-            var v = ItmTelemetry.BuildValues(ItmPage.CarSettings, Wrap(s));
+            var v = ItmTelemetryMapper.BuildValues(ItmPage.CarSettings, Wrap(s));
 
             // Order (per capture): Speed, Gear, TC, ABS, EngineMap, OilTemp, BrakeBias.
             // Int32 in tenths of a percent — 51.2% => 512 (confirmed by capture).
@@ -213,7 +227,7 @@ namespace FanaBridge.Tests
             var s = NewStatus();
             Set(s, "BrakeBias", 150.0);   // absurd; clamps to 1000 (100.0%)
 
-            var v = ItmTelemetry.BuildValues(ItmPage.CarSettings, Wrap(s));
+            var v = ItmTelemetryMapper.BuildValues(ItmPage.CarSettings, Wrap(s));
 
             Assert.Equal(1000, AsI32(v[6]));
         }
@@ -227,7 +241,7 @@ namespace FanaBridge.Tests
             Set(s, "EngineMap", 6);
             Set(s, "OilTemperature", 98.7);
 
-            var v = ItmTelemetry.BuildValues(ItmPage.CarSettings, Wrap(s));
+            var v = ItmTelemetryMapper.BuildValues(ItmPage.CarSettings, Wrap(s));
 
             Assert.Equal(ItmParam.TcSetting, v[2].ParamId);
             Assert.Equal((byte)4, AsU8(v[2]));
@@ -252,7 +266,7 @@ namespace FanaBridge.Tests
             Set(s, "DRSAvailable", 1);
             Set(s, "DRSEnabled", 0);
 
-            var v = ItmTelemetry.BuildValues(ItmPage.FuelErsDrs, Wrap(s));
+            var v = ItmTelemetryMapper.BuildValues(ItmPage.FuelErsDrs, Wrap(s));
 
             Assert.Equal(ItmParam.Fuel, v[2].ParamId);
             Assert.Equal(12.5f, AsF32(v[2]), 3);
@@ -320,7 +334,7 @@ namespace FanaBridge.Tests
             var s = NewStatus();
             Set(s, "TyreTemperatureFrontLeft", 88.0);
 
-            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.TyreFlTemp, 2, Wrap(s), out var v));
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.TyreFlTemp, 2, Wrap(s), out var v));
             Assert.Equal(2, v.Handle);
             Assert.Equal(ItmParam.TyreFlTemp, v.ParamId);
             Assert.Equal((byte)88, AsU8(v));
@@ -329,7 +343,7 @@ namespace FanaBridge.Tests
         [Fact]
         public void TryEncodeParam_UnknownParam_ReturnsFalse()
         {
-            Assert.False(ItmTelemetry.TryEncodeParam(9999, 0, Wrap(NewStatus()), out _));
+            Assert.False(ItmTelemetryMapper.TryEncodeParam(9999, 0, Wrap(NewStatus()), out _));
         }
 
         [Fact]
@@ -338,7 +352,7 @@ namespace FanaBridge.Tests
             // ENGINE_MAPPING is ASCII on the wire: map 3 => single byte '3' (0x33).
             var s = NewStatus();
             Set(s, "EngineMap", 3);
-            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.EngineMapping, 4, Wrap(s), out var v));
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.EngineMapping, 4, Wrap(s), out var v));
             Assert.Equal((byte)1, v.Size);
             Assert.Equal("3", AsAscii(v));
         }
@@ -349,7 +363,7 @@ namespace FanaBridge.Tests
             // Map 10 => two bytes '1','0' (matches official capture: p26 sz2 = 3130).
             var s = NewStatus();
             Set(s, "EngineMap", 10);
-            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.EngineMapping, 4, Wrap(s), out var v));
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.EngineMapping, 4, Wrap(s), out var v));
             Assert.Equal((byte)2, v.Size);
             Assert.Equal("10", AsAscii(v));
         }
@@ -375,7 +389,7 @@ namespace FanaBridge.Tests
         [Fact]
         public void CarAhead_NoOpponents_IsZero()
         {
-            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.CarAhead, 4, Wrap(NewStatus()), out var v));
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.CarAhead, 4, Wrap(NewStatus()), out var v));
             Assert.Equal(0f, AsF32(v), 3);
         }
 
@@ -387,9 +401,9 @@ namespace FanaBridge.Tests
             Set(s, "OpponentsBehindOnTrack", OpponentList(-1.2, -3.4));     // nearest = 1.2 (abs)
 
             // Car ahead is negative (you're behind them); car behind is positive.
-            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.CarAhead, 4, Wrap(s), out var ahead));
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.CarAhead, 4, Wrap(s), out var ahead));
             Assert.Equal(-0.8f, AsF32(ahead), 3);
-            Assert.True(ItmTelemetry.TryEncodeParam(ItmParam.CarBehind, 5, Wrap(s), out var behind));
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.CarBehind, 5, Wrap(s), out var behind));
             Assert.Equal(1.2f, AsF32(behind), 3);
         }
 
@@ -402,9 +416,9 @@ namespace FanaBridge.Tests
             Set(s, "TotalLaps", 34); Set(s, "CurrentLap", 5);
             Set(s, "OpponentsCount", 20); Set(s, "Position", 7);
 
-            Assert.True(ItmTelemetry.TryGetTotalSuffix(ItmParam.Lap, Wrap(s), out var lap));
+            Assert.True(ItmTelemetryMapper.TryGetTotalSuffix(ItmParam.Lap, Wrap(s), out var lap));
             Assert.Equal("/34", lap);
-            Assert.True(ItmTelemetry.TryGetTotalSuffix(ItmParam.Position, Wrap(s), out var pos));
+            Assert.True(ItmTelemetryMapper.TryGetTotalSuffix(ItmParam.Position, Wrap(s), out var pos));
             Assert.Equal("/20", pos);   // field = OpponentsCount (list includes the player)
         }
 
@@ -416,14 +430,14 @@ namespace FanaBridge.Tests
             Set(s, "TotalLaps", 0); Set(s, "CurrentLap", 1);
             Set(s, "OpponentsCount", 1); Set(s, "Position", 7);
 
-            Assert.False(ItmTelemetry.TryGetTotalSuffix(ItmParam.Lap, Wrap(s), out _));
-            Assert.False(ItmTelemetry.TryGetTotalSuffix(ItmParam.Position, Wrap(s), out _));
+            Assert.False(ItmTelemetryMapper.TryGetTotalSuffix(ItmParam.Lap, Wrap(s), out _));
+            Assert.False(ItmTelemetryMapper.TryGetTotalSuffix(ItmParam.Position, Wrap(s), out _));
         }
 
         [Fact]
         public void TotalSuffix_NoneForParamWithoutTotal()
         {
-            Assert.False(ItmTelemetry.TryGetTotalSuffix(ItmParam.Speed, Wrap(NewStatus()), out _));
+            Assert.False(ItmTelemetryMapper.TryGetTotalSuffix(ItmParam.Speed, Wrap(NewStatus()), out _));
         }
 
         [Fact]
@@ -432,7 +446,7 @@ namespace FanaBridge.Tests
             // The stock app renders fuel as value/capacity (e.g. "/23"), not a unit label.
             var s = NewStatus();
             Set(s, "Fuel", 12.0); Set(s, "MaxFuel", 23.0);
-            Assert.True(ItmTelemetry.TryGetTotalSuffix(ItmParam.Fuel, Wrap(s), out var fuel));
+            Assert.True(ItmTelemetryMapper.TryGetTotalSuffix(ItmParam.Fuel, Wrap(s), out var fuel));
             Assert.Equal("/23", fuel);
         }
 
@@ -442,7 +456,7 @@ namespace FanaBridge.Tests
             // Games that don't report a tank capacity get no "/0" — fall back to bare value.
             var s = NewStatus();
             Set(s, "Fuel", 12.0); Set(s, "MaxFuel", 0.0);
-            Assert.False(ItmTelemetry.TryGetTotalSuffix(ItmParam.Fuel, Wrap(s), out _));
+            Assert.False(ItmTelemetryMapper.TryGetTotalSuffix(ItmParam.Fuel, Wrap(s), out _));
         }
 
         [Fact]
@@ -454,7 +468,7 @@ namespace FanaBridge.Tests
             Set(s, "TyreTemperatureRearLeft", 90.0);
             Set(s, "TyreTemperatureRearRight", 91.0);
 
-            var v = ItmTelemetry.BuildValues(ItmPage.TyreTemps, Wrap(s));
+            var v = ItmTelemetryMapper.BuildValues(ItmPage.TyreTemps, Wrap(s));
 
             // Order (per capture): FL, RL, FR, RR
             Assert.Equal(ItmParam.TyreFlTemp, v[2].ParamId);

--- a/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -356,6 +356,21 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void ParseSubscriptionReport_InterleavedDevices_CollectsAllMatching()
+        {
+            // dev3 h0 SPEED, dev4 h0 SPEED (other display), dev3 h1 GEAR. The middle entry must be
+            // skipped, not stop the scan, so both device-3 entries are still collected.
+            var report = HexToBytes("ff0501" + "0300010034" + "0400010034" + "0301040034");
+            var subs = ItmTelemetry.ParseSubscriptionReport(report, report.Length);   // default device 3
+
+            Assert.Equal(2, subs.Count);
+            Assert.Equal(0, subs[0].Handle);
+            Assert.Equal(ItmParam.Speed, subs[0].ParamId);
+            Assert.Equal(1, subs[1].Handle);
+            Assert.Equal(ItmParam.Gear, subs[1].ParamId);
+        }
+
+        [Fact]
         public void TryEncodeParam_KnownParam_Encodes()
         {
             var s = NewStatus();

--- a/FanaBridge.Tests/WheelProfileItmDeviceTests.cs
+++ b/FanaBridge.Tests/WheelProfileItmDeviceTests.cs
@@ -22,5 +22,15 @@ namespace FanaBridge.Tests
         {
             Assert.Equal(id, new WheelProfile { ItmDeviceIdRaw = id }.ItmDeviceId);
         }
+
+        [Fact]
+        public void GetRestartReason_ItmDeviceChange_RequiresRestart()
+        {
+            var dev3 = new WheelCapabilities(new WheelProfile { Display = "itm", ItmDeviceIdRaw = 3 });
+            var dev4 = new WheelCapabilities(new WheelProfile { Display = "itm", ItmDeviceIdRaw = 4 });
+
+            Assert.NotNull(dev4.GetRestartReason(dev3));   // ITM display device changed → restart
+            Assert.Null(dev4.GetRestartReason(dev4));       // identical caps → no restart
+        }
     }
 }

--- a/FanaBridge.Tests/WheelProfileItmDeviceTests.cs
+++ b/FanaBridge.Tests/WheelProfileItmDeviceTests.cs
@@ -1,0 +1,26 @@
+using FanaBridge.Profiles;
+using FanaBridge.Protocol;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class WheelProfileItmDeviceTests
+    {
+        [Fact]
+        public void ItmDeviceId_DefaultsToDevice3_WhenOmitted()
+        {
+            // No "itmDeviceId" in the JSON -> device 3 (DefaultDeviceId), correct for PBME/GTSWX.
+            Assert.Equal(ItmEncoder.DefaultDeviceId, new WheelProfile().ItmDeviceId);
+            Assert.Equal((byte)3, new WheelProfile().ItmDeviceId);
+        }
+
+        [Theory]
+        [InlineData((byte)1)]   // base display
+        [InlineData((byte)3)]   // wheel OLED (PBME / GTSWX)
+        [InlineData((byte)4)]   // Bentley
+        public void ItmDeviceId_PassesThroughRawWireId(byte id)
+        {
+            Assert.Equal(id, new WheelProfile { ItmDeviceIdRaw = id }.ItmDeviceId);
+        }
+    }
+}

--- a/FanaBridge/Adapters/DisplaySettings.cs
+++ b/FanaBridge/Adapters/DisplaySettings.cs
@@ -42,5 +42,13 @@ namespace FanaBridge.Adapters
         public const bool DefaultShowPositionTotal = true;
         /// <summary>Show the "/field size" suffix on the ITM position field.</summary>
         public bool ItmShowPositionTotal { get; set; } = DefaultShowPositionTotal;
+
+        public const byte DefaultItmDefaultPage = 1;   // Lap Info
+        /// <summary>
+        /// The ITM page (wire page number) forced when the display starts. The wheel's display
+        /// button navigates from there. Defaults to page 1 (Lap Info). Valid page numbers depend
+        /// on the display device — see <c>ItmDeviceCatalog.PagesFor</c>.
+        /// </summary>
+        public byte ItmDefaultPage { get; set; } = DefaultItmDefaultPage;
     }
 }

--- a/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -306,7 +306,8 @@ namespace FanaBridge.Adapters
                 if (_itmDisplay == null)
                 {
                     _itmDisplay = new ItmDisplayDriver(plugin.Itm,
-                        log: msg => SimHub.Logging.Current.Info("FanaBridge: " + msg));
+                        log: msg => SimHub.Logging.Current.Info("FanaBridge: " + msg),
+                        deviceId: _config.Capabilities.ItmDeviceId);
                     SimHub.Logging.Current.Info(
                         "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: Created ITM display driver");
                 }

--- a/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -131,6 +131,7 @@ namespace FanaBridge.Adapters
                 ["itmEnabled"] = DisplaySettings.DefaultItmEnabled,
                 ["itmShowLapTotal"] = DisplaySettings.DefaultShowLapTotal,
                 ["itmShowPositionTotal"] = DisplaySettings.DefaultShowPositionTotal,
+                ["itmDefaultPage"] = DisplaySettings.DefaultItmDefaultPage,
             };
             _displaySettings = new DisplaySettings();
 
@@ -216,7 +217,7 @@ namespace FanaBridge.Adapters
             // Extract custom settings
             _customSettings = new JObject();
             foreach (var key in new[] { "wheelType", "moduleType", "displayMode", "itmEnabled",
-                                        "itmShowLapTotal", "itmShowPositionTotal" })
+                                        "itmShowLapTotal", "itmShowPositionTotal", "itmDefaultPage" })
             {
                 if (obj[key] != null)
                     _customSettings[key] = obj[key].DeepClone();
@@ -251,6 +252,7 @@ namespace FanaBridge.Adapters
                 ItmEnabled = (bool?)_customSettings["itmEnabled"] ?? DisplaySettings.DefaultItmEnabled,
                 ItmShowLapTotal = (bool?)_customSettings["itmShowLapTotal"] ?? DisplaySettings.DefaultShowLapTotal,
                 ItmShowPositionTotal = (bool?)_customSettings["itmShowPositionTotal"] ?? DisplaySettings.DefaultShowPositionTotal,
+                ItmDefaultPage = (byte?)_customSettings["itmDefaultPage"] ?? DisplaySettings.DefaultItmDefaultPage,
             };
 
             _displayManager?.UpdateSettings(_displaySettings);
@@ -440,6 +442,7 @@ namespace FanaBridge.Adapters
                     _customSettings["itmEnabled"] = _displaySettings.ItmEnabled;
                     _customSettings["itmShowLapTotal"] = _displaySettings.ItmShowLapTotal;
                     _customSettings["itmShowPositionTotal"] = _displaySettings.ItmShowPositionTotal;
+                    _customSettings["itmDefaultPage"] = _displaySettings.ItmDefaultPage;
                     _displayManager?.UpdateSettings(_displaySettings);
                     // ITM driver reads _displaySettings live each frame.
                 };

--- a/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -322,6 +322,7 @@ namespace FanaBridge.Adapters
                         _itmDisplay.Start();   // idempotent — re-arms bring-up after a disconnect
                     _itmDisplay.ShowLapTotal = _displaySettings.ItmShowLapTotal;
                     _itmDisplay.ShowPositionTotal = _displaySettings.ItmShowPositionTotal;
+                    _itmDisplay.DefaultPage = _displaySettings.ItmDefaultPage;
 
                     // Feed the firmware's pushed ITM subscription reports (col03-IN) to the
                     // driver so it follows the page the wheel button selects.
@@ -431,7 +432,7 @@ namespace FanaBridge.Adapters
             if (_config.Capabilities.Display != DisplayType.None)
             {
                 var screenPanel = new ScreenSettingsPanel();
-                screenPanel.Bind(_displaySettings, _config.Capabilities.Display);
+                screenPanel.Bind(_displaySettings, _config.Capabilities.Display, _config.Capabilities.ItmDeviceId);
                 screenPanel.SettingsChanged += () =>
                 {
                     // Sync back to JObject for persistence.

--- a/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -142,11 +142,11 @@ namespace FanaBridge.Adapters
             foreach (var kv in _subs)
             {
                 string suffix;
-                if (ItmTelemetry.TryGetUnitSuffix(kv.Value, data, out suffix))
+                if (ItmTelemetryMapper.TryGetUnitSuffix(kv.Value, data, out suffix))
                 {
                     // Static unit label (e.g. "C").
                 }
-                else if (ItmTelemetry.IsTotalParam(kv.Value))
+                else if (ItmTelemetryMapper.IsTotalParam(kv.Value))
                 {
                     // Lap/position/fuel: always emit an entry so a total that disappears is
                     // actively cleared — a zero-length suffix does NOT overwrite the firmware's
@@ -154,9 +154,9 @@ namespace FanaBridge.Adapters
                     // tank capacity it falls back to the unit label ("L"/"G") rather than a blank,
                     // so a bare fuel value still reads as fuel.
                     suffix = ShowTotalFor(kv.Value)
-                          && ItmTelemetry.TryGetTotalSuffix(kv.Value, data, out var total)
+                          && ItmTelemetryMapper.TryGetTotalSuffix(kv.Value, data, out var total)
                         ? total
-                        : (kv.Value == ItmParam.Fuel ? ItmTelemetry.FuelUnitLabel(data) : " ");
+                        : (kv.Value == ItmParam.Fuel ? ItmTelemetryMapper.FuelUnitLabel(data) : " ");
                 }
                 else
                 {
@@ -263,7 +263,7 @@ namespace FanaBridge.Adapters
             _valueBuf.Clear();
             foreach (var kv in _subs)
             {
-                if (ItmTelemetry.TryEncodeParam(kv.Value, kv.Key, data, out var v))
+                if (ItmTelemetryMapper.TryEncodeParam(kv.Value, kv.Key, data, out var v))
                     _valueBuf.Add(v);
                 else if (_unencodableWarned.Add(kv.Value))
                     // Firmware subscribed a parameter outside our page layouts — it will

--- a/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -25,6 +25,7 @@ namespace FanaBridge.Adapters
     public class ItmDisplayDriver
     {
         private readonly ItmEncoder _encoder;
+        private readonly byte _deviceId;   // which display this driver targets (PageSet + per-entry id)
         private readonly Func<long> _now;
         private readonly Action<string> _log;
 
@@ -62,11 +63,13 @@ namespace FanaBridge.Adapters
         // Subscribed paramIds we've already warned have no encoder — log each once.
         private readonly HashSet<ushort> _unencodableWarned = new HashSet<ushort>();
 
-        public ItmDisplayDriver(ItmEncoder encoder, Func<long> nowMs = null, Action<string> log = null)
+        public ItmDisplayDriver(ItmEncoder encoder, Func<long> nowMs = null, Action<string> log = null,
+            byte deviceId = ItmEncoder.DefaultDeviceId)
         {
             _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
             _now = nowMs ?? DefaultClock();
             _log = log ?? (_ => { });
+            _deviceId = deviceId;
         }
 
         private static Func<long> DefaultClock()
@@ -111,7 +114,7 @@ namespace FanaBridge.Adapters
         /// </summary>
         public void OnSubscriptionReport(byte[] report)
         {
-            var subs = ItmTelemetry.ParseSubscriptionReport(report, report?.Length ?? 0);
+            var subs = ItmTelemetry.ParseSubscriptionReport(report, report?.Length ?? 0, _deviceId);
             if (subs.Count == 0)
                 return;
 
@@ -175,7 +178,7 @@ namespace FanaBridge.Adapters
 
             if (defs != null)
             {
-                _encoder.SetParamDefs(defs);
+                _encoder.SetParamDefs(defs, _deviceId);
                 _log("ITM: ParamDefs sent — suffixes: " + s);
             }
         }
@@ -221,12 +224,12 @@ namespace FanaBridge.Adapters
             if (_phase == Phase.Enabling)
             {
                 // Bring-up: gate ITM on (FF 05 02 01), start the session (FF 02 02 00), then force
-                // page 1 (FF 05 04 03 01) so the display matches our Lap Info seed and shows correct
+                // page 1 (FF 05 04 <dev> 01) so the display matches our Lap Info seed and shows correct
                 // values right away. The wheel button navigates from there; detecting the wheel's
                 // current page on cold start (instead of forcing page 1) is deferred — see #43.
                 _encoder.SetItmMode(true);           // FF 05 02 01 — firmware ITM gate on
                 _encoder.EnableItm();                // FF 02 02 00 — start the display session
-                _encoder.SetPage((byte)3, (byte)1);  // FF 05 04 03 01 — force page 1
+                _encoder.SetPage(_deviceId, 1);      // force page 1 (Lap Info) on this display
                 SeedInitialSubscriptions();          // page 1 (Lap Info) params
                 _log("ITM: enabled — seeded " + _subs.Count + " params, following firmware subscriptions");
                 _phase = Phase.Running;
@@ -242,7 +245,7 @@ namespace FanaBridge.Adapters
             }
         }
 
-        // Bring-up forces page 1 via SetPage(3,1), which makes the firmware push page 1's
+        // Bring-up forces page 1 via SetPage(device, 1), which makes the firmware push page 1's
         // subscription — but that push takes ~tens of ms to arrive, and a bare Enable
         // announces nothing. Pre-seed the Lap Info handle→param map so values flow in that
         // gap; the firmware's push then confirms/replaces it. Only seeds when nothing's subscribed.
@@ -278,7 +281,7 @@ namespace FanaBridge.Adapters
             // Only record the values as last-sent (and log the first update) when the send
             // actually succeeded — a transport failure must not suppress the retry, or the
             // display would stay stale until a value changes.
-            if (!_encoder.SendValues(_valueBuf))
+            if (!_encoder.SendValues(_valueBuf, _deviceId))
                 return;
 
             Remember(_valueBuf);

--- a/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -40,6 +40,12 @@ namespace FanaBridge.Adapters
         public bool ShowPositionTotal { get; set; } = true;
 
         /// <summary>
+        /// The ITM page (wire page number) forced on bring-up; the wheel's display button
+        /// navigates from there. Read once per bring-up. Defaults to page 1 (Lap Info).
+        /// </summary>
+        public byte DefaultPage { get; set; } = 1;
+
+        /// <summary>
         /// Whether the ITM display is enabled. Set false to turn ITM off (the driver sends
         /// the firmware "ITM off" command and goes dormant); set true to re-enable (the
         /// next <see cref="Update"/> re-runs bring-up). Read live each frame.
@@ -51,6 +57,7 @@ namespace FanaBridge.Adapters
         private Phase _phase = Phase.Idle;
 
         private long _lastValuesMs;
+        private byte _lastPageApplied;   // last page we forced via SetPage — edge-detects a settings change
 
         // Firmware-driven subscription map: host handle -> parameter ID. Kept sorted by
         // handle so the dirty-tracking comparison sees a stable order.
@@ -224,19 +231,28 @@ namespace FanaBridge.Adapters
             if (_phase == Phase.Enabling)
             {
                 // Bring-up: gate ITM on (FF 05 02 01), start the session (FF 02 02 00), then force
-                // page 1 (FF 05 04 <dev> 01) so the display matches our Lap Info seed and shows correct
-                // values right away. The wheel button navigates from there; detecting the wheel's
-                // current page on cold start (instead of forcing page 1) is deferred — see #43.
-                _encoder.SetItmMode(true);           // FF 05 02 01 — firmware ITM gate on
-                _encoder.EnableItm();                // FF 02 02 00 — start the display session
-                _encoder.SetPage(_deviceId, 1);      // force page 1 (Lap Info) on this display
-                SeedInitialSubscriptions();          // page 1 (Lap Info) params
+                // the configured default page (FF 05 04 <dev> <page>) so the display matches our
+                // seed and shows correct values right away. The wheel button navigates from there;
+                // detecting the wheel's current page on cold start instead is deferred — see #43.
+                _encoder.SetItmMode(true);              // FF 05 02 01 — firmware ITM gate on
+                _encoder.EnableItm();                   // FF 02 02 00 — start the display session
+                _encoder.SetPage(_deviceId, DefaultPage);  // force the configured default page
+                _lastPageApplied = DefaultPage;
+                SeedInitialSubscriptions();             // the default page's params
                 _log("ITM: enabled — seeded " + _subs.Count + " params, following firmware subscriptions");
                 _phase = Phase.Running;
                 return;
             }
 
             // Running
+            // If the user changed the default page in settings, switch the display to it live
+            // (edge-triggered, so we don't fight the wheel button between changes).
+            if (DefaultPage != _lastPageApplied)
+            {
+                _encoder.SetPage(_deviceId, DefaultPage);
+                _lastPageApplied = DefaultPage;
+                _log("ITM: default page changed — forcing page " + DefaultPage);
+            }
             UpdateSlotDefs(data);   // refresh unit/total suffixes when they change
             if (now - _lastValuesMs >= ValueIntervalMs)
             {
@@ -245,17 +261,27 @@ namespace FanaBridge.Adapters
             }
         }
 
-        // Bring-up forces page 1 via SetPage(device, 1), which makes the firmware push page 1's
-        // subscription — but that push takes ~tens of ms to arrive, and a bare Enable
-        // announces nothing. Pre-seed the Lap Info handle→param map so values flow in that
-        // gap; the firmware's push then confirms/replaces it. Only seeds when nothing's subscribed.
+        // Bring-up forces the default page via SetPage(device, DefaultPage), which makes the
+        // firmware push that page's subscription — but that push takes ~tens of ms to arrive, and
+        // a bare Enable announces nothing. Pre-seed the default page's handle→param map so values
+        // flow in that gap; the firmware's push then confirms/replaces it. Seeds only when empty.
         private void SeedInitialSubscriptions()
         {
             if (_subs.Count > 0)
                 return;
-            var ids = ItmTelemetry.ParamsFor(ItmPage.LapInfo);
+            var ids = SeedParamsForPage(DefaultPage);
             for (int h = 0; h < ids.Count; h++)
                 _subs[(byte)h] = ids[h];
+        }
+
+        // The params the given page carries on this driver's device (empty for an unknown page
+        // or the legacy page). Used only to seed handles 0..N-1 before the firmware's push lands.
+        private IReadOnlyList<ushort> SeedParamsForPage(byte page)
+        {
+            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
+                if (p.Number == page)
+                    return p.Params;
+            return Array.Empty<ushort>();
         }
 
         private void SendSubscribedValues(GameData data)

--- a/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -251,6 +251,11 @@ namespace FanaBridge.Adapters
             {
                 _encoder.SetPage(_deviceId, DefaultPage);
                 _lastPageApplied = DefaultPage;
+                // Deliberately DON'T reseed here — keep the current subscriptions until the firmware
+                // pushes the new page's set. Unlike bring-up (which has no prior state), a live switch
+                // has valid subs to lose: if the PageSet flakes, or targets the page already shown (no
+                // push comes back), a speculative reseed would strand the display on wrong-page handles
+                // with nothing to correct it. The existing subs stay valid for whatever is displayed.
                 _log("ITM: default page changed — forcing page " + DefaultPage);
             }
             UpdateSlotDefs(data);   // refresh unit/total suffixes when they change

--- a/FanaBridge/Adapters/ItmTelemetryMapper.cs
+++ b/FanaBridge/Adapters/ItmTelemetryMapper.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Collections.Generic;
+using GameReaderCommon;
+using FanaBridge.Protocol;
+
+namespace FanaBridge.Adapters
+{
+    /// <summary>
+    /// Maps SimHub <see cref="GameData"/> telemetry to encoded <see cref="ItmValue"/> entries
+    /// and display suffixes for the ITM display. This is the <b>device-agnostic</b> half of ITM:
+    /// a parameter encodes from the telemetry frame the same way regardless of which display
+    /// shows it, so a single flat <c>paramId → encoder</c> registry serves every device.
+    ///
+    /// The wire-side vocabulary — the page catalog (which params a page carries) and
+    /// subscription-report parsing — lives in <see cref="ItmTelemetry"/> (Protocol, no SimHub).
+    /// This class knows both sides (wire <c>paramId</c> + SimHub <c>GameData</c>), which is why
+    /// it belongs in Adapters, not Protocol. It holds no wire framing and no state — the pure,
+    /// per-frame translation step, the ITM analogue of <c>FanatecDisplayDriver</c>'s reads.
+    /// </summary>
+    public static class ItmTelemetryMapper
+    {
+        // ── Typed encoder builders ───────────────────────────────────────
+        // Each returns an encoder: read + encode one parameter from a frame at a handle.
+        private static Func<StatusDataBase, byte, ItmValue> U8(ushort id, Func<StatusDataBase, byte> sel)
+            => (d, h) => ItmValue.UInt8(h, id, sel(d));
+
+        private static Func<StatusDataBase, byte, ItmValue> I16(ushort id, Func<StatusDataBase, short> sel)
+            => (d, h) => ItmValue.Int16(h, id, sel(d));
+
+        private static Func<StatusDataBase, byte, ItmValue> I32(ushort id, Func<StatusDataBase, int> sel)
+            => (d, h) => ItmValue.Int32(h, id, sel(d));
+
+        private static Func<StatusDataBase, byte, ItmValue> F32(ushort id, Func<StatusDataBase, float> sel)
+            => (d, h) => ItmValue.Float32(h, id, sel(d));
+
+        private static Func<StatusDataBase, byte, ItmValue> Str(ushort id, Func<StatusDataBase, string> sel)
+            => (d, h) => ItmValue.Ascii(h, id, sel(d));
+
+        // Flat paramId -> encoder registry. Device-agnostic: any subscribed parameter, on any
+        // display, encodes from the same frame the same way. The Protocol page catalog
+        // (ItmTelemetry.ParamsFor) says which params a page carries; this says how to encode one.
+        // A guard test asserts every catalog param has an entry here (see HasEncoder).
+        private static readonly Dictionary<ushort, Func<StatusDataBase, byte, ItmValue>> Registry = BuildRegistry();
+
+        private static Dictionary<ushort, Func<StatusDataBase, byte, ItmValue>> BuildRegistry()
+            => new Dictionary<ushort, Func<StatusDataBase, byte, ItmValue>>
+            {
+                // SPEED + GEAR head every page. SpeedLocal honours the user's km/h vs mph choice,
+                // matching the 7-seg driver.
+                [ItmParam.Speed] = I16(ItmParam.Speed, d => ClampSpeed(d.SpeedLocal)),
+                [ItmParam.Gear] = U8(ItmParam.Gear, d => EncodeGear(d.Gear)),
+
+                // Lap Info
+                [ItmParam.Lap] = U8(ItmParam.Lap, d => ClampByte(d.CurrentLap)),
+                [ItmParam.Position] = U8(ItmParam.Position, d => ClampByte(d.Position)),
+                [ItmParam.LapTime] = F32(ItmParam.LapTime, d => Seconds(d.CurrentLapTime)),
+                [ItmParam.LastLapTime] = F32(ItmParam.LastLapTime, d => Seconds(d.LastLapTime)),
+
+                // Fuel / ERS / DRS
+                [ItmParam.Fuel] = F32(ItmParam.Fuel, d => (float)d.Fuel),
+                [ItmParam.ErsLevel] = I32(ItmParam.ErsLevel, d => SafeRound(d.ERSPercent)),
+                [ItmParam.DrsZone] = U8(ItmParam.DrsZone, d => (byte)(d.DRSAvailable != 0 ? 1 : 0)),
+                [ItmParam.DrsActive] = U8(ItmParam.DrsActive, d => (byte)(d.DRSEnabled != 0 ? 1 : 0)),
+                [ItmParam.DeltaOwnBest] = F32(ItmParam.DeltaOwnBest, d => (float)(d.DeltaToSessionBest ?? 0.0)),
+
+                // Car Settings
+                [ItmParam.TcSetting] = U8(ItmParam.TcSetting, d => ClampByte(d.TCLevel)),
+                [ItmParam.AbsSetting] = U8(ItmParam.AbsSetting, d => ClampByte(d.ABSLevel)),
+                // ENGINE_MAPPING is ASCII text on the wire — map 10 travels as "10", not 0x0A.
+                // Sending the numeric byte wedges the firmware (verified via official capture).
+                [ItmParam.EngineMapping] = Str(ItmParam.EngineMapping, d => EngineMapText(d.EngineMap)),
+                [ItmParam.OilTemp] = U8(ItmParam.OilTemp, d => ClampByte(d.OilTemperature)),
+                // BRAKE_BIAS is Int32 tenths of a percent (512 = 51.2%); see BrakeBiasTenths.
+                [ItmParam.BrakeBias] = I32(ItmParam.BrakeBias, d => BrakeBiasTenths(d.BrakeBias)),
+
+                // Lap Times
+                [ItmParam.BestLapTime] = F32(ItmParam.BestLapTime, d => Seconds(d.BestLapTime)),
+                // Car ahead is shown as a negative gap (you're behind them); car behind positive.
+                [ItmParam.CarAhead] = F32(ItmParam.CarAhead, d => -NearestGap(d.OpponentsAheadOnTrack)),
+                [ItmParam.CarBehind] = F32(ItmParam.CarBehind, d => NearestGap(d.OpponentsBehindOnTrack)),
+
+                // Tyre Temps
+                [ItmParam.TyreFlTemp] = U8(ItmParam.TyreFlTemp, d => ClampByte(d.TyreTemperatureFrontLeft)),
+                [ItmParam.TyreRlTemp] = U8(ItmParam.TyreRlTemp, d => ClampByte(d.TyreTemperatureRearLeft)),
+                [ItmParam.TyreFrTemp] = U8(ItmParam.TyreFrTemp, d => ClampByte(d.TyreTemperatureFrontRight)),
+                [ItmParam.TyreRrTemp] = U8(ItmParam.TyreRrTemp, d => ClampByte(d.TyreTemperatureRearRight)),
+            };
+
+        // Parameters that wedge the PBME firmware when sent — never put them on the wire. The
+        // firmware may still subscribe them (so the field shows dashes), but sending a value
+        // locks up the display.
+        //
+        // Currently empty: ENGINE_MAPPING used to live here because sending it as a numeric byte
+        // froze the Car Settings page. A USBPcap of the official software revealed it is ASCII
+        // text (map "10" = bytes '1','0'), so it is now sent via Str(...). Keep the set for any
+        // future param that proves unsendable.
+        private static readonly HashSet<ushort> Unsupported = new HashSet<ushort>();
+
+        /// <summary>
+        /// Whether this parameter has a value encoder. Used by the catalog guard test to prove
+        /// every param a page can carry (<see cref="ItmTelemetry.ParamsFor"/>) is encodable.
+        /// </summary>
+        public static bool HasEncoder(ushort paramId) => Registry.ContainsKey(paramId);
+
+        // ── Suffixes ─────────────────────────────────────────────────────
+
+        // Temperatures whose value carries a unit label. SimHub delivers both the converted
+        // value AND its unit in the same frame (StatusDataBase.TemperatureUnit), so we read the
+        // label from that snapshot — no out-of-band settings lookup, always consistent with the
+        // value. (Fuel is NOT unit-labeled; it uses a "/capacity" total, with the unit only as a
+        // no-capacity fallback.)
+        private static readonly HashSet<ushort> TempParams = new HashSet<ushort>
+        {
+            ItmParam.OilTemp, ItmParam.TyreFlTemp, ItmParam.TyreFrTemp,
+            ItmParam.TyreRlTemp, ItmParam.TyreRrTemp,
+        };
+
+        /// <summary>
+        /// The unit suffix a temperature's value should display (single char, e.g. "C"/"F"/"K"),
+        /// or false if the parameter isn't a temperature. Read from the frame's
+        /// <c>TemperatureUnit</c> so it stays consistent with the already-converted value.
+        /// </summary>
+        public static bool TryGetUnitSuffix(ushort paramId, GameData data, out string suffix)
+        {
+            if (TempParams.Contains(paramId)) { suffix = UnitLabel(data?.NewData?.TemperatureUnit, "C"); return true; }
+            suffix = null;
+            return false;
+        }
+
+        /// <summary>The fuel unit as a single-char label (e.g. "L"/"G"), from the frame's
+        /// <c>FuelUnit</c>. Used only as a fallback when no tank capacity is available.</summary>
+        public static string FuelUnitLabel(GameData data) => UnitLabel(data?.NewData?.FuelUnit, "L");
+
+        // A unit string's first letter, uppercased — a single char for the display's tight space,
+        // robust to formats like "C" / "°C" / "Celsius" / "gal". Falls back when empty.
+        private static string UnitLabel(string raw, string fallback)
+        {
+            if (!string.IsNullOrEmpty(raw))
+                foreach (var c in raw)
+                    if (char.IsLetter(c)) return char.ToUpperInvariant(c).ToString();
+            return fallback;
+        }
+
+        /// <summary>Whether a parameter carries a "/total" suffix (lap, position, or fuel/capacity).</summary>
+        public static bool IsTotalParam(ushort paramId)
+            => paramId == ItmParam.Lap || paramId == ItmParam.Position || paramId == ItmParam.Fuel;
+
+        /// <summary>
+        /// The "/total" suffix for a parameter that has one — lap of total laps ("/34"),
+        /// position of field size ("/20"), fuel of tank capacity ("/23") — computed from the
+        /// current telemetry. The firmware cannot know these, so the host supplies them.
+        ///
+        /// Returns false (no suffix) when the parameter has no total, there is no telemetry
+        /// frame, or the game does not report a plausible total — i.e. the total must be present
+        /// and at least the current value. This drops misleading "/0" / "/2" suffixes from games
+        /// (e.g. Forza Horizon) that don't expose a race structure, while real races still show
+        /// the total.
+        /// </summary>
+        public static bool TryGetTotalSuffix(ushort paramId, GameData data, out string suffix)
+        {
+            suffix = null;
+            var s = data?.NewData;
+            if (s == null) return false;
+
+            switch (paramId)
+            {
+                case ItmParam.Lap:
+                    if (s.TotalLaps > 0 && s.TotalLaps >= s.CurrentLap)
+                        suffix = "/" + s.TotalLaps;
+                    return suffix != null;
+                case ItmParam.Position:
+                    int field = s.OpponentsCount;   // SimHub's opponents list already includes the player
+                    if (field > 1 && field >= s.Position)
+                        suffix = "/" + field;
+                    return suffix != null;
+                case ItmParam.Fuel:
+                    // Fuel of tank capacity (e.g. "/90"), in the user's SimHub unit. Suppress
+                    // when no capacity is reported so we never show a bare "/0".
+                    if (s.MaxFuel > 0 && s.MaxFuel >= s.Fuel)
+                        suffix = "/" + (int)Math.Round(s.MaxFuel);
+                    return suffix != null;
+                default:
+                    return false;
+            }
+        }
+
+        // ── Value encoding ───────────────────────────────────────────────
+
+        /// <summary>
+        /// Encodes a single subscribed parameter's current value at <paramref name="handle"/>,
+        /// for the firmware-driven path. Returns false when there is no telemetry frame or the
+        /// parameter has no known encoder.
+        /// </summary>
+        public static bool TryEncodeParam(ushort paramId, byte handle, GameData data, out ItmValue value)
+        {
+            value = default;
+            if (Unsupported.Contains(paramId))
+                return false;   // never send — wedges the firmware
+            var status = data?.NewData;
+            if (status == null || !Registry.TryGetValue(paramId, out var encode))
+                return false;
+            value = encode(status, handle);
+            return true;
+        }
+
+        /// <summary>
+        /// Encodes the current telemetry for <paramref name="page"/> into value entries.
+        /// Handles are assigned <paramref name="handleBase"/>..+N-1 in the page's catalog order
+        /// (<see cref="ItmTelemetry.ParamsFor"/>). Returns an empty list when there is no
+        /// telemetry frame or the page carries no parameters.
+        /// </summary>
+        public static IReadOnlyList<ItmValue> BuildValues(ItmPage page, GameData data, byte handleBase = 0)
+        {
+            var status = data?.NewData;
+            var ids = ItmTelemetry.ParamsFor(page);
+            if (status == null || ids.Count == 0)
+                return Array.Empty<ItmValue>();
+
+            var values = new ItmValue[ids.Count];
+            for (int i = 0; i < ids.Count; i++)
+                values[i] = Registry[ids[i]](status, (byte)(handleBase + i));
+            return values;
+        }
+
+        // ── Encoding helpers ─────────────────────────────────────────────
+
+        private static float Seconds(TimeSpan t) => (float)t.TotalSeconds;
+
+        // The nearest on-track gap (seconds) among a set of opponents, or 0 if none / unknown.
+        // SimHub gives no scalar gap-to-car-ahead/behind, so take the smallest
+        // |RelativeGapToPlayer| from the ahead/behind list (robust to list ordering).
+        private static float NearestGap(IEnumerable<Opponent> opponents)
+        {
+            if (opponents == null) return 0f;
+            double best = double.MaxValue;
+            foreach (var o in opponents)
+            {
+                double? g = o?.RelativeGapToPlayer;
+                if (g.HasValue)
+                {
+                    double a = Math.Abs(g.Value);
+                    if (a < best) best = a;
+                }
+            }
+            return best == double.MaxValue ? 0f : (float)best;
+        }
+
+        // Round a possibly non-finite value to int, mapping NaN/Infinity to 0. A NaN would
+        // otherwise slip through range comparisons (all false) into an undefined cast — the same
+        // firmware-safety concern BrakeBiasTenths guards against.
+        private static int SafeRound(double value)
+            => double.IsNaN(value) || double.IsInfinity(value) ? 0 : (int)Math.Round(value);
+
+        // Speed is non-negative; clamp to [0, Int16 max] (the SPEED param is Int16).
+        private static short ClampSpeed(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value)) return 0;
+            double v = Math.Round(value);
+            if (v < 0) return 0;
+            if (v > short.MaxValue) return short.MaxValue;
+            return (short)v;
+        }
+
+        private static byte ClampByte(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value)) return 0;
+            double v = Math.Round(value);
+            if (v < 0) return 0;
+            if (v > 255) return 255;
+            return (byte)v;
+        }
+
+        private static byte ClampByte(int value)
+        {
+            if (value < 0) return 0;
+            if (value > 255) return 255;
+            return (byte)value;
+        }
+
+        // BRAKE_BIAS is an Int32 in tenths of a percent (confirmed by capture: 51.2% => 512).
+        // SimHub reports a percentage, so send round(percent * 10), clamped to [0, 1000]
+        // (0–100.0%).
+        private static int BrakeBiasTenths(double percent)
+        {
+            if (double.IsNaN(percent) || double.IsInfinity(percent)) return 0;
+            int v = (int)Math.Round(percent * 10.0);
+            if (v < 0) return 0;
+            if (v > 1000) return 1000;
+            return v;
+        }
+
+        // ENGINE_MAPPING is rendered by the firmware as text (e.g. "1", "10"). SimHub reports the
+        // map as an int; send its decimal string. Clamp to [0, 99] so the payload stays within
+        // two ASCII bytes (the range the official software was observed to use).
+        private static string EngineMapText(int map)
+        {
+            if (map < 0) map = 0;
+            if (map > 99) map = 99;
+            return map.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>Reverse sentinel: -1 as a Uint8, which the firmware renders as "r".</summary>
+        private const byte GearReverse = 0xFF;
+
+        /// <summary>
+        /// Parses SimHub's gear string to the ITM Uint8 gear value: "N"/empty = 0, "1".."9" =
+        /// that number, "R" = <see cref="GearReverse"/>. Forward gears are literal, confirmed
+        /// against an official-software capture (N=0, 2=2, 3=3).
+        /// </summary>
+        private static byte EncodeGear(string gear)
+        {
+            if (string.IsNullOrEmpty(gear))
+                return 0;
+
+            gear = gear.Trim().ToUpperInvariant();
+            if (gear == "R" || gear == "REVERSE") return GearReverse;
+            if (gear == "N" || gear == "NEUTRAL") return 0;
+
+            return int.TryParse(gear, out int g) && g >= 0 && g <= 254 ? (byte)g : (byte)0;
+        }
+    }
+}

--- a/FanaBridge/Adapters/ItmTelemetryMapper.cs
+++ b/FanaBridge/Adapters/ItmTelemetryMapper.cs
@@ -86,16 +86,6 @@ namespace FanaBridge.Adapters
                 [ItmParam.TyreRrTemp] = U8(ItmParam.TyreRrTemp, d => ClampByte(d.TyreTemperatureRearRight)),
             };
 
-        // Parameters that wedge the PBME firmware when sent — never put them on the wire. The
-        // firmware may still subscribe them (so the field shows dashes), but sending a value
-        // locks up the display.
-        //
-        // Currently empty: ENGINE_MAPPING used to live here because sending it as a numeric byte
-        // froze the Car Settings page. A USBPcap of the official software revealed it is ASCII
-        // text (map "10" = bytes '1','0'), so it is now sent via Str(...). Keep the set for any
-        // future param that proves unsendable.
-        private static readonly HashSet<ushort> Unsupported = new HashSet<ushort>();
-
         /// <summary>
         /// Whether this parameter has a value encoder. Used by the catalog guard test to prove
         /// every param a page can carry (<see cref="ItmTelemetry.ParamsFor"/>) is encodable.
@@ -194,8 +184,6 @@ namespace FanaBridge.Adapters
         public static bool TryEncodeParam(ushort paramId, byte handle, GameData data, out ItmValue value)
         {
             value = default;
-            if (Unsupported.Contains(paramId))
-                return false;   // never send — wedges the firmware
             var status = data?.NewData;
             if (status == null || !Registry.TryGetValue(paramId, out var encode))
                 return false;

--- a/FanaBridge/Profiles/WheelCapabilities.cs
+++ b/FanaBridge/Profiles/WheelCapabilities.cs
@@ -108,6 +108,9 @@ namespace FanaBridge.Profiles
             if (Display != other.Display)
                 return "Display type changed (" + other.Display + " → " + Display + ")";
 
+            if (Display == DisplayType.Itm && ItmDeviceId != other.ItmDeviceId)
+                return "ITM display device changed (" + other.ItmDeviceId + " → " + ItmDeviceId + ")";
+
             return null;
         }
 

--- a/FanaBridge/Profiles/WheelCapabilities.cs
+++ b/FanaBridge/Profiles/WheelCapabilities.cs
@@ -22,6 +22,9 @@ namespace FanaBridge.Profiles
         /// <summary>Display type.</summary>
         public DisplayType Display { get; }
 
+        /// <summary>ITM display wire id — which device the ITM screen is (base=1, wheel OLED/PBME/GTSWX=3, Bentley=4).</summary>
+        public byte ItmDeviceId { get; }
+
         /// <summary>The source profile this was built from (null for the None sentinel).</summary>
         public WheelProfile Profile { get; }
 
@@ -119,6 +122,7 @@ namespace FanaBridge.Profiles
             Name = profile.Name;
             ShortName = profile.ShortName;
             Display = profile.DisplayType;
+            ItmDeviceId = profile.ItmDeviceId;
             ProfileSource = profile.Source;
             ProfileSourcePath = profile.SourcePath;
 

--- a/FanaBridge/Profiles/WheelProfile.cs
+++ b/FanaBridge/Profiles/WheelProfile.cs
@@ -49,6 +49,11 @@ namespace FanaBridge.Profiles
         [JsonProperty("display")]
         public string Display { get; set; }
 
+        /// <summary>ITM display wire id — 1 base, 3 wheel OLED (PBME/GTSWX), 4 Bentley.
+        /// Omit to default to 3 (correct for PBME/GTSWX).</summary>
+        [JsonProperty("itmDeviceId", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public byte? ItmDeviceIdRaw { get; set; }
+
         /// <summary>
         /// Pixel encoding for the Color LED channel.
         /// Defaults to "Rgb565" when omitted.  Set to "Rgb555" for hardware
@@ -102,6 +107,14 @@ namespace FanaBridge.Profiles
                 return FanaBridge.Profiles.DisplayType.None;
             }
         }
+
+        /// <summary>
+        /// ITM display wire id (which device the wheel's ITM screen is: 1 base, 3 wheel OLED,
+        /// 4 Bentley). Defaults to <see cref="FanaBridge.Protocol.ItmEncoder.DefaultDeviceId"/>
+        /// (3) when omitted — correct for PBME and GTSWX.
+        /// </summary>
+        [JsonIgnore]
+        public byte ItmDeviceId => ItmDeviceIdRaw ?? FanaBridge.Protocol.ItmEncoder.DefaultDeviceId;
 
         /// <summary>Total LED count across all channels.</summary>
         [JsonIgnore]

--- a/FanaBridge/Protocol/ItmDeviceCatalog.cs
+++ b/FanaBridge/Protocol/ItmDeviceCatalog.cs
@@ -3,28 +3,33 @@ using System.Collections.Generic;
 namespace FanaBridge.Protocol
 {
     /// <summary>
-    /// One page in an ITM device's page set: its on-wire page number, a human-readable name
-    /// (for UI page pickers), and the parameters it carries. Pure wire/reference data — no SimHub.
+    /// One slot in an ITM device's page set: the on-wire page number, which page content
+    /// (<see cref="ItmPage"/>) sits there, and that page's params and display name. Reference
+    /// data — no SimHub. The name and params are derived from the identity, defined once.
     /// </summary>
     public sealed class ItmPageInfo
     {
-        /// <summary>On-wire page number (the value sent in a <c>FF 05 04</c> PageSet).</summary>
+        /// <summary>On-wire page number on this device (the value sent in a <c>FF 05 04</c> PageSet).</summary>
         public byte Number { get; }
 
-        /// <summary>Human-readable page name, e.g. "Lap Info" / "Tyre Temps".</summary>
+        /// <summary>Which page content sits at this slot — the identity, not the wire number.</summary>
+        public ItmPage Page { get; }
+
+        /// <summary>The page's display name (reference data, from <see cref="ItmTelemetry.NameOf"/>).</summary>
         public string Name { get; }
 
         /// <summary>Parameter IDs this page carries, in order (empty for the legacy page).</summary>
         public IReadOnlyList<ushort> Params { get; }
 
         /// <summary>True for the legacy/fallback page — no telemetry parameters.</summary>
-        public bool IsLegacy => Params.Count == 0;
+        public bool IsLegacy => Page == ItmPage.Legacy;
 
-        public ItmPageInfo(byte number, string name, IReadOnlyList<ushort> parameters)
+        public ItmPageInfo(byte number, ItmPage page)
         {
             Number = number;
-            Name = name;
-            Params = parameters;
+            Page = page;
+            Name = ItmTelemetry.NameOf(page);
+            Params = ItmTelemetry.ParamsFor(page);
         }
     }
 
@@ -41,25 +46,25 @@ namespace FanaBridge.Protocol
     public static class ItmDeviceCatalog
     {
         // Standard six-page set — base display (1), the wheel OLED (3), and any device without a
-        // dedicated set below.
+        // dedicated set below. Each slot is (wire page number, page content).
         private static readonly IReadOnlyList<ItmPageInfo> Standard = new[]
         {
-            new ItmPageInfo(1, "Lap Info",         ItmTelemetry.ParamsFor(ItmPage.LapInfo)),
-            new ItmPageInfo(2, "Fuel / ERS / DRS", ItmTelemetry.ParamsFor(ItmPage.FuelErsDrs)),
-            new ItmPageInfo(3, "Car Settings",     ItmTelemetry.ParamsFor(ItmPage.CarSettings)),
-            new ItmPageInfo(4, "Lap Times",        ItmTelemetry.ParamsFor(ItmPage.LapTimes)),
-            new ItmPageInfo(5, "Tyre Temps",       ItmTelemetry.ParamsFor(ItmPage.TyreTemps)),
-            new ItmPageInfo(6, "Legacy",           ItmTelemetry.ParamsFor(ItmPage.Legacy)),
+            new ItmPageInfo(1, ItmPage.LapInfo),
+            new ItmPageInfo(2, ItmPage.FuelErsDrs),
+            new ItmPageInfo(3, ItmPage.CarSettings),
+            new ItmPageInfo(4, ItmPage.LapTimes),
+            new ItmPageInfo(5, ItmPage.TyreTemps),
+            new ItmPageInfo(6, ItmPage.Legacy),
         };
 
         // Bentley GT3 (device 4): no Car Settings; the remaining pages renumber to a contiguous 1–5.
         private static readonly IReadOnlyList<ItmPageInfo> Bentley = new[]
         {
-            new ItmPageInfo(1, "Lap Info",         ItmTelemetry.ParamsFor(ItmPage.LapInfo)),
-            new ItmPageInfo(2, "Fuel / ERS / DRS", ItmTelemetry.ParamsFor(ItmPage.FuelErsDrs)),
-            new ItmPageInfo(3, "Lap Times",        ItmTelemetry.ParamsFor(ItmPage.LapTimes)),
-            new ItmPageInfo(4, "Tyre Temps",       ItmTelemetry.ParamsFor(ItmPage.TyreTemps)),
-            new ItmPageInfo(5, "Legacy",           ItmTelemetry.ParamsFor(ItmPage.Legacy)),
+            new ItmPageInfo(1, ItmPage.LapInfo),
+            new ItmPageInfo(2, ItmPage.FuelErsDrs),
+            new ItmPageInfo(3, ItmPage.LapTimes),
+            new ItmPageInfo(4, ItmPage.TyreTemps),
+            new ItmPageInfo(5, ItmPage.Legacy),
         };
 
         /// <summary>

--- a/FanaBridge/Protocol/ItmDeviceCatalog.cs
+++ b/FanaBridge/Protocol/ItmDeviceCatalog.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// One page in an ITM device's page set: its on-wire page number, a human-readable name
+    /// (for UI page pickers), and the parameters it carries. Pure wire/reference data — no SimHub.
+    /// </summary>
+    public sealed class ItmPageInfo
+    {
+        /// <summary>On-wire page number (the value sent in a <c>FF 05 04</c> PageSet).</summary>
+        public byte Number { get; }
+
+        /// <summary>Human-readable page name, e.g. "Lap Info" / "Tyre Temps".</summary>
+        public string Name { get; }
+
+        /// <summary>Parameter IDs this page carries, in order (empty for the legacy page).</summary>
+        public IReadOnlyList<ushort> Params { get; }
+
+        /// <summary>True for the legacy/fallback page — no telemetry parameters.</summary>
+        public bool IsLegacy => Params.Count == 0;
+
+        public ItmPageInfo(byte number, string name, IReadOnlyList<ushort> parameters)
+        {
+            Number = number;
+            Name = name;
+            Params = parameters;
+        }
+    }
+
+    /// <summary>
+    /// The ITM page set each display device offers — keyed by wire device id. This is what a UI
+    /// reads to know which pages are valid/available (e.g. to populate a "default page" picker),
+    /// and it is the single place the per-device layouts are declared.
+    ///
+    /// The page <b>content</b> reuses the Base/BME param lists (<see cref="ItmTelemetry.ParamsFor"/>);
+    /// devices differ only in which pages they expose and their numbering:
+    /// <list type="bullet">
+    /// <item>Base display (1) and wheel OLED / PBME / GTSWX (3) share the standard six pages.</item>
+    /// <item>Bentley (4) has no Car Settings page and renumbers the rest to a contiguous 1–5.</item>
+    /// </list>
+    /// (GTSWX shares wire id 3 with the PBME; its only real difference — a compact Lap Times page —
+    /// is a parameter-level detail the firmware-driven path handles on its own, so it needs no
+    /// separate page set here.)
+    /// </summary>
+    public static class ItmDeviceCatalog
+    {
+        // Standard six-page set: base display, wheel OLED (PBME / GTSWX).
+        private static readonly IReadOnlyList<ItmPageInfo> Standard = new[]
+        {
+            new ItmPageInfo(1, "Lap Info",         ItmTelemetry.ParamsFor(ItmPage.LapInfo)),
+            new ItmPageInfo(2, "Fuel / ERS / DRS", ItmTelemetry.ParamsFor(ItmPage.FuelErsDrs)),
+            new ItmPageInfo(3, "Car Settings",     ItmTelemetry.ParamsFor(ItmPage.CarSettings)),
+            new ItmPageInfo(4, "Lap Times",        ItmTelemetry.ParamsFor(ItmPage.LapTimes)),
+            new ItmPageInfo(5, "Tyre Temps",       ItmTelemetry.ParamsFor(ItmPage.TyreTemps)),
+            new ItmPageInfo(6, "Legacy",           ItmTelemetry.ParamsFor(ItmPage.Legacy)),
+        };
+
+        // Bentley: no Car Settings; the remaining pages renumber to a contiguous 1–5.
+        private static readonly IReadOnlyList<ItmPageInfo> Bentley = new[]
+        {
+            new ItmPageInfo(1, "Lap Info",         ItmTelemetry.ParamsFor(ItmPage.LapInfo)),
+            new ItmPageInfo(2, "Fuel / ERS / DRS", ItmTelemetry.ParamsFor(ItmPage.FuelErsDrs)),
+            new ItmPageInfo(3, "Lap Times",        ItmTelemetry.ParamsFor(ItmPage.LapTimes)),
+            new ItmPageInfo(4, "Tyre Temps",       ItmTelemetry.ParamsFor(ItmPage.TyreTemps)),
+            new ItmPageInfo(5, "Legacy",           ItmTelemetry.ParamsFor(ItmPage.Legacy)),
+        };
+
+        /// <summary>
+        /// The pages a display device offers, in order, for the given wire
+        /// <paramref name="deviceId"/> (see <see cref="ItmDevice"/>). Unknown ids fall back to the
+        /// standard set. The list is shared/immutable — do not mutate.
+        /// </summary>
+        public static IReadOnlyList<ItmPageInfo> PagesFor(byte deviceId)
+        {
+            switch (deviceId)
+            {
+                case (byte)ItmDevice.Bentley: return Bentley;
+                case (byte)ItmDevice.Base:            // base display
+                case (byte)ItmDevice.BmeOrGtswx:      // wheel OLED (PBME / GTSWX)
+                default:
+                    return Standard;
+            }
+        }
+    }
+}

--- a/FanaBridge/Protocol/ItmDeviceCatalog.cs
+++ b/FanaBridge/Protocol/ItmDeviceCatalog.cs
@@ -29,23 +29,19 @@ namespace FanaBridge.Protocol
     }
 
     /// <summary>
-    /// The ITM page set each display device offers — keyed by wire device id. This is what a UI
-    /// reads to know which pages are valid/available (e.g. to populate a "default page" picker),
-    /// and it is the single place the per-device layouts are declared.
+    /// The pages each ITM display offers, keyed by wire device id — what a UI reads to populate a
+    /// "default page" picker and what the driver seeds from on bring-up. A device's page set is a
+    /// property of its firmware; today only device 4 (the Bentley GT3) differs from the standard
+    /// six-page set. Page <b>content</b> reuses the shared param lists (<see cref="ItmTelemetry.ParamsFor"/>).
     ///
-    /// The page <b>content</b> reuses the Base/BME param lists (<see cref="ItmTelemetry.ParamsFor"/>);
-    /// devices differ only in which pages they expose and their numbering:
-    /// <list type="bullet">
-    /// <item>Base display (1) and wheel OLED / PBME / GTSWX (3) share the standard six pages.</item>
-    /// <item>Bentley (4) has no Car Settings page and renumbers the rest to a contiguous 1–5.</item>
-    /// </list>
-    /// (GTSWX shares wire id 3 with the PBME; its only real difference — a compact Lap Times page —
-    /// is a parameter-level detail the firmware-driven path handles on its own, so it needs no
-    /// separate page set here.)
+    /// The page set currently tracks the device id 1:1. If two wheels ever share a device id but
+    /// lay their pages out differently, that is the seam to add a per-wheel discriminator (a profile
+    /// field) — until then, deriving the pages from the device id is the simplest honest model.
     /// </summary>
     public static class ItmDeviceCatalog
     {
-        // Standard six-page set: base display, wheel OLED (PBME / GTSWX).
+        // Standard six-page set — base display (1), the wheel OLED (3), and any device without a
+        // dedicated set below.
         private static readonly IReadOnlyList<ItmPageInfo> Standard = new[]
         {
             new ItmPageInfo(1, "Lap Info",         ItmTelemetry.ParamsFor(ItmPage.LapInfo)),
@@ -56,7 +52,7 @@ namespace FanaBridge.Protocol
             new ItmPageInfo(6, "Legacy",           ItmTelemetry.ParamsFor(ItmPage.Legacy)),
         };
 
-        // Bentley: no Car Settings; the remaining pages renumber to a contiguous 1–5.
+        // Bentley GT3 (device 4): no Car Settings; the remaining pages renumber to a contiguous 1–5.
         private static readonly IReadOnlyList<ItmPageInfo> Bentley = new[]
         {
             new ItmPageInfo(1, "Lap Info",         ItmTelemetry.ParamsFor(ItmPage.LapInfo)),
@@ -67,19 +63,15 @@ namespace FanaBridge.Protocol
         };
 
         /// <summary>
-        /// The pages a display device offers, in order, for the given wire
-        /// <paramref name="deviceId"/> (see <see cref="ItmDevice"/>). Unknown ids fall back to the
-        /// standard set. The list is shared/immutable — do not mutate.
+        /// The pages the given wire <paramref name="deviceId"/> offers, in order. Unknown ids fall
+        /// back to the standard set. The list is shared/immutable — do not mutate.
         /// </summary>
         public static IReadOnlyList<ItmPageInfo> PagesFor(byte deviceId)
         {
             switch (deviceId)
             {
-                case (byte)ItmDevice.Bentley: return Bentley;
-                case (byte)ItmDevice.Base:            // base display
-                case (byte)ItmDevice.BmeOrGtswx:      // wheel OLED (PBME / GTSWX)
-                default:
-                    return Standard;
+                case 4:  return Bentley;   // Bentley GT3
+                default: return Standard;
             }
         }
     }

--- a/FanaBridge/Protocol/ItmEncoder.cs
+++ b/FanaBridge/Protocol/ItmEncoder.cs
@@ -173,14 +173,18 @@ namespace FanaBridge.Protocol
         private const byte SUBCMD_PARAM_DEFS = 0x03;
         private const byte SUBCMD_PAGESET = 0x04;    // PageSet: byte[3]=display-device id, byte[4]=page
 
-        // First byte of every ValueUpdate/ParamDefs entry: the display-device id (which
-        // display the entry targets), not a marker. FanaBridge only drives the PBME/GTSWX
-        // (device 3), so it is hardcoded to 3; base (1) / Bentley (4) support would derive
-        // it per identity (#43).
-        private const byte ENTRY_DEVICE_ID = 0x03;
+        // First byte of every ValueUpdate/ParamDefs entry is the display-device id — which
+        // display the entry targets (see ItmDevice), not a marker. Callers pass the id for the
+        // display they drive; DefaultDeviceId (PBME/GTSWX, device 3) is used when omitted.
+
+        /// <summary>
+        /// Default display-device id when a caller doesn't specify one: the PBME/GTSWX
+        /// (device 3). A caller driving another display (base=1, Bentley=4) passes its own.
+        /// </summary>
+        public const byte DefaultDeviceId = (byte)ItmDevice.BmeOrGtswx;
 
         // Fixed-size prefixes of a single entry, before the variable tail. The leading
-        // byte is the display-device id (see ENTRY_DEVICE_ID), not a marker.
+        // byte is the display-device id, not a marker.
         // ValueUpdate:  deviceId, handle, idLo, idHi, size          (+ Size value bytes)
         // ParamDefs:    deviceId, slotId, posLo, posHi, suffixLen   (+ suffix bytes)
         private const int VALUE_ENTRY_HEADER = 5;
@@ -262,9 +266,10 @@ namespace FanaBridge.Protocol
         /// many 64-byte reports as needed, each carrying the <c>FF 05 03</c> header.
         /// Re-send after every <see cref="EnableItm"/>. Returns false if the list is
         /// null/empty, exceeds <see cref="MaxParams"/>, or any suffix exceeds
-        /// <see cref="MaxSuffixLength"/>.
+        /// <see cref="MaxSuffixLength"/>. <paramref name="deviceId"/> is the target display
+        /// (defaults to <see cref="DefaultDeviceId"/>).
         /// </summary>
-        public bool SetParamDefs(IReadOnlyList<ItmParamDef> defs)
+        public bool SetParamDefs(IReadOnlyList<ItmParamDef> defs, byte deviceId = DefaultDeviceId)
         {
             if (defs == null || defs.Count == 0 || defs.Count > MaxParams)
                 return false;
@@ -294,7 +299,7 @@ namespace FanaBridge.Protocol
                         if (pos + entryLen > REPORT_LENGTH)
                             break;
 
-                        _reportBuf[pos++] = ENTRY_DEVICE_ID;
+                        _reportBuf[pos++] = deviceId;
                         _reportBuf[pos++] = d.SlotId;
                         _reportBuf[pos++] = (byte)(d.Position & 0xFF);
                         _reportBuf[pos++] = (byte)((d.Position >> 8) & 0xFF);
@@ -316,9 +321,10 @@ namespace FanaBridge.Protocol
         /// Sends telemetry values (subcmd 0x01). Entries are packed into as many
         /// 64-byte reports as needed, each carrying the <c>FF 05 01</c> header.
         /// Returns false if the list is null/empty, exceeds <see cref="MaxParams"/>,
-        /// or any entry has a size other than 1, 2, or 4.
+        /// or any entry has a size other than 1, 2, or 4. <paramref name="deviceId"/> is the
+        /// target display (defaults to <see cref="DefaultDeviceId"/>).
         /// </summary>
-        public bool SendValues(IReadOnlyList<ItmValue> values)
+        public bool SendValues(IReadOnlyList<ItmValue> values, byte deviceId = DefaultDeviceId)
         {
             if (values == null || values.Count == 0 || values.Count > MaxParams)
                 return false;
@@ -346,7 +352,7 @@ namespace FanaBridge.Protocol
                         if (pos + entryLen > REPORT_LENGTH)
                             break;
 
-                        _reportBuf[pos++] = ENTRY_DEVICE_ID;
+                        _reportBuf[pos++] = deviceId;
                         _reportBuf[pos++] = v.Handle;
                         _reportBuf[pos++] = (byte)(v.ParamId & 0xFF);
                         _reportBuf[pos++] = (byte)((v.ParamId >> 8) & 0xFF);

--- a/FanaBridge/Protocol/ItmEncoder.cs
+++ b/FanaBridge/Protocol/ItmEncoder.cs
@@ -7,26 +7,6 @@ using FanaBridge.Transport;
 namespace FanaBridge.Protocol
 {
     /// <summary>
-    /// Target display device for an ITM page change (col03 <c>FF 05 04</c>, byte[3]).
-    /// Multiple ITM-capable surfaces can be present at once, each addressed by its
-    /// own device ID. See the protocol reference, "ITM Supported Devices".
-    /// </summary>
-    public enum ItmDevice : byte
-    {
-        /// <summary>The wheelbase's own display (PDD1/PDD1-PS4/PDD2).</summary>
-        Base = 1,
-
-        /// <summary>
-        /// The PBME's large OLED or the GTSWX's built-in display. These share device
-        /// ID 3 on the wire and are mutually exclusive — a setup has one or the other.
-        /// </summary>
-        BmeOrGtswx = 3,
-
-        /// <summary>The Bentley GT3 wheel's built-in display.</summary>
-        Bentley = 4,
-    }
-
-    /// <summary>
     /// A single telemetry value for an ITM ValueUpdate entry (col03 <c>FF 05 01</c>).
     /// The <see cref="Raw"/> bits are emitted little-endian, <see cref="Size"/> bytes
     /// wide. Use the typed factory helpers (<see cref="UInt8"/>, <see cref="Int16"/>,
@@ -174,14 +154,14 @@ namespace FanaBridge.Protocol
         private const byte SUBCMD_PAGESET = 0x04;    // PageSet: byte[3]=display-device id, byte[4]=page
 
         // First byte of every ValueUpdate/ParamDefs entry is the display-device id — which
-        // display the entry targets (see ItmDevice), not a marker. Callers pass the id for the
-        // display they drive; DefaultDeviceId (PBME/GTSWX, device 3) is used when omitted.
+        // display the entry targets, not a marker. Callers pass the id for the display they
+        // drive; DefaultDeviceId (the wheel OLED, device 3) is used when omitted.
 
         /// <summary>
-        /// Default display-device id when a caller doesn't specify one: the PBME/GTSWX
-        /// (device 3). A caller driving another display (base=1, Bentley=4) passes its own.
+        /// Default ITM display-device wire id when a caller doesn't specify one: <b>3</b> — the
+        /// wheel's OLED (PBME, GTSWX, Formula V3, …). Other displays: base = 1, Bentley = 4.
         /// </summary>
-        public const byte DefaultDeviceId = (byte)ItmDevice.BmeOrGtswx;
+        public const byte DefaultDeviceId = 3;
 
         // Fixed-size prefixes of a single entry, before the variable tail. The leading
         // byte is the display-device id, not a marker.
@@ -243,13 +223,10 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
-        /// Selects the active ITM page on a specific display device. Page changes
-        /// should be spaced at least 100&#160;ms apart (firmware reconfiguration time) —
-        /// the caller is responsible for that spacing.
+        /// Selects the active ITM page on a display device (byte[3] = wire device id,
+        /// byte[4] = page). Page changes should be spaced at least 100&#160;ms apart (firmware
+        /// reconfiguration time) — the caller is responsible for that spacing.
         /// </summary>
-        public bool SetPage(ItmDevice device, byte page) => SetPage((byte)device, page);
-
-        /// <summary>Raw overload of <see cref="SetPage(ItmDevice, byte)"/> for an arbitrary device ID.</summary>
         public bool SetPage(byte deviceId, byte page)
         {
             Array.Clear(_reportBuf, 0, REPORT_LENGTH);

--- a/FanaBridge/Protocol/ItmTelemetry.cs
+++ b/FanaBridge/Protocol/ItmTelemetry.cs
@@ -142,9 +142,11 @@ namespace FanaBridge.Protocol
         /// entries. Each entry is <c>[deviceId][fwHandle][paramId-LE][dataType]</c> — the leading
         /// byte is the display-device id (which display the entry is for), not a marker; the host
         /// handle is <c>fwHandle &amp; 0x7F</c> and <c>paramId == 0xFFFF</c> means unsubscribe.
-        /// Returns an empty list if the report carries no recognizable entries.
+        /// Only entries for <paramref name="deviceId"/> (the display this driver targets,
+        /// default <see cref="ItmEncoder.DefaultDeviceId"/>) are returned. Returns an empty
+        /// list if the report carries no recognizable entries.
         /// </summary>
-        public static IReadOnlyList<ItmSubscription> ParseSubscriptionReport(byte[] report, int len)
+        public static IReadOnlyList<ItmSubscription> ParseSubscriptionReport(byte[] report, int len, byte deviceId = ItmEncoder.DefaultDeviceId)
         {
             var result = new List<ItmSubscription>();
             if (report == null) return result;
@@ -161,11 +163,11 @@ namespace FanaBridge.Protocol
             if (start < 0) return result;
 
             // Entries: [deviceId][fwHandle][idLo][idHi][dataType], 5 bytes each. Byte 0 is the
-            // display-device id. We only drive the PBME/GTSWX (device 3), so stop at the first
-            // entry for any other display (base/Bentley multi-device support isn't wired up yet).
+            // display-device id. Each driver targets one display, so stop at the first entry for
+            // any other device (a report can, in principle, interleave devices).
             for (int i = start; i + 5 <= len; i += 5)
             {
-                if (report[i] != 0x03) break;   // device 3 = PBME/GTSWX (the only display we handle)
+                if (report[i] != deviceId) break;   // entries for the display this driver targets
                 byte fwHandle = report[i + 1];
                 ushort pid = (ushort)(report[i + 2] | (report[i + 3] << 8));
                 result.Add(new ItmSubscription(fwHandle, pid));

--- a/FanaBridge/Protocol/ItmTelemetry.cs
+++ b/FanaBridge/Protocol/ItmTelemetry.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using GameReaderCommon;
 
 namespace FanaBridge.Protocol
 {
@@ -88,272 +87,54 @@ namespace FanaBridge.Protocol
     }
 
     /// <summary>
-    /// Maps SimHub <see cref="GameData"/> telemetry to the encoded
-    /// <see cref="ItmValue"/> entries for a given <see cref="ItmPage"/>, ready to
-    /// hand to <see cref="ItmEncoder.SendValues"/>.
+    /// Wire-side ITM protocol vocabulary: the per-page parameter <b>catalog</b> (which
+    /// parameter IDs a page carries, in order) and firmware subscription-report parsing.
+    /// This is pure wire — no SimHub <c>GameData</c>. The SimHub telemetry → value/suffix
+    /// mapping lives in <c>ItmTelemetryMapper</c> (Adapters), which knows both sides.
     ///
-    /// This is the pure, per-frame translation step — the ITM analogue of
-    /// <c>FanatecDisplayDriver</c>'s telemetry reads. It holds no state and does
-    /// no I/O; page selection and the enable/ParamDefs sequence belong to the
-    /// (future) ITM display driver above it.
-    ///
-    /// Handles are assigned sequentially (0..N-1) in page-field order. That mirrors
-    /// a straightforward ParamDefs slot layout; if the on-hardware slot/handle
-    /// mapping (protocol reference, "Slot &amp; Handle Mapping") proves to need
-    /// specific handle ranges per page, this is the single place to change it.
+    /// The catalog is the firmware's page structure. Today only the Base/BME layout is
+    /// modelled (via <see cref="ItmPage"/>); per-device profiles (Bentley/GTSWX/Base) are a
+    /// follow-up — this is the single place the layouts are declared.
     /// </summary>
     public static class ItmTelemetry
     {
-        // A single page field: its parameter ID plus how to read+encode it from
-        // a telemetry frame for a given handle.
-        private sealed class Field
-        {
-            public readonly ushort ParamId;
-            private readonly Func<StatusDataBase, byte, ItmValue> _encode;
+        // ── Page catalog (paramId order per page, matching the official-software captures) ──
+        // Handles are assigned sequentially (0..N-1) in this order.
 
-            public Field(ushort paramId, Func<StatusDataBase, byte, ItmValue> encode)
-            {
-                ParamId = paramId;
-                _encode = encode;
-            }
+        private static readonly IReadOnlyList<ushort> LapInfoParams = Array.AsReadOnly(new ushort[]
+            { ItmParam.Speed, ItmParam.Gear, ItmParam.Lap, ItmParam.Position, ItmParam.LapTime, ItmParam.LastLapTime });
 
-            public ItmValue Encode(StatusDataBase data, byte handle) => _encode(data, handle);
-        }
+        private static readonly IReadOnlyList<ushort> FuelErsDrsParams = Array.AsReadOnly(new ushort[]
+            { ItmParam.Speed, ItmParam.Gear, ItmParam.Fuel, ItmParam.ErsLevel, ItmParam.DrsZone, ItmParam.DrsActive, ItmParam.DeltaOwnBest });
 
-        // ── Typed field builders ─────────────────────────────────────────
-        private static Field U8(ushort id, Func<StatusDataBase, byte> sel)
-            => new Field(id, (d, h) => ItmValue.UInt8(h, id, sel(d)));
+        // Order (handles 2..6) matches the official-software capture: TC, ABS, EngineMap, OilTemp, BrakeBias.
+        private static readonly IReadOnlyList<ushort> CarSettingsParams = Array.AsReadOnly(new ushort[]
+            { ItmParam.Speed, ItmParam.Gear, ItmParam.TcSetting, ItmParam.AbsSetting, ItmParam.EngineMapping, ItmParam.OilTemp, ItmParam.BrakeBias });
 
-        private static Field I16(ushort id, Func<StatusDataBase, short> sel)
-            => new Field(id, (d, h) => ItmValue.Int16(h, id, sel(d)));
+        private static readonly IReadOnlyList<ushort> LapTimesParams = Array.AsReadOnly(new ushort[]
+            { ItmParam.Speed, ItmParam.Gear, ItmParam.LastLapTime, ItmParam.BestLapTime, ItmParam.CarAhead, ItmParam.CarBehind });
 
-        private static Field I32(ushort id, Func<StatusDataBase, int> sel)
-            => new Field(id, (d, h) => ItmValue.Int32(h, id, sel(d)));
+        // Order (handles 2..5) matches the official-software capture: FL, RL, FR, RR.
+        private static readonly IReadOnlyList<ushort> TyreTempsParams = Array.AsReadOnly(new ushort[]
+            { ItmParam.Speed, ItmParam.Gear, ItmParam.TyreFlTemp, ItmParam.TyreRlTemp, ItmParam.TyreFrTemp, ItmParam.TyreRrTemp });
 
-        private static Field F32(ushort id, Func<StatusDataBase, float> sel)
-            => new Field(id, (d, h) => ItmValue.Float32(h, id, sel(d)));
-
-        private static Field Str(ushort id, Func<StatusDataBase, string> sel)
-            => new Field(id, (d, h) => ItmValue.Ascii(h, id, sel(d)));
-
-        // SPEED + GEAR head every page (protocol reference, "ITM Page Layouts").
-        // SpeedLocal honours the user's km/h vs mph choice, matching the 7-seg driver.
-        private static readonly Field SpeedField = I16(ItmParam.Speed, d => ClampSpeed(d.SpeedLocal));
-        private static readonly Field GearField = U8(ItmParam.Gear, d => EncodeGear(d.Gear));
-        // Shared: appears on both the Lap Info and Lap Times pages.
-        private static readonly Field LastLapTimeField = F32(ItmParam.LastLapTime, d => Seconds(d.LastLapTime));
-
-        // ── Page layouts ─────────────────────────────────────────────────
-        private static readonly Field[] LapInfo =
-        {
-            SpeedField,
-            GearField,
-            U8(ItmParam.Lap, d => ClampByte(d.CurrentLap)),
-            U8(ItmParam.Position, d => ClampByte(d.Position)),
-            F32(ItmParam.LapTime, d => Seconds(d.CurrentLapTime)),
-            LastLapTimeField,
-        };
-
-        private static readonly Field[] FuelErsDrs =
-        {
-            SpeedField,
-            GearField,
-            F32(ItmParam.Fuel, d => (float)d.Fuel),
-            I32(ItmParam.ErsLevel, d => SafeRound(d.ERSPercent)),
-            U8(ItmParam.DrsZone, d => (byte)(d.DRSAvailable != 0 ? 1 : 0)),
-            U8(ItmParam.DrsActive, d => (byte)(d.DRSEnabled != 0 ? 1 : 0)),
-            F32(ItmParam.DeltaOwnBest, d => (float)(d.DeltaToSessionBest ?? 0.0)),
-        };
-
-        // Field order (handles 2..6) matches the official-software capture:
-        // TC, ABS, EngineMap, OilTemp, BrakeBias.
-        private static readonly Field[] CarSettings =
-        {
-            SpeedField,
-            GearField,
-            U8(ItmParam.TcSetting, d => ClampByte(d.TCLevel)),
-            U8(ItmParam.AbsSetting, d => ClampByte(d.ABSLevel)),
-            // ENGINE_MAPPING is ASCII text on the wire — map 10 travels as "10", not 0x0A.
-            // Sending the numeric byte wedges the firmware (verified via official capture).
-            Str(ItmParam.EngineMapping, d => EngineMapText(d.EngineMap)),
-            U8(ItmParam.OilTemp, d => ClampByte(d.OilTemperature)),
-            // BRAKE_BIAS is Int32 tenths of a percent (512 = 51.2%); see BrakeBiasTenths.
-            I32(ItmParam.BrakeBias, d => BrakeBiasTenths(d.BrakeBias)),
-        };
-
-        private static readonly Field[] LapTimes =
-        {
-            SpeedField,
-            GearField,
-            LastLapTimeField,
-            F32(ItmParam.BestLapTime, d => Seconds(d.BestLapTime)),
-            // Car ahead is shown as a negative gap (you're behind them); car behind positive.
-            F32(ItmParam.CarAhead, d => -NearestGap(d.OpponentsAheadOnTrack)),
-            F32(ItmParam.CarBehind, d => NearestGap(d.OpponentsBehindOnTrack)),
-        };
-
-        // Field order (handles 2..5) matches the official-software capture:
-        // FL, RL, FR, RR (left column, then right column).
-        private static readonly Field[] TyreTemps =
-        {
-            SpeedField,
-            GearField,
-            U8(ItmParam.TyreFlTemp, d => ClampByte(d.TyreTemperatureFrontLeft)),
-            U8(ItmParam.TyreRlTemp, d => ClampByte(d.TyreTemperatureRearLeft)),
-            U8(ItmParam.TyreFrTemp, d => ClampByte(d.TyreTemperatureFrontRight)),
-            U8(ItmParam.TyreRrTemp, d => ClampByte(d.TyreTemperatureRearRight)),
-        };
-
-        private static readonly Field[] Empty = new Field[0];
-
-        // Flat paramId -> encoder registry, built from every page's fields. Lets the
-        // firmware-driven path encode a value for any subscribed parameter ID without
-        // caring which page it belongs to.
-        private static readonly Dictionary<ushort, Field> ByParam = BuildRegistry();
-
-        // Parameters that wedge the PBME firmware when sent — never put them on the wire.
-        // The firmware may still subscribe them (so the field shows dashes), but sending a
-        // value locks up the display.
-        //
-        // Currently empty: ENGINE_MAPPING used to live here because sending it as a numeric
-        // byte froze the Car Settings page. A USBPcap of the official software revealed it is
-        // ASCII text (map "10" = bytes '1','0'), so it is now sent via Str(...) instead of
-        // being suppressed. Keep the set for any future param that proves unsendable.
-        private static readonly HashSet<ushort> Unsupported = new HashSet<ushort>();
-
-        private static Dictionary<ushort, Field> BuildRegistry()
-        {
-            var map = new Dictionary<ushort, Field>();
-            foreach (var page in new[] { LapInfo, FuelErsDrs, CarSettings, LapTimes, TyreTemps })
-                foreach (var f in page)
-                    if (!map.ContainsKey(f.ParamId))
-                        map[f.ParamId] = f;
-            return map;
-        }
-
-        private static Field[] FieldsFor(ItmPage page)
-        {
-            switch (page)
-            {
-                case ItmPage.LapInfo: return LapInfo;
-                case ItmPage.FuelErsDrs: return FuelErsDrs;
-                case ItmPage.CarSettings: return CarSettings;
-                case ItmPage.LapTimes: return LapTimes;
-                case ItmPage.TyreTemps: return TyreTemps;
-                default: return Empty;   // Legacy / unknown: no parameters
-            }
-        }
-
-        // ── Public API ───────────────────────────────────────────────────
+        private static readonly IReadOnlyList<ushort> NoParams = Array.AsReadOnly(new ushort[0]);
 
         /// <summary>
-        /// The ordered parameter IDs that make up a page. Use to build the
-        /// ParamDefs slot layout. Empty for <see cref="ItmPage.Legacy"/>.
+        /// The ordered parameter IDs that make up a page — for building the ParamDefs slot
+        /// layout and the cold-start seed. Empty for <see cref="ItmPage.Legacy"/>.
         /// </summary>
         public static IReadOnlyList<ushort> ParamsFor(ItmPage page)
         {
-            var fields = FieldsFor(page);
-            var ids = new ushort[fields.Length];
-            for (int i = 0; i < fields.Length; i++)
-                ids[i] = fields[i].ParamId;
-            return ids;
-        }
-
-        // Temperatures whose value carries a unit label. SimHub delivers both the converted
-        // value AND its unit in the same frame (StatusDataBase.TemperatureUnit), so we read the
-        // label from that snapshot — no out-of-band settings lookup, always consistent with the
-        // value. (Fuel is NOT unit-labeled; it uses a "/capacity" total, with the unit only as a
-        // no-capacity fallback.)
-        private static readonly HashSet<ushort> TempParams = new HashSet<ushort>
-        {
-            ItmParam.OilTemp, ItmParam.TyreFlTemp, ItmParam.TyreFrTemp,
-            ItmParam.TyreRlTemp, ItmParam.TyreRrTemp,
-        };
-
-        /// <summary>
-        /// The unit suffix a temperature's value should display (single char, e.g. "C"/"F"/"K"),
-        /// or false if the parameter isn't a temperature. Read from the frame's
-        /// <c>TemperatureUnit</c> so it stays consistent with the already-converted value.
-        /// </summary>
-        public static bool TryGetUnitSuffix(ushort paramId, GameData data, out string suffix)
-        {
-            if (TempParams.Contains(paramId)) { suffix = UnitLabel(data?.NewData?.TemperatureUnit, "C"); return true; }
-            suffix = null;
-            return false;
-        }
-
-        /// <summary>The fuel unit as a single-char label (e.g. "L"/"G"), from the frame's
-        /// <c>FuelUnit</c>. Used only as a fallback when no tank capacity is available.</summary>
-        public static string FuelUnitLabel(GameData data) => UnitLabel(data?.NewData?.FuelUnit, "L");
-
-        // A unit string's first letter, uppercased — a single char for the display's tight space,
-        // robust to formats like "C" / "°C" / "Celsius" / "gal". Falls back when empty.
-        private static string UnitLabel(string raw, string fallback)
-        {
-            if (!string.IsNullOrEmpty(raw))
-                foreach (var c in raw)
-                    if (char.IsLetter(c)) return char.ToUpperInvariant(c).ToString();
-            return fallback;
-        }
-
-        /// <summary>Whether a parameter carries a "/total" suffix (lap, position, or fuel/capacity).</summary>
-        public static bool IsTotalParam(ushort paramId)
-            => paramId == ItmParam.Lap || paramId == ItmParam.Position || paramId == ItmParam.Fuel;
-
-        /// <summary>
-        /// The "/total" suffix for a parameter that has one — lap of total laps ("/34"),
-        /// position of field size ("/20"), fuel of tank capacity ("/23") — computed from the
-        /// current telemetry. The firmware cannot know these, so the host supplies them.
-        ///
-        /// Returns false (no suffix) when the parameter has no total, there is no
-        /// telemetry frame, or the game does not report a plausible total — i.e. the
-        /// total must be present and at least the current value. This drops misleading
-        /// "/0" / "/2" suffixes from games (e.g. Forza Horizon) that don't expose a race
-        /// structure, while real races still show the total.
-        /// </summary>
-        public static bool TryGetTotalSuffix(ushort paramId, GameData data, out string suffix)
-        {
-            suffix = null;
-            var s = data?.NewData;
-            if (s == null) return false;
-
-            switch (paramId)
+            switch (page)
             {
-                case ItmParam.Lap:
-                    if (s.TotalLaps > 0 && s.TotalLaps >= s.CurrentLap)
-                        suffix = "/" + s.TotalLaps;
-                    return suffix != null;
-                case ItmParam.Position:
-                    int field = s.OpponentsCount;   // SimHub's opponents list already includes the player
-                    if (field > 1 && field >= s.Position)
-                        suffix = "/" + field;
-                    return suffix != null;
-                case ItmParam.Fuel:
-                    // Fuel of tank capacity (e.g. "/90"), in the user's SimHub unit. Suppress
-                    // when no capacity is reported so we never show a bare "/0".
-                    if (s.MaxFuel > 0 && s.MaxFuel >= s.Fuel)
-                        suffix = "/" + (int)System.Math.Round(s.MaxFuel);
-                    return suffix != null;
-                default:
-                    return false;
+                case ItmPage.LapInfo: return LapInfoParams;
+                case ItmPage.FuelErsDrs: return FuelErsDrsParams;
+                case ItmPage.CarSettings: return CarSettingsParams;
+                case ItmPage.LapTimes: return LapTimesParams;
+                case ItmPage.TyreTemps: return TyreTempsParams;
+                default: return NoParams;   // Legacy / unknown: no parameters
             }
-        }
-
-        /// <summary>
-        /// Encodes a single subscribed parameter's current value at <paramref name="handle"/>,
-        /// for the firmware-driven path. Returns false when there is no telemetry frame or
-        /// the parameter has no known encoder.
-        /// </summary>
-        public static bool TryEncodeParam(ushort paramId, byte handle, GameData data, out ItmValue value)
-        {
-            value = default;
-            if (Unsupported.Contains(paramId))
-                return false;   // never send — wedges the firmware
-            var status = data?.NewData;
-            if (status == null || !ByParam.TryGetValue(paramId, out var field))
-                return false;
-            value = field.Encode(status, handle);
-            return true;
         }
 
         /// <summary>
@@ -390,122 +171,6 @@ namespace FanaBridge.Protocol
                 result.Add(new ItmSubscription(fwHandle, pid));
             }
             return result;
-        }
-
-        /// <summary>
-        /// Encodes the current telemetry for <paramref name="page"/> into the value
-        /// entries to send via <see cref="ItmEncoder.SendValues"/>. Handles are
-        /// assigned <paramref name="handleBase"/>..+N-1 in field order. Returns an
-        /// empty list when there is no telemetry frame or the page carries no parameters.
-        /// </summary>
-        public static IReadOnlyList<ItmValue> BuildValues(ItmPage page, GameData data, byte handleBase = 0)
-        {
-            var status = data?.NewData;
-            var fields = FieldsFor(page);
-            if (status == null || fields.Length == 0)
-                return Array.Empty<ItmValue>();
-
-            var values = new ItmValue[fields.Length];
-            for (int i = 0; i < fields.Length; i++)
-                values[i] = fields[i].Encode(status, (byte)(handleBase + i));
-            return values;
-        }
-
-        // ── Encoding helpers ─────────────────────────────────────────────
-
-        private static float Seconds(TimeSpan t) => (float)t.TotalSeconds;
-
-        // The nearest on-track gap (seconds) among a set of opponents, or 0 if none /
-        // unknown. SimHub gives no scalar gap-to-car-ahead/behind, so take the smallest
-        // |RelativeGapToPlayer| from the ahead/behind list (robust to list ordering).
-        private static float NearestGap(System.Collections.Generic.IEnumerable<Opponent> opponents)
-        {
-            if (opponents == null) return 0f;
-            double best = double.MaxValue;
-            foreach (var o in opponents)
-            {
-                double? g = o?.RelativeGapToPlayer;
-                if (g.HasValue)
-                {
-                    double a = Math.Abs(g.Value);
-                    if (a < best) best = a;
-                }
-            }
-            return best == double.MaxValue ? 0f : (float)best;
-        }
-
-        // Round a possibly non-finite value to int, mapping NaN/Infinity to 0. A NaN
-        // would otherwise slip through range comparisons (all false) into an undefined
-        // cast — the same firmware-safety concern BrakeBiasTenths guards against.
-        private static int SafeRound(double value)
-            => double.IsNaN(value) || double.IsInfinity(value) ? 0 : (int)Math.Round(value);
-
-        // Speed is non-negative; clamp to [0, Int16 max] (the SPEED param is Int16).
-        private static short ClampSpeed(double value)
-        {
-            if (double.IsNaN(value) || double.IsInfinity(value)) return 0;
-            double v = Math.Round(value);
-            if (v < 0) return 0;
-            if (v > short.MaxValue) return short.MaxValue;
-            return (short)v;
-        }
-
-        private static byte ClampByte(double value)
-        {
-            if (double.IsNaN(value) || double.IsInfinity(value)) return 0;
-            double v = Math.Round(value);
-            if (v < 0) return 0;
-            if (v > 255) return 255;
-            return (byte)v;
-        }
-
-        private static byte ClampByte(int value)
-        {
-            if (value < 0) return 0;
-            if (value > 255) return 255;
-            return (byte)value;
-        }
-
-        // BRAKE_BIAS is an Int32 in tenths of a percent (confirmed by capture: 51.2% =>
-        // 512). SimHub reports a percentage, so send round(percent * 10), clamped to
-        // [0, 1000] (0–100.0%).
-        private static int BrakeBiasTenths(double percent)
-        {
-            if (double.IsNaN(percent) || double.IsInfinity(percent)) return 0;
-            int v = (int)Math.Round(percent * 10.0);
-            if (v < 0) return 0;
-            if (v > 1000) return 1000;
-            return v;
-        }
-
-        // ENGINE_MAPPING is rendered by the firmware as text (e.g. "1", "10"). SimHub reports
-        // the map as an int; send its decimal string. Clamp to [0, 99] so the payload stays
-        // within two ASCII bytes (the range the official software was observed to use).
-        private static string EngineMapText(int map)
-        {
-            if (map < 0) map = 0;
-            if (map > 99) map = 99;
-            return map.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        }
-
-        /// <summary>Reverse sentinel: -1 as a Uint8, which the firmware renders as "r".</summary>
-        private const byte GearReverse = 0xFF;
-
-        /// <summary>
-        /// Parses SimHub's gear string to the ITM Uint8 gear value: "N"/empty = 0,
-        /// "1".."9" = that number, "R" = <see cref="GearReverse"/>. Forward gears are
-        /// literal, confirmed against an official-software capture (N=0, 2=2, 3=3).
-        /// </summary>
-        private static byte EncodeGear(string gear)
-        {
-            if (string.IsNullOrEmpty(gear))
-                return 0;
-
-            gear = gear.Trim().ToUpperInvariant();
-            if (gear == "R" || gear == "REVERSE") return GearReverse;
-            if (gear == "N" || gear == "NEUTRAL") return 0;
-
-            return int.TryParse(gear, out int g) && g >= 0 && g <= 254 ? (byte)g : (byte)0;
         }
     }
 }

--- a/FanaBridge/Protocol/ItmTelemetry.cs
+++ b/FanaBridge/Protocol/ItmTelemetry.cs
@@ -4,21 +4,21 @@ using System.Collections.Generic;
 namespace FanaBridge.Protocol
 {
     /// <summary>
-    /// ITM telemetry page. Each page is a fixed parameter layout the firmware
-    /// renders; SPEED and GEAR appear on every page as persistent headers. Values
-    /// match the Base/BME page numbering in the protocol reference, "ITM Page Layouts".
-    /// The numbering is Base/BME-specific — a Bentley display has no Car Settings page
-    /// and a different legacy page (5, not 6), so this enum does not map to a Bentley.
+    /// A page's <b>content identity</b> — the fixed parameter layout the firmware renders (SPEED
+    /// and GEAR appear on every page as persistent headers). This is <b>not</b> a wire page number:
+    /// the on-wire number is assigned per device by <see cref="ItmDeviceCatalog"/> (Car Settings is
+    /// wire page 3 on a standard display but absent on a Bentley, which renumbers the rest). Use it
+    /// only to look up a page's parameters via <see cref="ParamsFor"/>.
     /// </summary>
-    public enum ItmPage : byte
+    public enum ItmPage
     {
-        LapInfo = 1,
-        FuelErsDrs = 2,
-        CarSettings = 3,
-        LapTimes = 4,
-        TyreTemps = 5,
+        LapInfo,
+        FuelErsDrs,
+        CarSettings,
+        LapTimes,
+        TyreTemps,
         /// <summary>Legacy / default fallback — carries no telemetry parameters.</summary>
-        Legacy = 6,
+        Legacy,
     }
 
     /// <summary>
@@ -134,6 +134,24 @@ namespace FanaBridge.Protocol
                 case ItmPage.LapTimes: return LapTimesParams;
                 case ItmPage.TyreTemps: return TyreTempsParams;
                 default: return NoParams;   // Legacy / unknown: no parameters
+            }
+        }
+
+        /// <summary>
+        /// The page's canonical display name (reference data, e.g. "Lap Info") — the same across
+        /// every device that shows the page. Used by UI page pickers.
+        /// </summary>
+        public static string NameOf(ItmPage page)
+        {
+            switch (page)
+            {
+                case ItmPage.LapInfo: return "Lap Info";
+                case ItmPage.FuelErsDrs: return "Fuel / ERS / DRS";
+                case ItmPage.CarSettings: return "Car Settings";
+                case ItmPage.LapTimes: return "Lap Times";
+                case ItmPage.TyreTemps: return "Tyre Temps";
+                case ItmPage.Legacy: return "Legacy";
+                default: return page.ToString();
             }
         }
 

--- a/FanaBridge/Protocol/ItmTelemetry.cs
+++ b/FanaBridge/Protocol/ItmTelemetry.cs
@@ -92,9 +92,9 @@ namespace FanaBridge.Protocol
     /// This is pure wire — no SimHub <c>GameData</c>. The SimHub telemetry → value/suffix
     /// mapping lives in <c>ItmTelemetryMapper</c> (Adapters), which knows both sides.
     ///
-    /// The catalog is the firmware's page structure. Today only the Base/BME layout is
-    /// modelled (via <see cref="ItmPage"/>); per-device profiles (Bentley/GTSWX/Base) are a
-    /// follow-up — this is the single place the layouts are declared.
+    /// This declares each page's parameter list (<see cref="ParamsFor"/>) and display name
+    /// (<see cref="NameOf"/>), keyed by the <see cref="ItmPage"/> content identity. Which pages a
+    /// given display exposes — and their on-wire numbering is declared in <see cref="ItmDeviceCatalog"/>.
     /// </summary>
     public static class ItmTelemetry
     {
@@ -181,11 +181,12 @@ namespace FanaBridge.Protocol
             if (start < 0) return result;
 
             // Entries: [deviceId][fwHandle][idLo][idHi][dataType], 5 bytes each. Byte 0 is the
-            // display-device id. Each driver targets one display, so stop at the first entry for
-            // any other device (a report can, in principle, interleave devices).
+            // display-device id. Each driver targets one display, so skip entries for any other
+            // device rather than stopping — a report can interleave devices, and a later matching
+            // entry must still be collected. (Zero-padding never matches a real device id.)
             for (int i = start; i + 5 <= len; i += 5)
             {
-                if (report[i] != deviceId) break;   // entries for the display this driver targets
+                if (report[i] != deviceId) continue;   // entry for a different display — skip it
                 byte fwHandle = report[i + 1];
                 ushort pid = (ushort)(report[i + 2] | (report[i + 3] << 8));
                 result.Add(new ItmSubscription(fwHandle, pid));

--- a/FanaBridge/Resources/Profiles/PSWBENT.json
+++ b/FanaBridge/Resources/Profiles/PSWBENT.json
@@ -8,6 +8,7 @@
     "wheelType": "PSWBENT"
   },
   "display": "itm",
+  "itmDeviceId": 4,
   "verified": false,
   "leds": [
     { "channel": "revRgb",  "hwIndex": 0, "role": "rev",  "label": "Rev LED 1" },

--- a/FanaBridge/Resources/Profiles/wheel-profile.schema.json
+++ b/FanaBridge/Resources/Profiles/wheel-profile.schema.json
@@ -53,6 +53,11 @@
       "type": "string",
       "enum": ["none", "basic", "itm"]
     },
+    "itmDeviceId": {
+      "description": "ITM display wire id: 1 = base display, 3 = wheel OLED (PBME/GTSWX), 4 = Bentley. Omit to default to 3 (correct for PBME/GTSWX).",
+      "type": "integer",
+      "enum": [1, 3, 4]
+    },
     "colorFormat": {
       "description": "Pixel encoding for the Color LED channel. Defaults to \"rgb565\" (5-6-5). Set to \"rgb555\" for hardware whose LED controller only reads 5 green bits (e.g. Button Module Rally).",
       "type": "string",

--- a/FanaBridge/UI/ScreenSettingsPanel.xaml
+++ b/FanaBridge/UI/ScreenSettingsPanel.xaml
@@ -10,7 +10,7 @@
                     Background="#1A4488CC" BorderBrush="#4488CC" BorderThickness="1"
                     CornerRadius="4" Padding="10,8" Margin="0,0,0,12">
                 <TextBlock Foreground="#AADDFF" FontSize="12" TextWrapping="Wrap">
-                    &#x2139;  This wheel has an ITM telemetry display. Pages are selected with the wheel's display button — FanaBridge follows the wheel and shows live SimHub telemetry on each page (speed, gear, lap times, tyre temps, and more). The wheel's legacy page shows the simple gear/speed display picked under Legacy Display Mode below; choose "None" to leave it off.
+                    &#x2139;  This wheel has an ITM telemetry display — FanaBridge shows live SimHub telemetry on its pages (speed, gear, lap times, tyre temps, and more). Pick the page it starts on below, and use the wheel's display button to switch pages while driving. Its legacy page shows the simple gear/speed display picked under Legacy Display Mode; choose "None" to leave that off.
                 </TextBlock>
             </Border>
 
@@ -18,14 +18,30 @@
             <styles:SHSubSection x:Name="sectionItmOptions" Title="ITM Options" Visibility="Collapsed">
                 <StackPanel>
                     <CheckBox x:Name="chkEnableItm" Content="Enable ITM display"
-                              Checked="ItmOption_Changed" Unchecked="ItmOption_Changed" Margin="0,2,0,8" />
-                    <TextBlock Foreground="#999999" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,8">
-                        Show "/total" on the lap and position fields (e.g. "Lap 5 / 34" rather than "Lap 5"). Turn off for games that don't report usable totals.
-                    </TextBlock>
-                    <CheckBox x:Name="chkShowLapTotal" Content="Show lap total (Lap 5 / 34)"
-                              Checked="ItmOption_Changed" Unchecked="ItmOption_Changed" Margin="0,2" />
-                    <CheckBox x:Name="chkShowPositionTotal" Content="Show position total (P3 / 20)"
-                              Checked="ItmOption_Changed" Unchecked="ItmOption_Changed" Margin="0,4,0,2" />
+                              Checked="ItmOption_Changed" Unchecked="ItmOption_Changed" Margin="0,2,0,12" />
+
+                    <!-- Default page (choices populated per display device) -->
+                    <StackPanel x:Name="panelDefaultPage" Margin="0,0,0,12">
+                        <TextBlock Text="Default page" FontWeight="SemiBold" Margin="0,0,0,4" />
+                        <ComboBox x:Name="cmbDefaultPage"
+                                  SelectionChanged="CmbDefaultPage_SelectionChanged"
+                                  Width="220" HorizontalAlignment="Left" />
+                        <TextBlock Foreground="#999999" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0">
+                            The page shown when the display starts. The wheel's display button navigates from there.
+                        </TextBlock>
+                    </StackPanel>
+
+                    <!-- "/total" suffixes -->
+                    <StackPanel x:Name="panelTotals">
+                        <TextBlock Text="Totals" FontWeight="SemiBold" Margin="0,0,0,4" />
+                        <TextBlock Foreground="#999999" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,6">
+                            Show "/total" on the lap and position fields (e.g. "Lap 5 / 34" rather than "Lap 5"). Turn off for games that don't report usable totals.
+                        </TextBlock>
+                        <CheckBox x:Name="chkShowLapTotal" Content="Show lap total (Lap 5 / 34)"
+                                  Checked="ItmOption_Changed" Unchecked="ItmOption_Changed" Margin="0,2" />
+                        <CheckBox x:Name="chkShowPositionTotal" Content="Show position total (P3 / 20)"
+                                  Checked="ItmOption_Changed" Unchecked="ItmOption_Changed" Margin="0,4,0,2" />
+                    </StackPanel>
                 </StackPanel>
             </styles:SHSubSection>
 

--- a/FanaBridge/UI/ScreenSettingsPanel.xaml
+++ b/FanaBridge/UI/ScreenSettingsPanel.xaml
@@ -22,7 +22,7 @@
 
                     <!-- Default page (choices populated per display device) -->
                     <StackPanel x:Name="panelDefaultPage" Margin="0,0,0,12">
-                        <TextBlock Text="Default page" FontWeight="SemiBold" Margin="0,0,0,4" />
+                        <TextBlock Text="Default Page" FontWeight="SemiBold" Margin="0,0,0,4" />
                         <ComboBox x:Name="cmbDefaultPage"
                                   SelectionChanged="CmbDefaultPage_SelectionChanged"
                                   Width="220" HorizontalAlignment="Left" />

--- a/FanaBridge/UI/ScreenSettingsPanel.xaml.cs
+++ b/FanaBridge/UI/ScreenSettingsPanel.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using FanaBridge.Adapters;
 using FanaBridge.Profiles;
+using FanaBridge.Protocol;
 
 namespace FanaBridge.UI
 {
@@ -23,7 +24,8 @@ namespace FanaBridge.UI
         /// Binds the panel to a DisplaySettings instance.
         /// Call once after construction, before the panel is displayed.
         /// </summary>
-        public void Bind(DisplaySettings settings, DisplayType displayType = DisplayType.Basic)
+        public void Bind(DisplaySettings settings, DisplayType displayType = DisplayType.Basic,
+            byte itmDeviceId = ItmEncoder.DefaultDeviceId)
         {
             _settings = settings ?? new DisplaySettings();
             _suppressEvents = true;
@@ -40,6 +42,10 @@ namespace FanaBridge.UI
             chkShowLapTotal.IsChecked = _settings.ItmShowLapTotal;
             chkShowPositionTotal.IsChecked = _settings.ItmShowPositionTotal;
 
+            // Default-page choices depend on the display device (e.g. Bentley has fewer pages).
+            PopulateDefaultPages(itmDeviceId);
+            SelectByPageNumber(cmbDefaultPage, _settings.ItmDefaultPage);
+
             borderItmInfo.Visibility = isItm ? Visibility.Visible : Visibility.Collapsed;
             sectionItmOptions.Visibility = isItm ? Visibility.Visible : Visibility.Collapsed;
             // The mode selector drives the simple 7-seg gear/speed — the only display on
@@ -47,6 +53,8 @@ namespace FanaBridge.UI
             // cases, but titled "Legacy Display Mode" on ITM wheels.
             sectionDisplayMode.Title = isItm ? "Legacy Display Mode" : "Display Mode";
             sectionDisplayMode.Visibility = Visibility.Visible;
+
+            UpdateItmEnabledState();   // grey out the ITM sub-options when the display is off
 
             _suppressEvents = false;
         }
@@ -81,7 +89,51 @@ namespace FanaBridge.UI
             _settings.ItmEnabled = chkEnableItm.IsChecked == true;
             _settings.ItmShowLapTotal = chkShowLapTotal.IsChecked == true;
             _settings.ItmShowPositionTotal = chkShowPositionTotal.IsChecked == true;
+            UpdateItmEnabledState();   // enabling/disabling ITM greys the dependent options
             SettingsChanged?.Invoke();
+        }
+
+        // Populate the default-page choices for the given display device — name shown, wire page
+        // number stored. Includes the legacy page (some setups prefer to start there).
+        private void PopulateDefaultPages(byte itmDeviceId)
+        {
+            cmbDefaultPage.Items.Clear();
+            foreach (var page in ItmDeviceCatalog.PagesFor(itmDeviceId))
+                cmbDefaultPage.Items.Add(new ComboBoxItem { Content = page.Name, Tag = page.Number });
+        }
+
+        private static void SelectByPageNumber(ComboBox combo, byte pageNumber)
+        {
+            foreach (ComboBoxItem item in combo.Items)
+            {
+                if (item.Tag is byte n && n == pageNumber)
+                {
+                    combo.SelectedItem = item;
+                    return;
+                }
+            }
+            if (combo.Items.Count > 0)
+                combo.SelectedIndex = 0;   // stored page not offered by this device — fall back
+        }
+
+        private void CmbDefaultPage_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressEvents || _settings == null) return;
+
+            if (cmbDefaultPage.SelectedItem is ComboBoxItem selected && selected.Tag is byte pageNumber)
+            {
+                _settings.ItmDefaultPage = pageNumber;
+                SettingsChanged?.Invoke();
+            }
+        }
+
+        // Grey out the ITM sub-options (default page, totals) when the display is disabled —
+        // they have no effect until ITM is turned back on.
+        private void UpdateItmEnabledState()
+        {
+            bool on = chkEnableItm.IsChecked == true;
+            panelDefaultPage.IsEnabled = on;
+            panelTotals.IsEnabled = on;
         }
     }
 }

--- a/FanaBridge/UI/ScreenSettingsPanel.xaml.cs
+++ b/FanaBridge/UI/ScreenSettingsPanel.xaml.cs
@@ -102,7 +102,7 @@ namespace FanaBridge.UI
                 cmbDefaultPage.Items.Add(new ComboBoxItem { Content = page.Name, Tag = page.Number });
         }
 
-        private static void SelectByPageNumber(ComboBox combo, byte pageNumber)
+        private void SelectByPageNumber(ComboBox combo, byte pageNumber)
         {
             foreach (ComboBoxItem item in combo.Items)
             {
@@ -112,8 +112,15 @@ namespace FanaBridge.UI
                     return;
                 }
             }
+            // Stored page isn't offered by this device — fall back to the first page AND correct the
+            // backing setting, so it can't persist a page this device doesn't have. (SelectionChanged
+            // is suppressed during Bind, so the setting is synced here directly.)
             if (combo.Items.Count > 0)
-                combo.SelectedIndex = 0;   // stored page not offered by this device — fall back
+            {
+                combo.SelectedIndex = 0;
+                if (_settings != null && ((ComboBoxItem)combo.Items[0]).Tag is byte first)
+                    _settings.ItmDefaultPage = first;
+            }
         }
 
         private void CmbDefaultPage_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -795,7 +795,7 @@ Each entry:
 | 4 | 1 | Size | Value size in bytes (1, 2, or 4) |
 | 5+ | N | Value | Parameter value (little-endian, size from above) |
 
-> **The leading byte is the display-device id** — which display the entry is for, using the same values as [PageSet](#0x04--pageset). FanaBridge only drives the PBME/GTSWX, so every entry uses device 3; entries addressed to a display that isn't attached are silently ignored.
+> **The leading byte is the display-device id** — which display the entry is for, using the same values as [PageSet](#0x04--pageset). Entries addressed to a display that isn't attached are silently ignored.
 >
 > Multiple entries may be packed into one report; the firmware accepts batched updates.
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -124,10 +124,10 @@ The tuning menu supports 5 setup slots (index 0–4). Each slot stores a complet
 
 ---
 
-## ITM (In-Tuning-Menu)
+## ITM (Intelligent Telemetry Mode)
 
 ### ITM
-The telemetry display system that shows multi-page dashboards on compatible displays. "In-Tuning-Menu" is the historical name from the SDK; in practice it is used for game telemetry, not just tuning. See [ITM Display Protocol](reference/protocol.md#0x05--itm-display).
+The telemetry display system that shows multi-page dashboards on compatible displays — live speed, gear, lap times, fuel, tyre temps, and so on. See [ITM Display Protocol](reference/protocol.md#0x05--itm-display).
 
 ### ITM Device ID
 A numeric identifier routing ITM commands to the correct physical display. Values: 1 = wheelbase display, 2 = steering wheel / SmallOLED (disabled in current firmware), 3 = button module or compatible wheel display (shared, mutually exclusive), 4 = dedicated wheel display. See [ITM Display — Supported Devices](reference/protocol.md#itm-supported-devices) for the specific device mapping.


### PR DESCRIPTION
## Summary

Generalizes FanaBridge's ITM telemetry display from the hard-coded PBME (wire device 3) to any ITM-capable display. A wheel declares which display it drives via its profile's `itmDeviceId`, so the same code path serves the wheel OLED (PBME/GTSWX), the Bentley wheel and (in the future) base displays.

## What's here

- **Wire / adapter split** — ITM telemetry is separated into a device-agnostic wire catalog (`Protocol`) and a SimHub-facing value mapper (`Adapters`), keeping the layer boundaries clean.
- **Device-parameterized display path** — the per-entry device id and the PageSet target are driven by the profile's `itmDeviceId` (default 3 = wheel OLED; 1 = base display; 4 = Bentley). Behavior for currently-supported PBME wheels is byte-for-byte unchanged.
- **Per-device page catalog** — page sets (the standard six-page layout; Bentley's five-page layout with no Car Settings) feed the UI page picker and the bring-up seed. Page names and params derive from a single content-identity map, so nothing is duplicated per device.
- **Default-page setting** — choose which page shows on connect, plus a tidier Screen Options panel.

## Notes

- Experimental. The Bentley page layout is inferred and **not yet verified on hardware** (its profile is marked `verified: false`). The catalog derives the page set from the device id, with an in-code comment marking exactly where to split device-id vs page-layout if they ever diverge.
- No behavior change for currently-supported (PBME) wheels; 307 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)