### PR TITLE
Fix: Control Mapper UI-thread deadlock on wheel change

### DIFF
--- a/FanaBridge.Tests/ControlMapperBridgeTests.cs
+++ b/FanaBridge.Tests/ControlMapperBridgeTests.cs
@@ -163,6 +163,52 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void EnsureRegistered_ReEnumeratesOutsideLock_ReentrantCallDoesNotDeadlock()
+        {
+            var (bridge, pm, helper, worker) = NewSetup(stock: new FakeStockProvider("x"));
+
+            // SimHub's real UpdateControllerList does a synchronous Dispatcher.Invoke to the
+            // UI thread, which re-enters the bridge (IsRecognizeIndividualWheelsOn takes _sync).
+            // Model that re-entry as a call from another thread: if EnsureRegistered still holds
+            // _sync while re-enumerating, the re-entrant call blocks forever (the deadlock).
+            bool reentrantCompleted = false;
+            worker.OnUpdate = () =>
+            {
+                var t = System.Threading.Tasks.Task.Run(() => bridge.IsRecognizeIndividualWheelsOn(pm));
+                reentrantCompleted = t.Wait(System.TimeSpan.FromSeconds(5));
+            };
+
+            bool ok = bridge.EnsureRegistered(pm);
+
+            Assert.True(ok);
+            Assert.Equal(1, worker.UpdateControllerListCalls); // re-enumerate did run
+            Assert.True(reentrantCompleted,
+                "re-enumerate must run outside _sync; a UI-thread re-entry deadlocks if the lock is held");
+        }
+
+        [Fact]
+        public void RequestReEnumerate_RunsOutsideLock_ReentrantCallDoesNotDeadlock()
+        {
+            // The WheelChanged path (fires on every wheel/hub swap, converter or genuine).
+            var (bridge, pm, helper, worker) = NewSetup(stock: new FakeStockProvider("x"));
+            Assert.True(bridge.EnsureRegistered(pm));  // register first; the registration re-enumerate has OnUpdate=null
+            worker.UpdateControllerListCalls = 0;
+
+            bool reentrantCompleted = false;
+            worker.OnUpdate = () =>
+            {
+                var t = System.Threading.Tasks.Task.Run(() => bridge.IsRecognizeIndividualWheelsOn(pm));
+                reentrantCompleted = t.Wait(System.TimeSpan.FromSeconds(5));
+            };
+
+            bridge.RequestReEnumerate();
+
+            Assert.Equal(1, worker.UpdateControllerListCalls);
+            Assert.True(reentrantCompleted,
+                "RequestReEnumerate (WheelChanged) must re-enumerate outside _sync");
+        }
+
+        [Fact]
         public void EnsureRegistered_PluginNotLoaded_QuietRetry()
         {
             var pm = new FakePluginManager(null); // GetPlugin<T>() returns null
@@ -302,9 +348,14 @@ namespace FanaBridge.Tests.CmFakes
         /// <summary>When set, UpdateControllerList throws — drives the bridge's
         /// defensive catch in EnsureRegistered (a SimHub internal misbehaving mid-call).</summary>
         public bool ThrowOnUpdate;
+        /// <summary>Invoked inside UpdateControllerList to model SimHub's synchronous
+        /// Dispatcher.Invoke to the UI thread — used to assert the bridge isn't holding
+        /// <c>_sync</c> while it re-enumerates (see the deadlock regression tests).</summary>
+        public System.Action OnUpdate;
         internal void UpdateControllerList()
         {
             UpdateControllerListCalls++;
+            OnUpdate?.Invoke();
             if (ThrowOnUpdate)
                 throw new System.InvalidOperationException("simulated SimHub failure");
         }

--- a/FanaBridge/Adapters/ControlMapperBridge.cs
+++ b/FanaBridge/Adapters/ControlMapperBridge.cs
@@ -109,6 +109,7 @@ namespace FanaBridge.Adapters
         public bool EnsureRegistered(object pm)
         {
             if (pm == null) return false;
+            object rwToReEnum = null; // set when a re-enumerate is needed; dispatched AFTER releasing _sync
             lock (_sync)
             {
                 if (_giveUpLogged) return false;
@@ -183,9 +184,8 @@ namespace FanaBridge.Adapters
                             SimHub.Logging.Current.Info(
                                 "FanaBridge: Control Mapper variant provider re-registered after eviction");
                         }
-                        InvokeUpdateControllerList(rw); // re-key a rim already attached at toggle time
+                        rwToReEnum = rw; // defer the re-enumerate to outside _sync (see ReEnumerateOutsideLock)
                     }
-                    return true;
                 }
                 catch (Exception ex)
                 {
@@ -194,6 +194,10 @@ namespace FanaBridge.Adapters
                     return false;
                 }
             }
+            // A newly-registered provider needs the live controller list re-keyed —
+            // dispatch OUTSIDE _sync (see ReEnumerateOutsideLock) to avoid the deadlock.
+            ReEnumerateOutsideLock(rwToReEnum);
+            return true;
         }
 
         /// <summary>
@@ -203,6 +207,7 @@ namespace FanaBridge.Adapters
         /// </summary>
         public void RequestReEnumerate()
         {
+            object rw = null;
             lock (_sync)
             {
                 if (!_registered || _updListMethod == null || _getPluginCM == null || _pm == null)
@@ -210,15 +215,17 @@ namespace FanaBridge.Adapters
                 try
                 {
                     object cm = LiveControlMapper();
-                    object rw = cm != null ? _rwField.GetValue(cm) : null;
-                    if (rw != null) InvokeUpdateControllerList(rw);
+                    rw = cm != null ? _rwField.GetValue(cm) : null;
                 }
                 catch (Exception ex)
                 {
                     SimHub.Logging.Current.Debug(
-                        "FanaBridge: Control Mapper re-enumerate failed: " + ex.Message);
+                        "FanaBridge: Control Mapper re-enumerate lookup failed: " + ex.Message);
+                    return;
                 }
             }
+            // Dispatch OUTSIDE _sync — see ReEnumerateOutsideLock.
+            ReEnumerateOutsideLock(rw);
         }
 
         /// <summary>
@@ -536,6 +543,16 @@ namespace FanaBridge.Adapters
                 LogGiveUp("GetPlugin<ControlMapperPlugin> threw: " + ex.GetBaseException().Message);
                 return null;
             }
+        }
+
+        // Invoke SimHub's UpdateControllerList OUTSIDE _sync. UpdateControllerList does a
+        // synchronous Dispatcher.Invoke to the UI thread, which re-enters this bridge
+        // (e.g. IsRecognizeIndividualWheelsOn takes _sync); holding _sync across it
+        // deadlocks the plugin thread against the UI thread (WatchDog "Abnormal Inactivity").
+        private void ReEnumerateOutsideLock(object rw)
+        {
+            if (rw == null) return;
+            InvokeUpdateControllerList(rw);
         }
 
         private void InvokeUpdateControllerList(object rw)


### PR DESCRIPTION
## Summary

Fixes a deadlock in the Control Mapper integration that can freeze SimHub on any wheel/hub change.

`ControlMapperBridge.EnsureRegistered` and `RequestReEnumerate` called `RemapperWorker.UpdateControllerList` **while holding the bridge's `_sync` lock**. `UpdateControllerList` does a synchronous `Dispatcher.Invoke` to the UI thread, and that UI work re-enters the bridge (e.g. `IsRecognizeIndividualWheelsOn`, which also takes `_sync`). The plugin thread holds `_sync` and blocks on the UI thread; the UI thread blocks trying to take `_sync` → deadlock, which SimHub surfaces as an "Abnormal Inactivity" watchdog kill of the plugin.

The trigger is `WheelChanged` (fires on every wheel/hub swap), so this affects **genuine Fanatec hardware**, not only third-party converters.

## Fix

Capture the `RemapperWorker` handle inside the lock, then dispatch `UpdateControllerList` **after** releasing `_sync`, via a small `ReEnumerateOutsideLock` helper. Both call sites updated. No behavior change beyond moving the re-enumerate outside the lock.

## Tests

Two regression tests model SimHub's synchronous UI-thread re-entry as a call from another thread during `UpdateControllerList`, asserting it completes instead of blocking:
- `EnsureRegistered_ReEnumeratesOutsideLock_ReentrantCallDoesNotDeadlock`
- `RequestReEnumerate_RunsOutsideLock_ReentrantCallDoesNotDeadlock`

Both **fail (5s deadlock timeout) on the current code and pass with the fix** — verified red→green. Full suite: **312 passing**.

## Context

Independent of, but unblocks, the SRM converter identity work (#47): converter connect fires `WheelChanged` too, so that feature should not ship on top of this latent deadlock. This fix stands on its own and helps all users with the Control Mapper integration enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
