### PR TITLE
Prompt to add a detected wheel as a SimHub device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.5.0 - Unreleased
 
+### Added
+- **One-click device add from the settings page.** A detected wheel or hub still has to be added as a SimHub device before any LED or display output works — a step that's easy to miss after installing. The Device Status section now shows a prompt whenever the attached wheel/hub isn't in SimHub's device list yet, with an **Add to SimHub** button that adds it on the spot ([#49](https://github.com/kelchm/FanaBridge/pull/49))
+
 ### Fixed
 - **SRM Conversion Kit wheels are detected again.** A Fanatec wheel/hub run through an SRM Conversion Kit no longer sits at "Connecting…" — FanaBridge recovers the wheel's identity from the conversion kit when the base doesn't emit the usual Fanatec system report (regressed in v0.4.0). The genuine-hardware detection path is unchanged. ([#47](https://github.com/kelchm/FanaBridge/pull/47), fixes [#52](https://github.com/kelchm/FanaBridge/issues/52))
 - **Changing the active game in SimHub no longer kills all LED and display output.** SimHub restarts its plugin manager in-process on every game change; FanaBridge now survives that restart with its hardware connection intact instead of being torn down and rebuilt while SimHub's device instances kept writing into the disposed connection — previously everything went dark (while still showing *Connected*) until SimHub itself was restarted ([#51](https://github.com/kelchm/FanaBridge/issues/51))

--- a/FanaBridge.Tests/SimHubDevicesGatewayTests.cs
+++ b/FanaBridge.Tests/SimHubDevicesGatewayTests.cs
@@ -1,0 +1,104 @@
+using FanaBridge.Adapters;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// <see cref="SimHubDevicesGateway.IsSimilarDescriptor"/> must mirror how
+    /// SimHub counts existing devices against a candidate descriptor's
+    /// MaximumInstances, including its quirks — a mismatch either blocks the
+    /// prompt's button for an addable device or offers an add that ends in
+    /// SimHub's instance-cap error dialog.
+    /// </summary>
+    public class SimHubDevicesGatewayTests
+    {
+        [Fact]
+        public void SameId_IsSimilar()
+        {
+            Assert.True(SimHubDevicesGateway.IsSimilarDescriptor(
+                "Fanatec_PSWBMW", null,
+                "Fanatec_PSWBMW", null));
+        }
+
+        [Fact]
+        public void DifferentStandaloneWheels_AreNotSimilar()
+        {
+            Assert.False(SimHubDevicesGateway.IsSimilarDescriptor(
+                "Fanatec_PSWBMW", null,
+                "Fanatec_PSWF1", null));
+        }
+
+        [Fact]
+        public void HubModuleCombos_SharingModuleParent_AreSimilar()
+        {
+            // Same module on two different hubs — SimHub refuses the second add.
+            Assert.True(SimHubDevicesGateway.IsSimilarDescriptor(
+                "Fanatec_PHUB_PBME", "Fanatec_Module_PBME",
+                "Fanatec_APM2_PBME", "Fanatec_Module_PBME"));
+        }
+
+        [Fact]
+        public void HubModuleCombos_WithDifferentModules_AreNotSimilar()
+        {
+            Assert.False(SimHubDevicesGateway.IsSimilarDescriptor(
+                "Fanatec_PHUB_PBME", "Fanatec_Module_PBME",
+                "Fanatec_PHUB_PBMR", "Fanatec_Module_PBMR"));
+        }
+
+        [Fact]
+        public void ExistingParentMatchingCandidateId_IsSimilar()
+        {
+            Assert.True(SimHubDevicesGateway.IsSimilarDescriptor(
+                "Fanatec_PHUB_PBME", "Fanatec_Module_PBME",
+                "Fanatec_Module_PBME", null));
+        }
+
+        [Fact]
+        public void ExistingIdMatchingCandidateParent_IsSimilar_WhenExistingHasAParent()
+        {
+            Assert.True(SimHubDevicesGateway.IsSimilarDescriptor(
+                "Fanatec_Module_PBME", "Fanatec_SomeParent",
+                "Fanatec_PHUB_PBME", "Fanatec_Module_PBME"));
+        }
+
+        [Fact]
+        public void ParentlessExisting_DoesNotMatchCandidateParent()
+        {
+            // SimHub quirk, preserved deliberately: when the existing device has
+            // no parent, its id is never compared against the candidate's parent.
+            Assert.False(SimHubDevicesGateway.IsSimilarDescriptor(
+                "Fanatec_Module_PBME", null,
+                "Fanatec_PHUB_PBME", "Fanatec_Module_PBME"));
+        }
+
+        [Fact]
+        public void NullParents_DoNotMatchEachOther()
+        {
+            Assert.False(SimHubDevicesGateway.IsSimilarDescriptor(
+                "Fanatec_PSWBMW", null,
+                "Fanatec_PSWF1", null));
+        }
+
+        [Fact]
+        public void Comparison_IsCaseSensitive_LikeSimHub()
+        {
+            Assert.False(SimHubDevicesGateway.IsSimilarDescriptor(
+                "FANATEC_PSWBMW", null,
+                "Fanatec_PSWBMW", null));
+        }
+
+        [Fact]
+        public void Resolve_NullPluginManager_ReturnsNull()
+        {
+            Assert.Null(SimHubDevicesGateway.Resolve(null));
+        }
+
+        [Fact]
+        public void Queries_NullDevicesPlugin_AreQuiet()
+        {
+            Assert.False(SimHubDevicesGateway.HasDescriptor(null, "Fanatec_PSWBMW"));
+            Assert.False(SimHubDevicesGateway.IsDeviceAdded(null, "Fanatec_PSWBMW"));
+            Assert.Null(SimHubDevicesGateway.FindBlockingDevice(null, "Fanatec_PSWBMW", null));
+        }
+    }
+}

--- a/FanaBridge.Tests/SimHubDevicesGatewayTests.cs
+++ b/FanaBridge.Tests/SimHubDevicesGatewayTests.cs
@@ -4,89 +4,13 @@ using Xunit;
 namespace FanaBridge.Tests
 {
     /// <summary>
-    /// <see cref="SimHubDevicesGateway.IsSimilarDescriptor"/> must mirror how
-    /// SimHub counts existing devices against a candidate descriptor's
-    /// MaximumInstances, including its quirks — a mismatch either blocks the
-    /// prompt's button for an addable device or offers an add that ends in
-    /// SimHub's instance-cap error dialog.
+    /// The gateway must stay quiet (no throws, no false positives) when
+    /// SimHub's Devices plugin isn't resolvable or initialized yet — the
+    /// add-device prompt evaluates on every status refresh, including early
+    /// in startup.
     /// </summary>
     public class SimHubDevicesGatewayTests
     {
-        [Fact]
-        public void SameId_IsSimilar()
-        {
-            Assert.True(SimHubDevicesGateway.IsSimilarDescriptor(
-                "Fanatec_PSWBMW", null,
-                "Fanatec_PSWBMW", null));
-        }
-
-        [Fact]
-        public void DifferentStandaloneWheels_AreNotSimilar()
-        {
-            Assert.False(SimHubDevicesGateway.IsSimilarDescriptor(
-                "Fanatec_PSWBMW", null,
-                "Fanatec_PSWF1", null));
-        }
-
-        [Fact]
-        public void HubModuleCombos_SharingModuleParent_AreSimilar()
-        {
-            // Same module on two different hubs — SimHub refuses the second add.
-            Assert.True(SimHubDevicesGateway.IsSimilarDescriptor(
-                "Fanatec_PHUB_PBME", "Fanatec_Module_PBME",
-                "Fanatec_APM2_PBME", "Fanatec_Module_PBME"));
-        }
-
-        [Fact]
-        public void HubModuleCombos_WithDifferentModules_AreNotSimilar()
-        {
-            Assert.False(SimHubDevicesGateway.IsSimilarDescriptor(
-                "Fanatec_PHUB_PBME", "Fanatec_Module_PBME",
-                "Fanatec_PHUB_PBMR", "Fanatec_Module_PBMR"));
-        }
-
-        [Fact]
-        public void ExistingParentMatchingCandidateId_IsSimilar()
-        {
-            Assert.True(SimHubDevicesGateway.IsSimilarDescriptor(
-                "Fanatec_PHUB_PBME", "Fanatec_Module_PBME",
-                "Fanatec_Module_PBME", null));
-        }
-
-        [Fact]
-        public void ExistingIdMatchingCandidateParent_IsSimilar_WhenExistingHasAParent()
-        {
-            Assert.True(SimHubDevicesGateway.IsSimilarDescriptor(
-                "Fanatec_Module_PBME", "Fanatec_SomeParent",
-                "Fanatec_PHUB_PBME", "Fanatec_Module_PBME"));
-        }
-
-        [Fact]
-        public void ParentlessExisting_DoesNotMatchCandidateParent()
-        {
-            // SimHub quirk, preserved deliberately: when the existing device has
-            // no parent, its id is never compared against the candidate's parent.
-            Assert.False(SimHubDevicesGateway.IsSimilarDescriptor(
-                "Fanatec_Module_PBME", null,
-                "Fanatec_PHUB_PBME", "Fanatec_Module_PBME"));
-        }
-
-        [Fact]
-        public void NullParents_DoNotMatchEachOther()
-        {
-            Assert.False(SimHubDevicesGateway.IsSimilarDescriptor(
-                "Fanatec_PSWBMW", null,
-                "Fanatec_PSWF1", null));
-        }
-
-        [Fact]
-        public void Comparison_IsCaseSensitive_LikeSimHub()
-        {
-            Assert.False(SimHubDevicesGateway.IsSimilarDescriptor(
-                "FANATEC_PSWBMW", null,
-                "Fanatec_PSWBMW", null));
-        }
-
         [Fact]
         public void Resolve_NullPluginManager_ReturnsNull()
         {
@@ -98,7 +22,6 @@ namespace FanaBridge.Tests
         {
             Assert.False(SimHubDevicesGateway.HasDescriptor(null, "Fanatec_PSWBMW"));
             Assert.False(SimHubDevicesGateway.IsDeviceAdded(null, "Fanatec_PSWBMW"));
-            Assert.Null(SimHubDevicesGateway.FindBlockingDevice(null, "Fanatec_PSWBMW", null));
         }
     }
 }

--- a/FanaBridge/Adapters/FanatecDevicesRegistry.cs
+++ b/FanaBridge/Adapters/FanatecDevicesRegistry.cs
@@ -23,71 +23,7 @@ namespace FanaBridge.Adapters
         {
             SimHub.Logging.Current.Info("FanatecDevicesRegistry: GetDevices() called");
 
-            // Ensure profiles are loaded from disk
-            WheelProfileStore.EnsureLoaded();
-
-            // One DeviceInstance per device match key.  When multiple profiles
-            // share the same match (e.g. built-in + user test variants),
-            // the built-in profile wins for the device descriptor (name,
-            // type ID).  The actual LED/display capabilities used at runtime
-            // come from the currently-active profile (see FanatecLedManager.GetDriver).
-            var configs = new Dictionary<string, DeviceConfig>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var profile in WheelProfileStore.GetAll())
-            {
-                // Skip bare hub profiles (no LEDs, no display)
-                if (!profile.HasLeds && profile.DisplayType == DisplayType.None)
-                {
-                    SimHub.Logging.Current.Info(
-                        "FanatecDevicesRegistry: Skipping bare profile '" + profile.Id + "'");
-                    continue;
-                }
-
-                var config = new DeviceConfig
-                {
-                    Profile = profile,
-                    Capabilities = new WheelCapabilities(profile),
-                };
-
-                if (configs.TryGetValue(config.DeviceTypeId, out var existing))
-                {
-                    // Built-in always wins — it defines the device's full capability
-                    if (existing.Profile.Source == ProfileSource.BuiltIn)
-                    {
-                        SimHub.Logging.Current.Info(
-                            "FanatecDevicesRegistry: Profile '" + profile.Id +
-                            "' (" + profile.Source + ") skipped — built-in '" +
-                            existing.Profile.Id + "' defines device " + config.DeviceTypeId);
-                        continue;
-                    }
-
-                    // New profile is built-in, existing is user — promote built-in
-                    if (profile.Source == ProfileSource.BuiltIn)
-                    {
-                        SimHub.Logging.Current.Info(
-                            "FanatecDevicesRegistry: Built-in '" + profile.Id +
-                            "' replaces user '" + existing.Profile.Id +
-                            "' for device " + config.DeviceTypeId);
-                    }
-                    else
-                    {
-                        // Both are user profiles — keep the first one.
-                        // The registry only determines the device descriptor
-                        // (name, type ID). LED capability comes from the
-                        // currently-active profile at runtime.
-                        SimHub.Logging.Current.Info(
-                            "FanatecDevicesRegistry: Profile '" + profile.Id +
-                            "' (" + profile.Source + ") skipped — '" +
-                            existing.Profile.Id + "' already registered for " +
-                            config.DeviceTypeId);
-                        continue;
-                    }
-                }
-
-                configs[config.DeviceTypeId] = config;
-            }
-
-            foreach (var config in configs.Values)
+            foreach (var config in BuildConfigs(verbose: true))
             {
                 SimHub.Logging.Current.Info(
                     "FanatecDevicesRegistry: Registering " + config.Capabilities.Name +
@@ -113,6 +49,113 @@ namespace FanaBridge.Adapters
                     IsDeprecated = false,
                 };
             }
+        }
+
+        /// <summary>
+        /// Builds the deduplicated set of device configs that back the
+        /// registered descriptors — one per device match key. When multiple
+        /// profiles share the same match (e.g. built-in + user test variants),
+        /// the built-in profile wins for the device descriptor (name, type ID).
+        /// The actual LED/display capabilities used at runtime come from the
+        /// currently-active profile (see FanatecLedManager.GetDriver).
+        ///
+        /// Shared by descriptor registration (<see cref="GetDevices"/>) and the
+        /// settings page's add-device prompt so both resolve a detected wheel
+        /// to the same DeviceTypeID. <paramref name="verbose"/> logs the
+        /// skip/dedupe decisions; only registration does, so the per-refresh
+        /// prompt path doesn't flood the log.
+        /// </summary>
+        public static IReadOnlyCollection<DeviceConfig> BuildConfigs(bool verbose = false)
+        {
+            // Ensure profiles are loaded from disk
+            WheelProfileStore.EnsureLoaded();
+
+            var configs = new Dictionary<string, DeviceConfig>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var profile in WheelProfileStore.GetAll())
+            {
+                // Skip bare hub profiles (no LEDs, no display)
+                if (!profile.HasLeds && profile.DisplayType == DisplayType.None)
+                {
+                    if (verbose)
+                        SimHub.Logging.Current.Info(
+                            "FanatecDevicesRegistry: Skipping bare profile '" + profile.Id + "'");
+                    continue;
+                }
+
+                var config = new DeviceConfig
+                {
+                    Profile = profile,
+                    Capabilities = new WheelCapabilities(profile),
+                };
+
+                if (configs.TryGetValue(config.DeviceTypeId, out var existing))
+                {
+                    // Built-in always wins — it defines the device's full capability
+                    if (existing.Profile.Source == ProfileSource.BuiltIn)
+                    {
+                        if (verbose)
+                            SimHub.Logging.Current.Info(
+                                "FanatecDevicesRegistry: Profile '" + profile.Id +
+                                "' (" + profile.Source + ") skipped — built-in '" +
+                                existing.Profile.Id + "' defines device " + config.DeviceTypeId);
+                        continue;
+                    }
+
+                    // New profile is built-in, existing is user — promote built-in
+                    if (profile.Source == ProfileSource.BuiltIn)
+                    {
+                        if (verbose)
+                            SimHub.Logging.Current.Info(
+                                "FanatecDevicesRegistry: Built-in '" + profile.Id +
+                                "' replaces user '" + existing.Profile.Id +
+                                "' for device " + config.DeviceTypeId);
+                    }
+                    else
+                    {
+                        // Both are user profiles — keep the first one.
+                        // The registry only determines the device descriptor
+                        // (name, type ID). LED capability comes from the
+                        // currently-active profile at runtime.
+                        if (verbose)
+                            SimHub.Logging.Current.Info(
+                                "FanatecDevicesRegistry: Profile '" + profile.Id +
+                                "' (" + profile.Source + ") skipped — '" +
+                                existing.Profile.Id + "' already registered for " +
+                                config.DeviceTypeId);
+                        continue;
+                    }
+                }
+
+                configs[config.DeviceTypeId] = config;
+            }
+
+            return configs.Values;
+        }
+
+        /// <summary>
+        /// The registered device config matching the currently attached
+        /// wheel/hub + module, or null when nothing registered matches (no
+        /// profile, or only a bare profile that never gets a descriptor).
+        /// Uses <see cref="DeviceConfig.MatchesAttachment"/> — the same exact
+        /// wheel+module predicate as device-state reporting — rather than
+        /// <c>WheelProfileStore.FindByWheelType</c>, whose bare-wheel fallback
+        /// would suggest a device that could never report Connected for a
+        /// hub with a module attached.
+        /// </summary>
+        public static DeviceConfig FindConfigForAttachment(
+            bool wheelDetected, string wheelCode, string moduleCode)
+        {
+            if (!wheelDetected)
+                return null;
+
+            foreach (var config in BuildConfigs())
+            {
+                if (config.MatchesAttachment(wheelDetected, wheelCode, moduleCode))
+                    return config;
+            }
+
+            return null;
         }
     }
 }

--- a/FanaBridge/Adapters/SimHubDevicesGateway.cs
+++ b/FanaBridge/Adapters/SimHubDevicesGateway.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using SimHub.Plugins;
+using SimHub.Plugins.Devices;
+
+namespace FanaBridge.Adapters
+{
+    /// <summary>
+    /// Read-and-check access to SimHub's Devices plugin for the settings
+    /// page's add-device prompt. FanaBridge registers device descriptors via
+    /// <see cref="FanatecDevicesRegistry"/>, but whether the user has actually
+    /// ADDED a device is state owned by SimHub's DevicesPlugin: an un-added
+    /// device has no DeviceInstance at all, so added-ness is invisible to
+    /// FanaBridge's own device instances and must be queried here.
+    /// </summary>
+    public static class SimHubDevicesGateway
+    {
+        /// <summary>SimHub's Devices plugin, or null if not (yet) loaded.</summary>
+        public static DevicesPlugin Resolve(PluginManager pluginManager)
+        {
+            return pluginManager?.GetPlugin<DevicesPlugin>();
+        }
+
+        /// <summary>
+        /// Whether SimHub registered a descriptor with this DeviceTypeID.
+        /// Descriptors are collected once at startup, so a profile created
+        /// this session has a config but no descriptor until SimHub restarts —
+        /// offering an add for it would silently do nothing.
+        /// </summary>
+        public static bool HasDescriptor(DevicesPlugin devices, string deviceTypeId)
+        {
+            var descriptors = devices?.DevicesPluginSettings?.DeviceDescriptors;
+            if (descriptors == null || deviceTypeId == null)
+                return false;
+
+            // Ordinal: SimHub resolves DeviceTypeIDs with ==, never ignore-case.
+            return descriptors.Any(d =>
+                string.Equals(d?.DeviceTypeID, deviceTypeId, StringComparison.Ordinal));
+        }
+
+        /// <summary>
+        /// Whether the user has added a device with this DeviceTypeID.
+        /// Flattens composite devices the same way SimHub's own device list does.
+        /// </summary>
+        public static bool IsDeviceAdded(DevicesPlugin devices, string deviceTypeId)
+        {
+            if (devices?.DevicesPluginSettings == null || deviceTypeId == null)
+                return false;
+
+            return devices.GetDevices().Any(d =>
+                string.Equals(d?.DeviceDescriptor?.DeviceTypeID, deviceTypeId, StringComparison.Ordinal));
+        }
+
+        /// <summary>
+        /// The already-added device that would make SimHub refuse to add
+        /// <paramref name="deviceTypeId"/>, or null when the add can proceed.
+        /// SimHub enforces MaximumInstances (1 for all FanaBridge descriptors)
+        /// across a descriptor FAMILY, not just the exact id: an existing
+        /// device blocks a candidate when their ids match or they are related
+        /// through ParentDeviceTypeID — for FanaBridge that means two
+        /// hub+module combos sharing the same module. Attempting the add
+        /// anyway ends in SimHub's "You can only add 1 instances of …" dialog,
+        /// so the prompt explains the conflict instead of offering the button.
+        /// </summary>
+        public static DeviceInstance FindBlockingDevice(
+            DevicesPlugin devices, string deviceTypeId, string parentDeviceTypeId)
+        {
+            var added = devices?.DevicesPluginSettings?.Devices;
+            if (added == null || deviceTypeId == null)
+                return null;
+
+            // Root devices only — SimHub's instance cap counts the same set.
+            return added.ToList().FirstOrDefault(d =>
+                d?.DeviceDescriptor != null
+                && IsSimilarDescriptor(
+                    d.DeviceDescriptor.DeviceTypeID, d.DeviceDescriptor.ParentDeviceTypeID,
+                    deviceTypeId, parentDeviceTypeId));
+        }
+
+        /// <summary>
+        /// Mirrors how SimHub decides which existing devices count against a
+        /// candidate descriptor's MaximumInstances: same DeviceTypeID, or —
+        /// when the existing device has a parent — a shared parent, or a
+        /// parent/child relation in either direction.
+        /// </summary>
+        internal static bool IsSimilarDescriptor(
+            string existingId, string existingParentId,
+            string candidateId, string candidateParentId)
+        {
+            if (string.Equals(existingId, candidateId, StringComparison.Ordinal))
+                return true;
+
+            if (existingParentId == null)
+                return false;
+
+            return string.Equals(existingParentId, candidateParentId, StringComparison.Ordinal)
+                || string.Equals(existingParentId, candidateId, StringComparison.Ordinal)
+                || string.Equals(existingId, candidateParentId, StringComparison.Ordinal);
+        }
+    }
+}

--- a/FanaBridge/Adapters/SimHubDevicesGateway.cs
+++ b/FanaBridge/Adapters/SimHubDevicesGateway.cs
@@ -40,7 +40,11 @@ namespace FanaBridge.Adapters
 
         /// <summary>
         /// Whether the user has added a device with this DeviceTypeID.
-        /// Flattens composite devices the same way SimHub's own device list does.
+        /// Flattens composite devices the same way SimHub's own device list
+        /// does. Note this is an exact-id check: SimHub additionally caps
+        /// instances across a descriptor family (shared ParentDeviceTypeID),
+        /// and answers such an add with its own explanatory dialog — that
+        /// rare edge is left to SimHub rather than pre-checked here.
         /// </summary>
         public static bool IsDeviceAdded(DevicesPlugin devices, string deviceTypeId)
         {
@@ -49,53 +53,6 @@ namespace FanaBridge.Adapters
 
             return devices.GetDevices().Any(d =>
                 string.Equals(d?.DeviceDescriptor?.DeviceTypeID, deviceTypeId, StringComparison.Ordinal));
-        }
-
-        /// <summary>
-        /// The already-added device that would make SimHub refuse to add
-        /// <paramref name="deviceTypeId"/>, or null when the add can proceed.
-        /// SimHub enforces MaximumInstances (1 for all FanaBridge descriptors)
-        /// across a descriptor FAMILY, not just the exact id: an existing
-        /// device blocks a candidate when their ids match or they are related
-        /// through ParentDeviceTypeID — for FanaBridge that means two
-        /// hub+module combos sharing the same module. Attempting the add
-        /// anyway ends in SimHub's "You can only add 1 instances of …" dialog,
-        /// so the prompt explains the conflict instead of offering the button.
-        /// </summary>
-        public static DeviceInstance FindBlockingDevice(
-            DevicesPlugin devices, string deviceTypeId, string parentDeviceTypeId)
-        {
-            var added = devices?.DevicesPluginSettings?.Devices;
-            if (added == null || deviceTypeId == null)
-                return null;
-
-            // Root devices only — SimHub's instance cap counts the same set.
-            return added.ToList().FirstOrDefault(d =>
-                d?.DeviceDescriptor != null
-                && IsSimilarDescriptor(
-                    d.DeviceDescriptor.DeviceTypeID, d.DeviceDescriptor.ParentDeviceTypeID,
-                    deviceTypeId, parentDeviceTypeId));
-        }
-
-        /// <summary>
-        /// Mirrors how SimHub decides which existing devices count against a
-        /// candidate descriptor's MaximumInstances: same DeviceTypeID, or —
-        /// when the existing device has a parent — a shared parent, or a
-        /// parent/child relation in either direction.
-        /// </summary>
-        internal static bool IsSimilarDescriptor(
-            string existingId, string existingParentId,
-            string candidateId, string candidateParentId)
-        {
-            if (string.Equals(existingId, candidateId, StringComparison.Ordinal))
-                return true;
-
-            if (existingParentId == null)
-                return false;
-
-            return string.Equals(existingParentId, candidateParentId, StringComparison.Ordinal)
-                || string.Equals(existingParentId, candidateId, StringComparison.Ordinal)
-                || string.Equals(existingId, candidateParentId, StringComparison.Ordinal);
         }
     }
 }

--- a/FanaBridge/UI/SettingsControl.xaml
+++ b/FanaBridge/UI/SettingsControl.xaml
@@ -46,15 +46,23 @@
                     <TextBlock x:Name="txtStatusDetail" Foreground="#E0A800" FontSize="11"
                                TextWrapping="Wrap" Margin="0,0,0,10" Visibility="Collapsed" />
 
+                    <!-- Capabilities — styled like a chain node (value + caption) -->
+                    <StackPanel Margin="0,0,0,2">
+                        <TextBlock x:Name="txtCapabilities" Text="—" TextWrapping="Wrap" />
+                        <TextBlock Text="Capabilities" Foreground="#888888" FontSize="11" />
+                    </StackPanel>
+
                     <!-- Shown when the attached wheel resolves to a registered SimHub
                          device the user hasn't added yet — LED/display output never
-                         starts without the device. Laid out as a callout bar: glyph,
-                         headline + muted detail, action button; left-anchored and
-                         width-capped so it doesn't sprawl on wide windows. Texts and
-                         button visibility are driven by UpdateAddDevicePrompt. -->
+                         starts without the device. Sits below the status readout
+                         (chain + capabilities) with the actions, so it doesn't split
+                         them apart. Laid out as a callout bar: glyph, headline +
+                         muted detail, action button; left-anchored and width-capped
+                         so it doesn't sprawl on wide windows. Texts and button
+                         visibility are driven by UpdateAddDevicePrompt. -->
                     <Border x:Name="borderAddDeviceAlert" Visibility="Collapsed"
                             Background="#1AFFCC00" BorderBrush="#FFCC00" BorderThickness="1"
-                            CornerRadius="4" Padding="12,10" Margin="0,0,0,12"
+                            CornerRadius="4" Padding="12,10" Margin="0,10,0,2"
                             HorizontalAlignment="Left" MaxWidth="700">
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -77,12 +85,6 @@
                             </styles:SHButtonPrimary>
                         </Grid>
                     </Border>
-
-                    <!-- Capabilities — styled like a chain node (value + caption) -->
-                    <StackPanel Margin="0,0,0,2">
-                        <TextBlock x:Name="txtCapabilities" Text="—" TextWrapping="Wrap" />
-                        <TextBlock Text="Capabilities" Foreground="#888888" FontSize="11" />
-                    </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,8">
                         <styles:SHButtonPrimary x:Name="btnReconnect" Click="BtnReconnect_Click" HorizontalAlignment="Left">
                             Reconnect

--- a/FanaBridge/UI/SettingsControl.xaml
+++ b/FanaBridge/UI/SettingsControl.xaml
@@ -46,6 +46,24 @@
                     <TextBlock x:Name="txtStatusDetail" Foreground="#E0A800" FontSize="11"
                                TextWrapping="Wrap" Margin="0,0,0,10" Visibility="Collapsed" />
 
+                    <!-- Shown when the attached wheel resolves to a registered SimHub
+                         device the user hasn't added yet — LED/display output never
+                         starts without the device. Text and button visibility are
+                         driven by UpdateAddDevicePrompt. -->
+                    <Border x:Name="borderAddDeviceAlert" Visibility="Collapsed"
+                            Background="#1AFFCC00" BorderBrush="#FFCC00" BorderThickness="1"
+                            CornerRadius="4" Padding="10,8" Margin="0,0,0,12">
+                        <StackPanel>
+                            <TextBlock x:Name="txtAddDeviceText" Foreground="#FFEEBB" FontSize="12"
+                                       TextWrapping="Wrap" />
+                            <styles:SHButtonPrimary x:Name="btnAddDevice" Click="BtnAddDevice_Click"
+                                                    HorizontalAlignment="Left" Margin="0,8,0,0"
+                                                    ToolTip="Add the detected wheel or hub/module combo to SimHub's device list. SimHub switches to its Devices page once added.">
+                                Add Device to SimHub
+                            </styles:SHButtonPrimary>
+                        </StackPanel>
+                    </Border>
+
                     <!-- Capabilities — styled like a chain node (value + caption) -->
                     <StackPanel Margin="0,0,0,2">
                         <TextBlock x:Name="txtCapabilities" Text="—" TextWrapping="Wrap" />

--- a/FanaBridge/UI/SettingsControl.xaml
+++ b/FanaBridge/UI/SettingsControl.xaml
@@ -48,20 +48,34 @@
 
                     <!-- Shown when the attached wheel resolves to a registered SimHub
                          device the user hasn't added yet — LED/display output never
-                         starts without the device. Text and button visibility are
-                         driven by UpdateAddDevicePrompt. -->
+                         starts without the device. Laid out as a callout bar: glyph,
+                         headline + muted detail, action button; left-anchored and
+                         width-capped so it doesn't sprawl on wide windows. Texts and
+                         button visibility are driven by UpdateAddDevicePrompt. -->
                     <Border x:Name="borderAddDeviceAlert" Visibility="Collapsed"
                             Background="#1AFFCC00" BorderBrush="#FFCC00" BorderThickness="1"
-                            CornerRadius="4" Padding="10,8" Margin="0,0,0,12">
-                        <StackPanel>
-                            <TextBlock x:Name="txtAddDeviceText" Foreground="#FFEEBB" FontSize="12"
-                                       TextWrapping="Wrap" />
-                            <styles:SHButtonPrimary x:Name="btnAddDevice" Click="BtnAddDevice_Click"
-                                                    HorizontalAlignment="Left" Margin="0,8,0,0"
+                            CornerRadius="4" Padding="12,10" Margin="0,0,0,12"
+                            HorizontalAlignment="Left" MaxWidth="700">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="&#x26A0;" FontSize="18" Foreground="#FFCC00"
+                                       VerticalAlignment="Center" Margin="0,0,12,0" />
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                <TextBlock x:Name="txtAddDeviceTitle" Foreground="#FFEEBB" FontSize="12"
+                                           FontWeight="SemiBold" TextWrapping="Wrap" />
+                                <TextBlock x:Name="txtAddDeviceDetail" Foreground="#FFEEBB" Opacity="0.7"
+                                           FontSize="11" TextWrapping="Wrap" Margin="0,2,0,0" />
+                            </StackPanel>
+                            <styles:SHButtonPrimary Grid.Column="2" x:Name="btnAddDevice" Click="BtnAddDevice_Click"
+                                                    VerticalAlignment="Center" Margin="16,0,0,0"
                                                     ToolTip="Add the detected wheel or hub/module combo to SimHub's device list. SimHub switches to its Devices page once added.">
-                                Add Device to SimHub
+                                Add to SimHub
                             </styles:SHButtonPrimary>
-                        </StackPanel>
+                        </Grid>
                     </Border>
 
                     <!-- Capabilities — styled like a chain node (value + caption) -->

--- a/FanaBridge/UI/SettingsControl.xaml.cs
+++ b/FanaBridge/UI/SettingsControl.xaml.cs
@@ -401,8 +401,7 @@ namespace FanaBridge.UI
             string name = config.Capabilities?.ShortName ?? config.Capabilities?.Name ?? "This device";
 
             txtAddDeviceTitle.Text = name + " isn't added to SimHub yet";
-            txtAddDeviceDetail.Text = "SimHub can't drive it until it's added. LEDs also need "
-                + "an LED profile afterwards — via the LED editor or a profile plugin.";
+            txtAddDeviceDetail.Text = "SimHub only sends output to devices in its device list.";
             btnAddDevice.IsEnabled = true;
             _promptDeviceTypeId = config.DeviceTypeId;
 

--- a/FanaBridge/UI/SettingsControl.xaml.cs
+++ b/FanaBridge/UI/SettingsControl.xaml.cs
@@ -400,26 +400,11 @@ namespace FanaBridge.UI
 
             string name = config.Capabilities?.ShortName ?? config.Capabilities?.Name ?? "This device";
 
-            var blocking = SimHubDevicesGateway.FindBlockingDevice(
-                devices, config.DeviceTypeId, config.ParentDeviceTypeId);
-            if (blocking != null)
-            {
-                // SimHub would answer the add with its instance-cap error dialog,
-                // so explain the conflict instead of offering the button.
-                txtAddDeviceTitle.Text = name + " can't be added yet";
-                txtAddDeviceDetail.Text = "SimHub allows only one of these devices at a time "
-                    + "— remove \"" + blocking.MainDisplayName + "\" on SimHub's Devices page first.";
-                btnAddDevice.Visibility = Visibility.Collapsed;
-            }
-            else
-            {
-                txtAddDeviceTitle.Text = name + " isn't added to SimHub yet";
-                txtAddDeviceDetail.Text = "LED and display output stays off until it's added "
-                    + "as a SimHub device.";
-                btnAddDevice.Visibility = Visibility.Visible;
-                btnAddDevice.IsEnabled = true;
-                _promptDeviceTypeId = config.DeviceTypeId;
-            }
+            txtAddDeviceTitle.Text = name + " isn't added to SimHub yet";
+            txtAddDeviceDetail.Text = "SimHub can't drive it until it's added. LEDs also need "
+                + "an LED profile afterwards — via the LED editor or a profile plugin.";
+            btnAddDevice.IsEnabled = true;
+            _promptDeviceTypeId = config.DeviceTypeId;
 
             borderAddDeviceAlert.Visibility = Visibility.Visible;
         }

--- a/FanaBridge/UI/SettingsControl.xaml.cs
+++ b/FanaBridge/UI/SettingsControl.xaml.cs
@@ -406,16 +406,16 @@ namespace FanaBridge.UI
             {
                 // SimHub would answer the add with its instance-cap error dialog,
                 // so explain the conflict instead of offering the button.
-                txtAddDeviceText.Text = "⚠  " + name + " is detected, but SimHub won't "
-                    + "add it while \"" + blocking.MainDisplayName + "\" is in its device "
-                    + "list — remove that device on SimHub's Devices page first.";
+                txtAddDeviceTitle.Text = name + " can't be added yet";
+                txtAddDeviceDetail.Text = "SimHub allows only one of these devices at a time "
+                    + "— remove \"" + blocking.MainDisplayName + "\" on SimHub's Devices page first.";
                 btnAddDevice.Visibility = Visibility.Collapsed;
             }
             else
             {
-                txtAddDeviceText.Text = "⚠  " + name + " is detected, but it hasn't "
-                    + "been added to SimHub's devices yet — LEDs and display output stay "
-                    + "off until it is.";
+                txtAddDeviceTitle.Text = name + " isn't added to SimHub yet";
+                txtAddDeviceDetail.Text = "LED and display output stays off until it's added "
+                    + "as a SimHub device.";
                 btnAddDevice.Visibility = Visibility.Visible;
                 btnAddDevice.IsEnabled = true;
                 _promptDeviceTypeId = config.DeviceTypeId;

--- a/FanaBridge/UI/SettingsControl.xaml.cs
+++ b/FanaBridge/UI/SettingsControl.xaml.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
@@ -7,9 +9,11 @@ using System.Windows.Documents;
 using System.Windows.Media;
 using System.Windows.Navigation;
 using System.Windows.Threading;
+using FanaBridge.Adapters;
 using FanaBridge.Profiles;
 using FanaBridge.Protocol;
 using FanaBridge.Transport;
+using SimHub.Plugins.Devices;
 using Timer = System.Timers.Timer;
 
 namespace FanaBridge.UI
@@ -28,6 +32,18 @@ namespace FanaBridge.UI
         /// </summary>
         private WheelCapabilities _bootCaps;
         private bool _restartPromptDismissed;
+
+        /// <summary>
+        /// DeviceTypeID the add-device prompt's button would add; null while
+        /// the prompt is hidden or the add is blocked by a similar device.
+        /// </summary>
+        private string _promptDeviceTypeId;
+
+        /// <summary>
+        /// SimHub's device collection, watched while this control is loaded so
+        /// the add-device prompt tracks devices added/removed outside this page.
+        /// </summary>
+        private ObservableCollection<DeviceInstance> _watchedDevices;
 
         public SettingsControl()
         {
@@ -255,6 +271,8 @@ namespace FanaBridge.UI
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
             StopScroll();
+            StopPromptRetry();
+            UnwatchSimHubDevices();
             Plugin.StateChanged -= OnPluginStateChanged;
         }
 
@@ -270,6 +288,10 @@ namespace FanaBridge.UI
             // Independent of device connection (Control Mapper is configured with or
             // without a wheel attached), so it runs ahead of the connection returns.
             UpdateControlMapperStatus();
+
+            // Also self-contained (hides itself while disconnected), so it runs
+            // ahead of the early returns below and stays correct on every path.
+            UpdateAddDevicePrompt();
 
             if (!Plugin.IsDeviceConnected)
             {
@@ -315,6 +337,199 @@ namespace FanaBridge.UI
             UpdateProfilePicker(
                 wheelbase.WheelDetected, wheelbase.WheelCode, wheelbase.ModuleCode,
                 identified ? caps : null);
+        }
+
+        // =====================================================================
+        // ADD-DEVICE PROMPT
+        //
+        // LEDs and display output only start once the user adds the wheel's
+        // device entry in SimHub — a step many users miss after installing the
+        // plugin. Whenever the attached wheel resolves to a registered
+        // descriptor with no added device yet, show a banner with a one-click
+        // add. Added-ness lives in SimHub's Devices plugin, so besides
+        // StateChanged this also watches SimHub's device collection while the
+        // page is visible.
+        // =====================================================================
+
+        private void UpdateAddDevicePrompt()
+        {
+            _promptDeviceTypeId = null;
+
+            var wheelbase = Plugin?.Wheelbase;
+            if (wheelbase == null || !Plugin.IsDeviceConnected || !wheelbase.HasIdentity
+                || !wheelbase.WheelDetected)
+            {
+                // Every way out of these states (connect/disconnect, identity
+                // commit) raises StateChanged, so no re-poll is needed.
+                StopPromptRetry();
+                borderAddDeviceAlert.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            if (!wheelbase.IdentityStable)
+            {
+                // The unstable→stable edge is silent when the identity settles
+                // back UNCHANGED (nothing commits, so no StateChanged) — re-poll
+                // until stable or the banner could stay hidden indefinitely
+                // after an update landed inside the settle window.
+                ArmPromptRetry();
+                borderAddDeviceAlert.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            StopPromptRetry();
+
+            var devices = SimHubDevicesGateway.Resolve(Plugin.PluginManager);
+            if (devices != null)
+                WatchSimHubDevices(devices);
+
+            var config = FanatecDevicesRegistry.FindConfigForAttachment(
+                wheelbase.WheelDetected, wheelbase.WheelCode, wheelbase.ModuleCode);
+
+            // Stay quiet when there is nothing addable: no matching registered
+            // config, a config whose descriptor SimHub doesn't know (a profile
+            // created this session — the restart notice owns that message), or
+            // the device is already added.
+            if (config == null || devices == null
+                || !SimHubDevicesGateway.HasDescriptor(devices, config.DeviceTypeId)
+                || SimHubDevicesGateway.IsDeviceAdded(devices, config.DeviceTypeId))
+            {
+                borderAddDeviceAlert.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            string name = config.Capabilities?.ShortName ?? config.Capabilities?.Name ?? "This device";
+
+            var blocking = SimHubDevicesGateway.FindBlockingDevice(
+                devices, config.DeviceTypeId, config.ParentDeviceTypeId);
+            if (blocking != null)
+            {
+                // SimHub would answer the add with its instance-cap error dialog,
+                // so explain the conflict instead of offering the button.
+                txtAddDeviceText.Text = "⚠  " + name + " is detected, but SimHub won't "
+                    + "add it while \"" + blocking.MainDisplayName + "\" is in its device "
+                    + "list — remove that device on SimHub's Devices page first.";
+                btnAddDevice.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                txtAddDeviceText.Text = "⚠  " + name + " is detected, but it hasn't "
+                    + "been added to SimHub's devices yet — LEDs and display output stay "
+                    + "off until it is.";
+                btnAddDevice.Visibility = Visibility.Visible;
+                btnAddDevice.IsEnabled = true;
+                _promptDeviceTypeId = config.DeviceTypeId;
+            }
+
+            borderAddDeviceAlert.Visibility = Visibility.Visible;
+        }
+
+        private async void BtnAddDevice_Click(object sender, RoutedEventArgs e)
+        {
+            string deviceTypeId = _promptDeviceTypeId;
+            if (Plugin == null || deviceTypeId == null)
+                return;
+
+            var devices = SimHubDevicesGateway.Resolve(Plugin.PluginManager);
+            if (devices == null)
+                return;
+
+            // Re-check right before adding — a double-add would end in SimHub's
+            // instance-cap error dialog.
+            if (SimHubDevicesGateway.IsDeviceAdded(devices, deviceTypeId))
+            {
+                UpdateStatus();
+                return;
+            }
+
+            btnAddDevice.IsEnabled = false;
+            try
+            {
+                // Sanctioned add path: wires extensions, default settings and
+                // Init like a manual add; autoName skips the naming dialog. On
+                // success SimHub switches to its Devices page so the user sees
+                // the new entry. Returns null if the user cancelled or SimHub
+                // refused; the add isn't persisted until SaveSettings.
+                var instance = await devices.ShowAddDevice(
+                    this, deviceTypeId, requestName: false, autoName: true);
+                if (instance != null)
+                {
+                    devices.SaveSettings();
+                    SimHub.Logging.Current.Info(
+                        "FanaBridge: Added SimHub device " + deviceTypeId + " from the settings prompt");
+                }
+            }
+            catch (Exception ex)
+            {
+                SimHub.Logging.Current.Warn(
+                    "FanaBridge: Failed to add SimHub device " + deviceTypeId + ": " + ex.Message);
+            }
+            finally
+            {
+                btnAddDevice.IsEnabled = true;
+                UpdateStatus();
+            }
+        }
+
+        // Re-polls the prompt while the wheel identity is settling; interval is
+        // comfortably above the settler's 200 ms quiet window. Created lazily,
+        // stopped whenever the identity is readable again or the page unloads.
+        private DispatcherTimer _promptRetryTimer;
+
+        private void ArmPromptRetry()
+        {
+            if (!IsLoaded)
+                return;
+
+            if (_promptRetryTimer == null)
+            {
+                _promptRetryTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
+                _promptRetryTimer.Tick += (s, e) => UpdateAddDevicePrompt();
+            }
+
+            _promptRetryTimer.Start();
+        }
+
+        private void StopPromptRetry()
+        {
+            _promptRetryTimer?.Stop();
+        }
+
+        // SimHub raises no event of its own when the user adds or removes a
+        // device, and Plugin.StateChanged doesn't fire for it either — watching
+        // the (public) device collection keeps the banner honest without
+        // polling. Subscribed lazily on first prompt evaluation, dropped on
+        // Unloaded, symmetric across tab switches.
+        private void WatchSimHubDevices(DevicesPlugin devices)
+        {
+            // A StateChanged racing OnUnloaded can queue an UpdateStatus that
+            // runs after the unsubscribes; without this guard it would
+            // re-subscribe on a control SimHub has already discarded, pinning
+            // it (and re-running the prompt) for the rest of the app's life.
+            if (!IsLoaded)
+                return;
+
+            var collection = devices?.DevicesPluginSettings?.Devices;
+            if (collection == null || ReferenceEquals(_watchedDevices, collection))
+                return;
+
+            UnwatchSimHubDevices();
+            _watchedDevices = collection;
+            _watchedDevices.CollectionChanged += OnSimHubDevicesChanged;
+        }
+
+        private void UnwatchSimHubDevices()
+        {
+            if (_watchedDevices == null)
+                return;
+
+            _watchedDevices.CollectionChanged -= OnSimHubDevicesChanged;
+            _watchedDevices = null;
+        }
+
+        private void OnSimHubDevicesChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            Dispatcher.BeginInvoke(new Action(UpdateAddDevicePrompt));
         }
 
         // =====================================================================

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ If your wheel isn't listed, use the **Wheel Profile Wizard** (see [Usage](#usage
 
 1. In the Fanatec software, set **Fanatec App LED/Display output** to **Disabled** (otherwise the Fanatec driver and FanaBridge will fight over control of the LEDs and display)
 2. Connect your Fanatec wheelbase and attach a supported wheel
-3. In SimHub, go to **Devices**, click **Add** (+), then **Add New Device**, and choose your wheel or hub/module combo
+3. Add the wheel as a SimHub device — either:
+   - Open the **FanaBridge** settings tab and click **Add Device to SimHub** on the prompt that appears when a detected wheel or hub hasn't been added yet, or
+   - In SimHub, go to **Devices**, click **Add** (+), then **Add New Device**, and choose your wheel or hub/module combo
 4. Configure LED profiles using SimHub's built-in LED Editor, or with a third-party LED profile plugin like [ATSR Hub EVO](https://github.com/ATSR-Alex/ATSR-Hub-EVO)
 
 ### Adding an unsupported wheel

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If your wheel isn't listed, use the **Wheel Profile Wizard** (see [Usage](#usage
 1. In the Fanatec software, set **Fanatec App LED/Display output** to **Disabled** (otherwise the Fanatec driver and FanaBridge will fight over control of the LEDs and display)
 2. Connect your Fanatec wheelbase and attach a supported wheel
 3. Add the wheel as a SimHub device — either:
-   - Open the **FanaBridge** settings tab and click **Add Device to SimHub** on the prompt that appears when a detected wheel or hub hasn't been added yet, or
+   - Open the **FanaBridge** settings tab and click **Add to SimHub** on the prompt that appears when a detected wheel or hub hasn't been added yet, or
    - In SimHub, go to **Devices**, click **Add** (+), then **Add New Device**, and choose your wheel or hub/module combo
 4. Configure LED profiles using SimHub's built-in LED Editor, or with a third-party LED profile plugin like [ATSR Hub EVO](https://github.com/ATSR-Alex/ATSR-Hub-EVO)
 


### PR DESCRIPTION
## Summary

A detected wheel drives no LEDs or display until the user adds its device entry in SimHub — a step many users miss after installing the plugin. The settings page now shows a callout in DEVICE STATUS whenever the attached wheel/hub resolves to a registered descriptor with no added device, with a one-click **Add to SimHub** button. The detail line sticks to one job — "SimHub only sends output to devices in its device list." (A hint about the follow-up LED-profile step was considered and cut; if it lands anywhere it'll be help text in the LEDs panel, out of scope here.)

## How it works

- **Detection**: the attached identity is resolved through the registry's own config set (`FanatecDevicesRegistry.FindConfigForAttachment`, extracted from `GetDevices()`), so the prompt uses the exact same wheel+module matching as device-state reporting — no bare-wheel fallback that would suggest a device stuck at Scanning.
- **Added-check**: `SimHubDevicesGateway` queries SimHub's `DevicesPlugin.GetDevices()` by `DeviceTypeID` (Ordinal). An un-added device has no `DeviceInstance` at all, so this is the only place added-ness is visible.
- **Add**: `ShowAddDevice(source, id, requestName:false, autoName:true)` on the UI thread — the sanctioned path that wires extensions, defaults, and `Init` like a manual add — followed by `DevicesPlugin.SaveSettings()` for crash-durable persistence. SimHub switches to its Devices page on success so the user sees the new entry. If SimHub refuses the add (its instance cap counts across a descriptor family, e.g. the same button module on two hubs), SimHub shows its own explanatory dialog — deliberately not pre-checked here.
- **Staying fresh**: re-evaluates on `StateChanged`, on tab load, on SimHub's device collection changing (`CollectionChanged` — SimHub raises no add/remove event of its own), and re-polls briefly while the wheel identity is settling, since a flap that settles back unchanged commits nothing and raises no event. Descriptors are collected once at SimHub startup, so a profile created this session stays quiet (the existing restart notice owns that message).

## UI

Callout bar below the status readout (chain + capabilities), next to the action row: warning glyph, semibold headline (device name + state), muted detail line, and the action button vertically centered on the right. Left-anchored, width-capped at 700px.

## Testing

- Full suite passes (394 tests), including gateway null-guard tests keeping the prompt quiet before SimHub's Devices plugin is available.
- Exercised on hardware (ClubSport DD+ › Podium Hub › Button Module Endurance): banner appears when the device isn't added, adds on click, hides once added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
