### PR TITLE
Route col03 input through typed per-family streams

### DIFF
--- a/FanaBridge.Tests/Col03FrameClassifierTests.cs
+++ b/FanaBridge.Tests/Col03FrameClassifierTests.cs
@@ -1,0 +1,156 @@
+using FanaBridge.Protocol;
+using FanaBridge.Transport;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class Col03FrameClassifierTests
+    {
+        // A frame long enough to satisfy the FF 08 length rule (module byte at
+        // sig + 0x1F must be inside the frame).
+        private static byte[] Frame(int length, params byte[] head)
+        {
+            var b = new byte[length];
+            for (int i = 0; i < head.Length; i++) b[i] = head[i];
+            return b;
+        }
+
+        private static Col03Family Classify(byte[] frame)
+        {
+            Assert.True(Col03FrameClassifier.TryClassify(frame, frame.Length, out var family));
+            return family;
+        }
+
+        // ── Identity (FF 08) ──────────────────────────────────────────────
+
+        [Theory]
+        [InlineData(0)] // raw
+        [InlineData(1)] // behind a report-id
+        [InlineData(2)] // behind two prefix bytes
+        public void Ff08_AtToleratedOffsets_IsIdentity(int offset)
+        {
+            var frame = new byte[64];
+            frame[offset] = 0xFF;
+            frame[offset + 1] = 0x08;
+            Assert.Equal(Col03Family.Identity, Classify(frame));
+        }
+
+        [Fact]
+        public void Ff08_AtOffset3_IsNotIdentity()
+        {
+            var frame = Frame(64, 0x00, 0x00, 0x00, 0xFF, 0x08);
+            Assert.False(Col03FrameClassifier.TryClassify(frame, frame.Length, out _));
+        }
+
+        [Fact]
+        public void Ff08_TooShortForModuleByte_IsNotIdentity()
+        {
+            // Sig at 0 needs len >= 0x20; 0x1F is one byte short.
+            var frame = Frame(0x1F, 0xFF, 0x08);
+            Assert.False(Col03FrameClassifier.TryClassify(frame, frame.Length, out _));
+        }
+
+        [Fact]
+        public void FindIdentitySignature_ReturnsOffset()
+        {
+            var frame = new byte[64];
+            frame[1] = 0xFF;
+            frame[2] = 0x08;
+            Assert.Equal(1, Col03FrameClassifier.FindIdentitySignature(frame, frame.Length));
+        }
+
+        // ── SRM (0xDD) ────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void Dd_AtOffset0Or1_WithPayload_IsSrm(int offset)
+        {
+            var frame = new byte[16];
+            frame[offset] = 0xDD;
+            Assert.Equal(Col03Family.Srm, Classify(frame));
+        }
+
+        [Fact]
+        public void Dd_AtOffset2_IsNotSrm()
+        {
+            var frame = Frame(16, 0x00, 0x00, 0xDD);
+            Assert.False(Col03FrameClassifier.TryClassify(frame, frame.Length, out _));
+        }
+
+        [Fact]
+        public void Dd_WithTruncatedPayload_IsNotSrm()
+        {
+            // 0xDD at offset 1 needs len >= 7; 6 is one short.
+            var frame = Frame(6, 0x00, 0xDD);
+            Assert.False(Col03FrameClassifier.TryClassify(frame, frame.Length, out _));
+        }
+
+        [Fact]
+        public void Dd_MinimalReply_LengthBoundaryHolds()
+        {
+            // 0xDD at offset 0 with exactly the 6-byte reply is valid.
+            var frame = Frame(6, 0xDD);
+            Assert.Equal(Col03Family.Srm, Classify(frame));
+        }
+
+        // ── ITM (FF 05) / Tuning (FF 03) ──────────────────────────────────
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void Ff05_AtToleratedOffsets_IsItm(int offset)
+        {
+            var frame = new byte[64];
+            frame[offset] = 0xFF;
+            frame[offset + 1] = 0x05;
+            Assert.Equal(Col03Family.Itm, Classify(frame));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void Ff03_AtToleratedOffsets_IsTuning(int offset)
+        {
+            var frame = new byte[64];
+            frame[offset] = 0xFF;
+            frame[offset + 1] = 0x03;
+            Assert.Equal(Col03Family.Tuning, Classify(frame));
+        }
+
+        // ── Precedence and noise ──────────────────────────────────────────
+
+        [Fact]
+        public void Precedence_FfDdFf08_ClassifiesAsIdentity()
+        {
+            // 0xDD at offset 1 AND FF 08 at offset 2 — the historical dispatch
+            // checked FF 08 first, so Identity must win.
+            var frame = Frame(64, 0xFF, 0xDD, 0xFF, 0x08);
+            Assert.Equal(Col03Family.Identity, Classify(frame));
+        }
+
+        [Fact]
+        public void ShortFf08_WithDd_FallsThroughToSrm()
+        {
+            // Too short for the FF 08 length rule, but a valid 0xDD reply.
+            var frame = Frame(16, 0xDD, 0xFF, 0x08);
+            Assert.Equal(Col03Family.Srm, Classify(frame));
+        }
+
+        [Fact]
+        public void AxisJunk_IsUnclassified()
+        {
+            var frame = Frame(64, 0x01, 0x80, 0x7F, 0x00, 0x40);
+            Assert.False(Col03FrameClassifier.TryClassify(frame, frame.Length, out _));
+        }
+
+        [Fact]
+        public void NullOrEmpty_IsUnclassified()
+        {
+            Assert.False(Col03FrameClassifier.TryClassify(null, 0, out _));
+            Assert.False(Col03FrameClassifier.TryClassify(new byte[0], 0, out _));
+        }
+    }
+}

--- a/FanaBridge.Tests/Col03QueueSetTests.cs
+++ b/FanaBridge.Tests/Col03QueueSetTests.cs
@@ -1,0 +1,103 @@
+using FanaBridge.Transport;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class Col03QueueSetTests
+    {
+        private static byte[] IdentityFrame()
+        {
+            var b = new byte[64];
+            b[0] = 0xFF; b[1] = 0x08;
+            return b;
+        }
+
+        private static byte[] ItmFrame()
+        {
+            var b = new byte[64];
+            b[0] = 0xFF; b[1] = 0x05;
+            return b;
+        }
+
+        private static byte[] SrmFrame(byte marker = 0)
+        {
+            var b = new byte[16];
+            b[0] = 0xDD; b[1] = marker;
+            return b;
+        }
+
+        private static byte[] TuningFrame()
+        {
+            var b = new byte[64];
+            b[0] = 0xFF; b[1] = 0x03;
+            return b;
+        }
+
+        [Fact]
+        public void Route_DeliversEachFamilyToItsOwnQueue()
+        {
+            var set = new Col03QueueSet();
+            set.Route(IdentityFrame(), 64);
+            set.Route(ItmFrame(), 64);
+            set.Route(SrmFrame(), 16);
+            set.Route(TuningFrame(), 64);
+
+            var dest = new byte[64];
+            Assert.Equal(64, set.Get(Col03Family.Identity).TryRead(dest, 0));
+            Assert.Equal(64, set.Get(Col03Family.Itm).TryRead(dest, 0));
+            Assert.Equal(16, set.Get(Col03Family.Srm).TryRead(dest, 0));
+            Assert.Equal(64, set.Get(Col03Family.Tuning).TryRead(dest, 0));
+
+            // Exactly one frame each — cross-family pops come back empty.
+            Assert.Equal(-1, set.Get(Col03Family.Identity).TryRead(dest, 0));
+            Assert.Equal(-1, set.Get(Col03Family.Itm).TryRead(dest, 0));
+            Assert.Equal(-1, set.Get(Col03Family.Srm).TryRead(dest, 0));
+            Assert.Equal(-1, set.Get(Col03Family.Tuning).TryRead(dest, 0));
+        }
+
+        [Fact]
+        public void Route_DropsUnclassifiedFrames()
+        {
+            var set = new Col03QueueSet();
+            set.Route(new byte[] { 0x01, 0x80, 0x7F, 0x00 }, 4); // axis junk
+
+            var dest = new byte[64];
+            Assert.Equal(-1, set.Get(Col03Family.Identity).TryRead(dest, 0));
+            Assert.Equal(-1, set.Get(Col03Family.Itm).TryRead(dest, 0));
+            Assert.Equal(-1, set.Get(Col03Family.Srm).TryRead(dest, 0));
+            Assert.Equal(-1, set.Get(Col03Family.Tuning).TryRead(dest, 0));
+        }
+
+        [Fact]
+        public void Overflow_DropsOldestWithinOneFamily_OthersUntouched()
+        {
+            var set = new Col03QueueSet();
+
+            // One identity frame, then flood SRM past its capacity (16).
+            set.Route(IdentityFrame(), 64);
+            for (byte i = 0; i < 20; i++)
+                set.Route(SrmFrame(i), 16);
+
+            var dest = new byte[64];
+
+            // SRM kept the NEWEST 16 (markers 4..19) — oldest dropped.
+            Assert.Equal(16, set.Get(Col03Family.Srm).TryRead(dest, 0));
+            Assert.Equal(4, dest[1]);
+
+            // The identity frame was not disturbed by the SRM overflow.
+            Assert.Equal(64, set.Get(Col03Family.Identity).TryRead(dest, 0));
+        }
+
+        [Fact]
+        public void Close_WakesEveryFamilyWithMinusOne()
+        {
+            var set = new Col03QueueSet();
+            set.Route(IdentityFrame(), 64);
+            set.Close();
+
+            var dest = new byte[64];
+            Assert.Equal(-1, set.Get(Col03Family.Identity).TryRead(dest, 0));
+            Assert.Equal(-1, set.Get(Col03Family.Tuning).TryRead(dest, 250)); // no blocking after close
+        }
+    }
+}

--- a/FanaBridge.Tests/ConnectionMonitorTests.cs
+++ b/FanaBridge.Tests/ConnectionMonitorTests.cs
@@ -230,9 +230,12 @@ namespace FanaBridge.Tests
         }
 
         // ── ForceReconnect ───────────────────────────────────────────────
+        // ForceReconnect only REQUESTS the reconnect (it may be called from the
+        // UI thread); the work happens on the next frame's Update so all device
+        // I/O stays on the frame thread.
 
         [Fact]
-        public void ForceReconnect_WhenConnected_DisconnectsAndReconnects()
+        public void ForceReconnect_WhenConnected_DisconnectsAndReconnectsOnNextUpdate()
         {
             var wheelbase = new StubWheelbase();
             bool connectedFired = false;
@@ -242,6 +245,9 @@ namespace FanaBridge.Tests
             monitor.TryInitialConnect();
 
             monitor.ForceReconnect();
+            Assert.Equal(0, wheelbase.DisconnectCalls); // deferred — nothing yet
+
+            monitor.Update();
 
             Assert.True(monitor.IsConnected);
             Assert.True(connectedFired);
@@ -249,18 +255,20 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void ForceReconnect_WhenDisconnected_SkipsDisconnect()
+        public void ForceReconnect_WhenDisconnected_SkipsDisconnectAndBypassesCooldown()
         {
             var wheelbase = new StubWheelbase();
             int connectAttempts = 0;
 
-            var monitor = Create(wheelbase, () => ++connectAttempts >= 2);
+            var monitor = Create(wheelbase, () => ++connectAttempts >= 3);
             monitor.TryInitialConnect(); // fails (attempt 1)
+            monitor.Update();            // fails (attempt 2) → long cooldown armed
 
             Assert.False(monitor.IsConnected);
             Assert.Equal(0, wheelbase.DisconnectCalls);
 
-            monitor.ForceReconnect(); // attempt 2 → succeeds
+            monitor.ForceReconnect();
+            monitor.Update(); // attempt 3, immediately (cooldown bypassed) → succeeds
 
             Assert.True(monitor.IsConnected);
             Assert.Equal(0, wheelbase.DisconnectCalls); // wasn't connected, so no disconnect
@@ -277,7 +285,8 @@ namespace FanaBridge.Tests
             monitor.Disconnected += () => disconnectedFired = true;
             monitor.TryInitialConnect(); // attempt 1 → succeeds
 
-            monitor.ForceReconnect(); // attempt 2 → fails
+            monitor.ForceReconnect();
+            monitor.Update(); // disconnects, then attempt 2 → fails
 
             Assert.False(monitor.IsConnected);
             Assert.True(disconnectedFired);

--- a/FanaBridge.Tests/FakeReportStream.cs
+++ b/FanaBridge.Tests/FakeReportStream.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using FanaBridge.Transport;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// Scriptable <see cref="IReportStream"/> for transport fakes: enqueue frames
+    /// with <see cref="Enqueue"/>, and they come back from <see cref="TryRead"/>
+    /// in order (-1 when empty — timeouts are not simulated). Records Flush calls
+    /// and forwards enqueued frames to any taps, mirroring the real stream.
+    /// </summary>
+    internal sealed class FakeReportStream : IReportStream
+    {
+        private readonly Queue<byte[]> _frames = new Queue<byte[]>();
+        private readonly List<Action<byte[]>> _taps = new List<Action<byte[]>>();
+
+        public int FlushCount;
+        public int ReadCount;
+
+        /// <summary>A shared always-empty stream for fakes that never script reads.</summary>
+        public static readonly FakeReportStream Empty = new FakeReportStream();
+
+        public void Enqueue(byte[] frame)
+        {
+            _frames.Enqueue(frame);
+            foreach (var tap in _taps.ToArray())
+                tap((byte[])frame.Clone());
+        }
+
+        public int PendingCount => _frames.Count;
+
+        public int TryRead(byte[] destination, int timeoutMs)
+        {
+            ReadCount++;
+            if (_frames.Count == 0) return -1;
+            var frame = _frames.Dequeue();
+            int n = Math.Min(frame.Length, destination.Length);
+            Array.Copy(frame, destination, n);
+            return n;
+        }
+
+        public void Flush()
+        {
+            FlushCount++;
+            _frames.Clear();
+        }
+
+        public IDisposable Tap(Action<byte[]> observer)
+        {
+            _taps.Add(observer);
+            return new TapToken(this, observer);
+        }
+
+        private sealed class TapToken : IDisposable
+        {
+            private readonly FakeReportStream _stream;
+            private readonly Action<byte[]> _observer;
+            public TapToken(FakeReportStream stream, Action<byte[]> observer)
+            {
+                _stream = stream;
+                _observer = observer;
+            }
+            public void Dispose() => _stream._taps.Remove(_observer);
+        }
+    }
+}

--- a/FanaBridge.Tests/FanatecDisplayDriverTests.cs
+++ b/FanaBridge.Tests/FanatecDisplayDriverTests.cs
@@ -35,7 +35,10 @@ namespace FanaBridge.Tests
             }
 
             public bool SendCol03(byte[] data) => true;
-            public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public IReportStream IdentityReports => FakeReportStream.Empty;
+            public IReportStream ItmReports => FakeReportStream.Empty;
+            public IReportStream SrmReports => FakeReportStream.Empty;
+            public IReportStream TuningReports => FakeReportStream.Empty;
             public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
             public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOpDisposable();

--- a/FanaBridge.Tests/FanatecLedDriverTests.cs
+++ b/FanaBridge.Tests/FanatecLedDriverTests.cs
@@ -31,7 +31,10 @@ namespace FanaBridge.Tests
 
             public bool SendCol01(byte[] data) { lock (_lock) { _col01.Add((byte[])data.Clone()); } return true; }
             public bool SendCol03(byte[] data) { lock (_lock) { _col03.Add((byte[])data.Clone()); } return true; }
-            public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public IReportStream IdentityReports => FakeReportStream.Empty;
+            public IReportStream ItmReports => FakeReportStream.Empty;
+            public IReportStream SrmReports => FakeReportStream.Empty;
+            public IReportStream TuningReports => FakeReportStream.Empty;
             public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
             public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOp();

--- a/FanaBridge.Tests/FanatecTuningControllerTests.cs
+++ b/FanaBridge.Tests/FanatecTuningControllerTests.cs
@@ -21,40 +21,38 @@ namespace FanaBridge.Tests
             public List<byte[]> SentCol03Reports { get; } = new List<byte[]>();
             public List<byte[]> SentCol01Reports { get; } = new List<byte[]>();
 
-            /// <summary>Queue of reports that ReadCol03 will return.</summary>
+            /// <summary>
+            /// Scripted tuning responses. Each is delivered to the tuning stream
+            /// when a READ request is SENT — mirroring the device answering after
+            /// the request, so the elicit's stale-frame flush (which runs before
+            /// the send) can't clear a pre-scripted reply.
+            /// </summary>
             public Queue<byte[]> ReadQueue { get; } = new Queue<byte[]>();
 
-            /// <summary>
-            /// When true, the first ReadCol03 call returns -1 (simulates
-            /// drain completion), then subsequent calls use the queue.
-            /// </summary>
-            public bool DrainReturnsNegative { get; set; } = true;
+            public FakeReportStream Tuning { get; } = new FakeReportStream();
+            public FakeReportStream Identity { get; } = new FakeReportStream();
+            public FakeReportStream Itm { get; } = new FakeReportStream();
 
-            private bool _drained;
+            public IReportStream IdentityReports => Identity;
+            public IReportStream ItmReports => Itm;
+            public IReportStream SrmReports => FakeReportStream.Empty;
+            public IReportStream TuningReports => Tuning;
 
             public bool SendCol03(byte[] data)
             {
                 var copy = new byte[data.Length];
                 Array.Copy(data, copy, data.Length);
                 SentCol03Reports.Add(copy);
-                return true;
-            }
 
-            public int ReadCol03(byte[] buffer, int timeoutMs)
-            {
-                // Simulate drain phase: first call returns -1 (no data)
-                if (DrainReturnsNegative && !_drained)
+                if (data.Length > 2 &&
+                    data[0] == 0xFF &&
+                    data[1] == FanatecTuningController.CMD_CLASS &&
+                    data[2] == FanatecTuningController.SUBCMD_READ &&
+                    ReadQueue.Count > 0)
                 {
-                    _drained = true;
-                    return -1;
+                    Tuning.Enqueue(ReadQueue.Dequeue());
                 }
-
-                if (ReadQueue.Count == 0)
-                    return -1;
-
-                var report = ReadQueue.Dequeue();
-                Array.Copy(report, buffer, Math.Min(report.Length, buffer.Length));
-                return report.Length;
+                return true;
             }
 
             public bool SendCol01(byte[] data)
@@ -267,6 +265,52 @@ namespace FanaBridge.Tests
             Assert.Equal(FanatecTuningController.COL01_TUNING_ACK, offPacket[4]);
             Assert.Equal(0x00, offPacket[5]);
             Assert.Equal(0x00, offPacket[6]);
+        }
+
+        // ── Family isolation (the old shared-stream steal scenarios) ─────
+
+        [Fact]
+        public void ReadTuningStateRaw_NeverTouchesOtherFamilies()
+        {
+            var transport = new StubTransport();
+            transport.ReadQueue.Enqueue(FakeReadResponse(0x01));
+
+            // Pending pushes on the streams the tuning controller does NOT own.
+            var identityPush = new byte[64];
+            identityPush[0] = 0xFF; identityPush[1] = 0x08;
+            transport.Identity.Enqueue(identityPush);
+            var itmPush = new byte[64];
+            itmPush[0] = 0xFF; itmPush[1] = 0x05;
+            transport.Itm.Enqueue(itmPush);
+
+            var controller = new FanatecTuningController(transport);
+            var raw = controller.ReadTuningStateRaw();
+
+            Assert.NotNull(raw);
+            // The old code's 50 ms pre-drain swallowed ANY pending frame; the
+            // elicit touches only the tuning stream — the pushes survive, unread.
+            Assert.Equal(1, transport.Identity.PendingCount);
+            Assert.Equal(1, transport.Itm.PendingCount);
+            Assert.Equal(0, transport.Identity.ReadCount);
+            Assert.Equal(0, transport.Itm.ReadCount);
+        }
+
+        [Fact]
+        public void ReadTuningStateRaw_FlushesStaleTuningResponse()
+        {
+            var transport = new StubTransport();
+
+            // A stale response sitting in the tuning stream (e.g. from an
+            // earlier aborted read) must not be returned for a new request.
+            transport.Tuning.Enqueue(FakeReadResponse(0x77));
+            transport.ReadQueue.Enqueue(FakeReadResponse(0x01));
+
+            var controller = new FanatecTuningController(transport);
+            var raw = controller.ReadTuningStateRaw();
+
+            Assert.NotNull(raw);
+            Assert.Equal(1, transport.Tuning.FlushCount);
+            Assert.Equal(0x01, raw[FanatecTuningController.READ_ENCODER_MODE_OFFSET]);
         }
 
         // ── Constructor ──────────────────────────────────────────────────

--- a/FanaBridge.Tests/HidReportQueueTests.cs
+++ b/FanaBridge.Tests/HidReportQueueTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using FanaBridge.Transport;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class HidReportQueueTests
+    {
+        private static byte[] Report(params byte[] bytes) => bytes;
+
+        // ── Empty / timeout-0 contract (the per-frame drain path) ─────────
+
+        [Fact]
+        public void TryRead_EmptyWithZeroTimeout_ReturnsMinusOneImmediately()
+        {
+            var queue = new HidReportQueue(16);
+            var dest = new byte[64];
+
+            var sw = Stopwatch.StartNew();
+            int n = queue.TryRead(dest, 0);
+            sw.Stop();
+
+            Assert.Equal(-1, n);
+            // The whole point of the queue: an idle poll must not block (and
+            // must not throw). Generous bound to tolerate CI scheduling.
+            Assert.True(sw.ElapsedMilliseconds < 50,
+                $"idle TryRead took {sw.ElapsedMilliseconds} ms");
+        }
+
+        [Fact]
+        public void TryRead_EmptyWithNegativeTimeout_ReturnsMinusOne()
+        {
+            var queue = new HidReportQueue(16);
+            Assert.Equal(-1, queue.TryRead(new byte[64], -5));
+        }
+
+        // ── Basic dequeue semantics ───────────────────────────────────────
+
+        [Fact]
+        public void EnqueueThenTryRead_ReturnsLengthAndBytes()
+        {
+            var queue = new HidReportQueue(16);
+            queue.Enqueue(Report(0xFF, 0x08, 0x01, 0x02), 4);
+
+            var dest = new byte[64];
+            int n = queue.TryRead(dest, 0);
+
+            Assert.Equal(4, n);
+            Assert.Equal(new byte[] { 0xFF, 0x08, 0x01, 0x02 }, new ArraySegment<byte>(dest, 0, 4));
+        }
+
+        [Fact]
+        public void Enqueue_TakesPrivateCopy()
+        {
+            var queue = new HidReportQueue(16);
+            var source = Report(0xAA, 0xBB);
+            queue.Enqueue(source, 2);
+            source[0] = 0x00; // reader thread reuses its buffer — must not alias
+
+            var dest = new byte[64];
+            queue.TryRead(dest, 0);
+            Assert.Equal(0xAA, dest[0]);
+        }
+
+        [Fact]
+        public void TryRead_PreservesFifoOrder()
+        {
+            var queue = new HidReportQueue(16);
+            queue.Enqueue(Report(1), 1);
+            queue.Enqueue(Report(2), 1);
+            queue.Enqueue(Report(3), 1);
+
+            var dest = new byte[64];
+            queue.TryRead(dest, 0); Assert.Equal(1, dest[0]);
+            queue.TryRead(dest, 0); Assert.Equal(2, dest[0]);
+            queue.TryRead(dest, 0); Assert.Equal(3, dest[0]);
+            Assert.Equal(-1, queue.TryRead(dest, 0));
+        }
+
+        [Fact]
+        public void Enqueue_LengthBeyondReport_ClampsToReportLength()
+        {
+            var queue = new HidReportQueue(16);
+            queue.Enqueue(Report(7, 8), 10);
+
+            var dest = new byte[64];
+            Assert.Equal(2, queue.TryRead(dest, 0));
+        }
+
+        [Fact]
+        public void Enqueue_ZeroLengthOrNull_Ignored()
+        {
+            var queue = new HidReportQueue(16);
+            queue.Enqueue(Report(1, 2, 3), 0);
+            queue.Enqueue(null, 3);
+
+            Assert.Equal(-1, queue.TryRead(new byte[64], 0));
+        }
+
+        [Fact]
+        public void TryRead_SmallDestination_TruncatesToDestination()
+        {
+            var queue = new HidReportQueue(16);
+            queue.Enqueue(Report(1, 2, 3, 4), 4);
+
+            var dest = new byte[2];
+            int n = queue.TryRead(dest, 0);
+
+            Assert.Equal(2, n);
+            Assert.Equal(new byte[] { 1, 2 }, dest);
+        }
+
+        // ── Capacity: drop-oldest ─────────────────────────────────────────
+
+        [Fact]
+        public void Enqueue_BeyondCapacity_DropsOldest()
+        {
+            var queue = new HidReportQueue(2);
+            queue.Enqueue(Report(1), 1);
+            queue.Enqueue(Report(2), 1);
+            queue.Enqueue(Report(3), 1); // evicts report 1
+
+            var dest = new byte[64];
+            queue.TryRead(dest, 0); Assert.Equal(2, dest[0]);
+            queue.TryRead(dest, 0); Assert.Equal(3, dest[0]);
+            Assert.Equal(-1, queue.TryRead(dest, 0));
+        }
+
+        // ── Blocking wait (elicited command→response reads) ───────────────
+
+        [Fact]
+        public async Task TryRead_BlockedReader_WokenByEnqueue()
+        {
+            var queue = new HidReportQueue(16);
+            var dest = new byte[64];
+
+            var reader = Task.Run(() => queue.TryRead(dest, 5000));
+            // Let the reader park in its wait before producing.
+            await Task.Delay(50);
+            queue.Enqueue(Report(0xDD, 1, 2, 3, 4, 5), 6);
+
+            var winner = await Task.WhenAny(reader, Task.Delay(1000));
+            Assert.True(winner == reader, "reader was not woken by Enqueue");
+            Assert.Equal(6, await reader);
+            Assert.Equal(0xDD, dest[0]);
+        }
+
+        [Fact]
+        public void TryRead_EmptyWithShortTimeout_TimesOutWithMinusOne()
+        {
+            var queue = new HidReportQueue(16);
+
+            var sw = Stopwatch.StartNew();
+            int n = queue.TryRead(new byte[64], 50);
+            sw.Stop();
+
+            Assert.Equal(-1, n);
+            Assert.True(sw.ElapsedMilliseconds >= 40,
+                $"timed out after only {sw.ElapsedMilliseconds} ms");
+        }
+
+        // ── Close (Disconnect path) ───────────────────────────────────────
+
+        [Fact]
+        public async Task Close_WakesBlockedReaderWithMinusOne()
+        {
+            var queue = new HidReportQueue(16);
+
+            var reader = Task.Run(() => queue.TryRead(new byte[64], 5000));
+            await Task.Delay(50);
+            queue.Close();
+
+            var winner = await Task.WhenAny(reader, Task.Delay(1000));
+            Assert.True(winner == reader, "reader was not woken by Close");
+            Assert.Equal(-1, await reader);
+        }
+
+        [Fact]
+        public void Close_DropsQueuedReportsAndRefusesNewOnes()
+        {
+            var queue = new HidReportQueue(16);
+            queue.Enqueue(Report(1), 1);
+            queue.Close();
+            queue.Enqueue(Report(2), 1);
+
+            Assert.Equal(-1, queue.TryRead(new byte[64], 0));
+            // A closed queue must not block even with a timeout.
+            Assert.Equal(-1, queue.TryRead(new byte[64], 250));
+        }
+    }
+}

--- a/FanaBridge.Tests/HidReportQueueTests.cs
+++ b/FanaBridge.Tests/HidReportQueueTests.cs
@@ -189,5 +189,76 @@ namespace FanaBridge.Tests
             // A closed queue must not block even with a timeout.
             Assert.Equal(-1, queue.TryRead(new byte[64], 250));
         }
+
+        // ── Flush ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Flush_DropsPendingWithoutClosing()
+        {
+            var queue = new HidReportQueue(16);
+            queue.Enqueue(Report(1), 1);
+            queue.Flush();
+
+            Assert.Equal(-1, queue.TryRead(new byte[64], 0));
+
+            // Still open: new frames flow.
+            queue.Enqueue(Report(2), 1);
+            var dest = new byte[64];
+            Assert.Equal(1, queue.TryRead(dest, 0));
+            Assert.Equal(2, dest[0]);
+        }
+
+        // ── Taps (non-consuming observers) ────────────────────────────────
+
+        [Fact]
+        public void Tap_ObserverGetsCopy_ConsumerStillGetsFrame()
+        {
+            var queue = new HidReportQueue(16);
+            byte[] observed = null;
+            using (queue.Tap(f => observed = f))
+            {
+                queue.Enqueue(Report(0xAB, 0xCD), 2);
+            }
+
+            Assert.NotNull(observed);
+            Assert.Equal(new byte[] { 0xAB, 0xCD }, observed);
+
+            // The tap did NOT consume: the owner still reads the frame.
+            var dest = new byte[64];
+            Assert.Equal(2, queue.TryRead(dest, 0));
+            Assert.Equal(0xAB, dest[0]);
+
+            // The observer's copy is private — mutating it can't corrupt the
+            // frame the consumer received.
+            observed[0] = 0x00;
+            Assert.Equal(0xAB, dest[0]);
+        }
+
+        [Fact]
+        public void Tap_Disposed_StopsObserving()
+        {
+            var queue = new HidReportQueue(16);
+            int seen = 0;
+            var token = queue.Tap(_ => seen++);
+            queue.Enqueue(Report(1), 1);
+            token.Dispose();
+            queue.Enqueue(Report(2), 1);
+
+            Assert.Equal(1, seen);
+        }
+
+        [Fact]
+        public void Tap_ThrowingObserver_DoesNotBreakEnqueue()
+        {
+            var queue = new HidReportQueue(16);
+            using (queue.Tap(_ => throw new InvalidOperationException("observer bug")))
+            {
+                queue.Enqueue(Report(7), 1);
+            }
+
+            var dest = new byte[64];
+            Assert.Equal(1, queue.TryRead(dest, 0));
+            Assert.Equal(7, dest[0]);
+        }
     }
 }

--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -31,7 +31,10 @@ namespace FanaBridge.Tests
             }
 
             public bool SendCol01(byte[] data) => true;
-            public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public IReportStream IdentityReports => FakeReportStream.Empty;
+            public IReportStream ItmReports => FakeReportStream.Empty;
+            public IReportStream SrmReports => FakeReportStream.Empty;
+            public IReportStream TuningReports => FakeReportStream.Empty;
             public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
             public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOp();

--- a/FanaBridge.Tests/ItmEncoderTests.cs
+++ b/FanaBridge.Tests/ItmEncoderTests.cs
@@ -32,7 +32,10 @@ namespace FanaBridge.Tests
             }
 
             public bool SendCol01(byte[] data) => true;
-            public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public IReportStream IdentityReports => FakeReportStream.Empty;
+            public IReportStream ItmReports => FakeReportStream.Empty;
+            public IReportStream SrmReports => FakeReportStream.Empty;
+            public IReportStream TuningReports => FakeReportStream.Empty;
             public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
             public int Col01MaxInputReportLength => 34;
 

--- a/FanaBridge.Tests/LegacyLedEncoderTests.cs
+++ b/FanaBridge.Tests/LegacyLedEncoderTests.cs
@@ -29,7 +29,10 @@ namespace FanaBridge.Tests
                 return true;
             }
 
-            public int ReadCol03(byte[] buffer, int timeoutMs) => -1;
+            public IReportStream IdentityReports => FakeReportStream.Empty;
+            public IReportStream ItmReports => FakeReportStream.Empty;
+            public IReportStream SrmReports => FakeReportStream.Empty;
+            public IReportStream TuningReports => FakeReportStream.Empty;
             public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
             public int Col01MaxInputReportLength => 34;
             public IDisposable BeginBatch() => new NoOpDisposable();

--- a/FanaBridge.Tests/ReportElicitTests.cs
+++ b/FanaBridge.Tests/ReportElicitTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using FanaBridge.Protocol;
+using FanaBridge.Transport;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class ReportElicitTests
+    {
+        // Transport stub whose stream answers scripted responses when a request
+        // is SENT (mirroring a device replying to the request, after the elicit's
+        // stale-flush has already run).
+        private sealed class StubTransport : IDeviceTransport
+        {
+            public bool IsConnected { get; set; } = true;
+            public int Col03MaxInputReportLength => 64;
+            public int Col01MaxInputReportLength => 34;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public bool SendCol01(byte[] data) => true;
+
+            public FakeReportStream Stream { get; } = new FakeReportStream();
+            public IReportStream IdentityReports => FakeReportStream.Empty;
+            public IReportStream ItmReports => FakeReportStream.Empty;
+            public IReportStream SrmReports => FakeReportStream.Empty;
+            public IReportStream TuningReports => Stream;
+
+            public List<byte[]> Sent { get; } = new List<byte[]>();
+            public List<int> SentAtBatchDepth { get; } = new List<int>();
+            public Queue<byte[]> RespondOnSend { get; } = new Queue<byte[]>();
+            public bool FailSends { get; set; }
+
+            private int _batchDepth;
+
+            public bool SendCol03(byte[] data)
+            {
+                if (FailSends) return false;
+                Sent.Add((byte[])data.Clone());
+                SentAtBatchDepth.Add(_batchDepth);
+                while (RespondOnSend.Count > 0)
+                    Stream.Enqueue(RespondOnSend.Dequeue());
+                return true;
+            }
+
+            public IDisposable BeginBatch()
+            {
+                _batchDepth++;
+                return new Scope(this);
+            }
+
+            private sealed class Scope : IDisposable
+            {
+                private StubTransport _t;
+                public Scope(StubTransport t) { _t = t; }
+                public void Dispose() { if (_t != null) { _t._batchDepth--; _t = null; } }
+            }
+        }
+
+        private static byte[] FrameOf(params byte[] head)
+        {
+            var b = new byte[64];
+            Array.Copy(head, b, head.Length);
+            return b;
+        }
+
+        private static readonly Func<byte[], int, bool> MatchMarker7 =
+            (f, n) => n > 0 && f[0] == 7;
+
+        [Fact]
+        public void Elicit_ReturnsMatchedResponse()
+        {
+            var t = new StubTransport();
+            t.RespondOnSend.Enqueue(FrameOf(7, 0xAA));
+
+            var buf = new byte[64];
+            int n = ReportElicit.Elicit(t, t.Stream, new[] { FrameOf(1) }, MatchMarker7, 100, buf);
+
+            Assert.Equal(64, n);
+            Assert.Equal(0xAA, buf[1]);
+            Assert.Single(t.Sent);
+        }
+
+        [Fact]
+        public void Elicit_FlushesStaleFramesBeforeSending()
+        {
+            var t = new StubTransport();
+            t.Stream.Enqueue(FrameOf(7, 0x01)); // stale frame that WOULD match
+            t.RespondOnSend.Enqueue(FrameOf(7, 0x02)); // the real response
+
+            var buf = new byte[64];
+            int n = ReportElicit.Elicit(t, t.Stream, new[] { FrameOf(1) }, MatchMarker7, 100, buf);
+
+            Assert.Equal(1, t.Stream.FlushCount);
+            Assert.Equal(64, n);
+            Assert.Equal(0x02, buf[1]); // got the fresh response, not the stale one
+        }
+
+        [Fact]
+        public void Elicit_SkipsNonMatchingFrames()
+        {
+            var t = new StubTransport();
+            t.RespondOnSend.Enqueue(FrameOf(9)); // wrong frame on our own stream
+            t.RespondOnSend.Enqueue(FrameOf(7)); // the match
+
+            var buf = new byte[64];
+            int n = ReportElicit.Elicit(t, t.Stream, new[] { FrameOf(1) }, MatchMarker7, 100, buf);
+
+            Assert.Equal(64, n);
+            Assert.Equal(7, buf[0]);
+        }
+
+        [Fact]
+        public void Elicit_NoResponse_ReturnsMinusOne()
+        {
+            var t = new StubTransport();
+
+            var buf = new byte[64];
+            int n = ReportElicit.Elicit(t, t.Stream, new[] { FrameOf(1) }, MatchMarker7, 100, buf);
+
+            Assert.Equal(-1, n);
+        }
+
+        [Fact]
+        public void Elicit_SendFailure_ReturnsMinusOne()
+        {
+            var t = new StubTransport { FailSends = true };
+
+            var buf = new byte[64];
+            int n = ReportElicit.Elicit(t, t.Stream, new[] { FrameOf(1) }, MatchMarker7, 100, buf);
+
+            Assert.Equal(-1, n);
+        }
+
+        [Fact]
+        public void Elicit_SendsAllRequestsInOrder_UnderOneBatch()
+        {
+            var t = new StubTransport();
+            t.RespondOnSend.Enqueue(FrameOf(7));
+
+            var buf = new byte[64];
+            ReportElicit.Elicit(t, t.Stream, new[] { FrameOf(1), FrameOf(2) }, MatchMarker7, 100, buf);
+
+            Assert.Equal(2, t.Sent.Count);
+            Assert.Equal(1, t.Sent[0][0]);
+            Assert.Equal(2, t.Sent[1][0]);
+            Assert.All(t.SentAtBatchDepth, depth => Assert.Equal(1, depth));
+        }
+    }
+}

--- a/FanaBridge/Protocol/Col03FrameClassifier.cs
+++ b/FanaBridge/Protocol/Col03FrameClassifier.cs
@@ -1,0 +1,100 @@
+using FanaBridge.Transport;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// The single home for col03 frame-family wire signatures. The transport's
+    /// reader thread routes every inbound frame through <see cref="TryClassify"/>;
+    /// protocol decoders reuse the same predicates so a frame can never be
+    /// classified one way at the pump and another way at the consumer.
+    ///
+    /// All scans tolerate a leading report-id byte and are allocation-free
+    /// (this runs on the reader thread for every inbound report).
+    /// </summary>
+    internal static class Col03FrameClassifier
+    {
+        // The shared scan: an 0xFF-prefixed signature pair at offsets 0..2
+        // (tolerating a leading report-id byte), bounded so the pair and
+        // everything before maxOffset stays inside the frame.
+        private static int FindPair(byte[] buf, int len, byte second, int maxOffset)
+        {
+            for (int i = 0; i <= maxOffset && i + 1 < len; i++)
+                if (buf[i] == 0xFF && buf[i + 1] == second)
+                    return i;
+            return -1;
+        }
+
+        /// <summary>
+        /// Locates the FF 08 system-report signature (offsets 0..2), requiring the
+        /// frame to be long enough to hold the module byte — a shorter FF 08
+        /// fragment is NOT an identity report and must not reach the decoder.
+        /// Returns the signature offset, or -1.
+        /// </summary>
+        public static int FindIdentitySignature(byte[] buf, int len)
+        {
+            int limit = len - (FanatecIdentity.OffModule + 1);
+            if (limit > 2) limit = 2;
+            return limit < 0 ? -1 : FindPair(buf, len, 0x08, limit);
+        }
+
+        /// <summary>
+        /// Locates the FF 03 tuning-response signature (offsets 0..2, same
+        /// report-id tolerance the router applies). Returns the offset, or -1.
+        /// </summary>
+        public static int FindTuningSignature(byte[] buf, int len)
+            => FindPair(buf, len, 0x03, 2);
+
+        /// <summary>
+        /// True for an SRM DE FA <c>0xDD</c> identity reply: 0xDD at offset 0 (raw)
+        /// or 1 (behind a report-id) — NOT deeper, so an FF 08 / FF 05 frame is
+        /// never mistaken for one — with the 6-byte reply payload present.
+        /// </summary>
+        public static bool IsSrm(byte[] buf, int len, out int sig)
+        {
+            for (int i = 0; i <= 1 && i < len; i++)
+                if (buf[i] == 0xDD)
+                {
+                    sig = i;
+                    return len >= i + 6;
+                }
+            sig = -1;
+            return false;
+        }
+
+        /// <summary>
+        /// Locates the FF 05 ITM signature (offsets 0..2, same report-id
+        /// tolerance the router applies). Returns the offset, or -1. Consumers
+        /// needing a specific subcommand check the byte after the pair.
+        /// </summary>
+        public static int FindItmSignature(byte[] buf, int len)
+            => FindPair(buf, len, 0x05, 2);
+
+        /// <summary>True for an FF 05 ITM subscription/page push (offsets 0..2).</summary>
+        public static bool IsItm(byte[] buf, int len)
+            => FindItmSignature(buf, len) >= 0;
+
+        /// <summary>True for an FF 03 tuning response (offsets 0..2).</summary>
+        public static bool IsTuning(byte[] buf, int len)
+            => FindTuningSignature(buf, len) >= 0;
+
+        /// <summary>
+        /// Classifies a frame into its family, or returns false for axis/other
+        /// frames (which are dropped — same fate they had under the old
+        /// signature-skip drains). Precedence mirrors the historical dispatch
+        /// order (Identity → Srm → Itm), so pathological frames like
+        /// <c>FF DD FF 08 …</c> classify the same way they always routed.
+        /// </summary>
+        public static bool TryClassify(byte[] buf, int len, out Col03Family family)
+        {
+            if (buf != null && len > 0)
+            {
+                if (FindIdentitySignature(buf, len) >= 0) { family = Col03Family.Identity; return true; }
+                if (IsSrm(buf, len, out _)) { family = Col03Family.Srm; return true; }
+                if (IsItm(buf, len)) { family = Col03Family.Itm; return true; }
+                if (IsTuning(buf, len)) { family = Col03Family.Tuning; return true; }
+            }
+            family = default;
+            return false;
+        }
+    }
+}

--- a/FanaBridge/Protocol/ConverterCaptureProbe.cs
+++ b/FanaBridge/Protocol/ConverterCaptureProbe.cs
@@ -30,8 +30,8 @@ namespace FanaBridge.Protocol
         private const int PulseWindowMs = 110;      // per-SubId col01 read window (~ native Sleep(100) pulse gap)
         private const int FinalDrainMs = 160;       // trailing drain for anything still streaming
         private const int Col01ReadTimeoutMs = 20;
-        private const int Col03MaxReads = 12;
-        private const int Col03ReadTimeoutMs = 40;
+        private const int Ff08ExtraWaitMs = 200;    // grace after the pulses if the FF 08 tap is still empty
+        private const int DeFaWaitMs = 150;         // per-report-id wait for the 0xDD reply
 
         /// <summary>The captured surfaces. Any field may be null when that surface stayed silent.</summary>
         public sealed class Result
@@ -58,7 +58,14 @@ namespace FanaBridge.Protocol
             var engage = new List<string>();
             var sw = new Stopwatch();
 
-            // Hold the transport for the whole capture so the runtime's frames don't interleave ours.
+            // The FF 08 reply belongs to the identity stream, whose single owner is
+            // the wheelbase's frame drain — so the probe OBSERVES via a tap instead
+            // of consuming. The tap spans the whole run: the reply usually lands
+            // during the col01 pulse phase. The batch protects our WRITE sequence
+            // from interleaving; the runtime's reads are unaffected (lock-free).
+            var ff08 = new FirstFrame(f => Col03FrameClassifier.FindIdentitySignature(f, f.Length) >= 0);
+
+            using (io.IdentityReports.Tap(ff08.Offer))
             using (io.BeginBatch())
             {
                 // col03 FF 08 enable + trigger.
@@ -76,10 +83,51 @@ namespace FanaBridge.Protocol
                 DrainCol01(io, FinalDrainMs, seen, r, sw);
                 r.Engage = "engage[" + string.Join("  ", engage) + "]";
 
-                CaptureFf08(io, r);
+                FinishFf08(ff08, r);
                 CaptureDeFa(io, r);
             }
             return r;
+        }
+
+        // First frame accepted by a predicate, offered from a tap (reader thread)
+        // and awaited by the probe (UI thread). A Monitor latch, not a poll:
+        // Await wakes the moment Offer accepts, keeping the probe's batch-held
+        // wait as short as the device's actual response latency.
+        private sealed class FirstFrame
+        {
+            private readonly object _sync = new object();
+            private readonly Func<byte[], bool> _accept;
+            private byte[] _frame;
+
+            public FirstFrame(Func<byte[], bool> accept) { _accept = accept; }
+
+            public void Offer(byte[] frame)
+            {
+                lock (_sync)
+                {
+                    if (_frame == null && _accept(frame))
+                    {
+                        _frame = frame;
+                        System.Threading.Monitor.PulseAll(_sync);
+                    }
+                }
+            }
+
+            /// <summary>Waits up to <paramref name="windowMs"/> for an accepted frame.</summary>
+            public byte[] Await(int windowMs)
+            {
+                lock (_sync)
+                {
+                    int start = Environment.TickCount;
+                    int remaining = windowMs;
+                    while (_frame == null && remaining > 0)
+                    {
+                        System.Threading.Monitor.Wait(_sync, remaining);
+                        remaining = windowMs - (Environment.TickCount - start);
+                    }
+                    return _frame;
+                }
+            }
         }
 
         private static void Pulse(IDeviceTransport io, byte subId, string label,
@@ -134,60 +182,52 @@ namespace FanaBridge.Protocol
             return string.Format("rim 0x{0:X2} {1}", wire, FanatecIdentity.DecodeCode(wire) ?? "unrecognized");
         }
 
-        // Read col03 for an FF 08 system report (the engage already enabled+triggered it).
-        private static void CaptureFf08(IDeviceTransport io, Result r)
+        // Decode the FF 08 system report the identity tap collected (the engage
+        // enabled+triggered it; the reply lands during the pulse phase). A short
+        // grace wait covers a slow responder.
+        private static void FinishFf08(FirstFrame ff08, Result r)
         {
-            int len = io.Col03MaxInputReportLength;
-            if (len < 64) len = 64;
-            var buf = new byte[len];
+            var frame = ff08.Await(Ff08ExtraWaitMs);
+            if (frame == null) return;
 
-            for (int i = 0; i < Col03MaxReads; i++)
-            {
-                int n = io.ReadCol03(buf, Col03ReadTimeoutMs);
-                if (n <= 0) break;
+            int n = frame.Length;
+            int sig = Col03FrameClassifier.FindIdentitySignature(frame, n);
+            if (sig < 0) return;
 
-                int sig = FindPair(buf, n, 0xFF, 0x08);
-                if (sig < 0 || n < sig + 0x20) continue;
-
-                r.Ff08Raw = Hex(buf, n);
-                byte baseType = buf[sig + 0x02], wire = buf[sig + 0x18], mod = buf[sig + 0x1F];
-                r.Ff08Line = string.Format(
-                    "base [0x02]=0x{0:X2} {1}   rim [0x18]=0x{2:X2} {3}   module [0x1F]=0x{4:X2} {5}",
-                    baseType, FanatecIdentity.DecodeBaseCode(baseType) ?? "unrecognized",
-                    wire, FanatecIdentity.DecodeCode(wire) ?? "unrecognized",
-                    mod, FanatecIdentity.DecodeModule(mod) ?? "none");
-                return;
-            }
+            r.Ff08Raw = Hex(frame, n);
+            byte baseType = frame[sig + 0x02], wire = frame[sig + 0x18], mod = frame[sig + 0x1F];
+            r.Ff08Line = string.Format(
+                "base [0x02]=0x{0:X2} {1}   rim [0x18]=0x{2:X2} {3}   module [0x1F]=0x{4:X2} {5}",
+                baseType, FanatecIdentity.DecodeBaseCode(baseType) ?? "unrecognized",
+                wire, FanatecIdentity.DecodeCode(wire) ?? "unrecognized",
+                mod, FanatecIdentity.DecodeModule(mod) ?? "none");
         }
 
-        // Query the SRM Conversion Kit's DE FA AD -> 0xDD channel on col03. Tries both report-ids
-        // (0xFF and 0x00); a genuine base answers neither. OUT data = 00 DE FA AD;
+        // Query the SRM Conversion Kit's DE FA AD -> 0xDD channel on col03, observing the reply
+        // via an SRM-stream tap (the wheelbase owns that stream — and may legitimately consume
+        // the same reply; the tap sees every frame regardless). Tries both report-ids (0xFF and
+        // 0x00); a genuine base answers neither. OUT data = 00 DE FA AD;
         // IN = DD [kitMaj] [kitMin] [wheelId] [wheelFw] [module].
         private static void CaptureDeFa(IDeviceTransport io, Result r)
         {
             foreach (byte reportId in new byte[] { 0xFF, 0x00 })
             {
-                var outRep = new byte[64];
-                outRep[0] = reportId;                       // report-id
-                outRep[1] = 0x00;                           // data[0] = channel/sub byte
-                outRep[2] = 0xDE; outRep[3] = 0xFA; outRep[4] = 0xAD; // magic + cmd AD (get-wheel)
-                try { if (!io.SendCol03(outRep)) continue; }
-                catch { continue; }
-
-                int len = io.Col03MaxInputReportLength;
-                if (len < 64) len = 64;
-                var buf = new byte[len];
-
-                for (int i = 0; i < Col03MaxReads; i++)
+                var dd = new FirstFrame(f => Col03FrameClassifier.IsSrm(f, f.Length, out _));
+                using (io.SrmReports.Tap(dd.Offer))
                 {
-                    int n = io.ReadCol03(buf, Col03ReadTimeoutMs);
-                    if (n <= 0) break;
+                    var outRep = new byte[64];
+                    outRep[0] = reportId;                       // report-id
+                    outRep[1] = 0x00;                           // data[0] = channel/sub byte
+                    outRep[2] = 0xDE; outRep[3] = 0xFA; outRep[4] = 0xAD; // magic + cmd AD (get-wheel)
+                    try { if (!io.SendCol03(outRep)) continue; }
+                    catch { continue; }
 
-                    int sig = FindByte(buf, n, 0xDD, 3); // scan first 3 bytes for the 0xDD signature
-                    if (sig < 0 || n < sig + 6) continue;
+                    var frame = dd.Await(DeFaWaitMs);
+                    if (frame == null) continue;
+                    if (!Col03FrameClassifier.IsSrm(frame, frame.Length, out int sig)) continue;
 
-                    r.DeFaRaw = Hex(buf, n);
-                    r.DeFaLine = DescribeDeFa(buf, sig, reportId);
+                    r.DeFaRaw = Hex(frame, frame.Length);
+                    r.DeFaLine = DescribeDeFa(frame, sig, reportId);
                     return;
                 }
             }
@@ -217,21 +257,6 @@ namespace FanaBridge.Protocol
             var b = new byte[64];
             b[0] = 0xFF; b[1] = 0x08; b[2] = b2; b[3] = b3;
             return b;
-        }
-
-        // FF 08-style signature scan (tolerates a leading report-id byte).
-        private static int FindPair(byte[] buf, int n, byte a, byte b)
-        {
-            for (int i = 0; i <= 2 && i + 1 < n; i++)
-                if (buf[i] == a && buf[i + 1] == b) return i;
-            return -1;
-        }
-
-        private static int FindByte(byte[] buf, int n, byte val, int within)
-        {
-            for (int i = 0; i < within && i < n; i++)
-                if (buf[i] == val) return i;
-            return -1;
         }
 
         private static string Hex(byte[] buf, int n)

--- a/FanaBridge/Protocol/FanatecTuningController.cs
+++ b/FanaBridge/Protocol/FanatecTuningController.cs
@@ -21,7 +21,10 @@ namespace FanaBridge.Protocol
         internal const byte SUBCMD_READ = 0x02;
         internal const byte DEVICE_ID_BMR = 0x02;
         internal const int READ_TIMEOUT_MS = 1000;
-        internal const int DRAIN_TIMEOUT_MS = 50;
+        // Quiet-window drain before each read: absorbs a LATE response still in
+        // flight from a previous timed-out read, which would otherwise be
+        // matched as the new request's reply (responses carry no correlation id).
+        internal const int STALE_GRACE_MS = 50;
 
         internal const int READ_ENCODER_MODE_OFFSET = 18;
         internal const int WRITE_ENCODER_MODE_OFFSET = 19;
@@ -161,9 +164,11 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
-        /// Reads the current tuning state from the device.
-        /// Sends a READ request on col03 and waits for the matching response.
-        /// Must be called inside a batch.
+        /// Reads the current tuning state from the device: an elicit on the
+        /// tuning response stream (this controller is its single owner, so the
+        /// stale-frame flush can't discard identity/ITM pushes and the response
+        /// can't be consumed by anyone else). Safe inside an outer batch
+        /// (the elicit's own batch is re-entrant).
         /// </summary>
         private byte[] ReadTuningState(byte deviceId)
         {
@@ -180,31 +185,30 @@ namespace FanaBridge.Protocol
                 if (maxInputLen <= 0) maxInputLen = REPORT_LENGTH;
                 var buf = new byte[maxInputLen];
 
-                // Drain any stale input reports (short timeout)
-                while (_transport.ReadCol03(buf, DRAIN_TIMEOUT_MS) >= 0) { }
-
-                // Send the read request on col03
-                _transport.SendCol03(request);
-
-                // Read responses until we get the matching tuning state
-                var deadline = DateTime.UtcNow.AddMilliseconds(READ_TIMEOUT_MS);
-
-                while (DateTime.UtcNow < deadline)
-                {
-                    int bytesRead = _transport.ReadCol03(buf, READ_TIMEOUT_MS);
-                    if (bytesRead >= 3 &&
-                        buf[0] == 0xFF &&
-                        buf[1] == CMD_CLASS &&
-                        buf[2] == deviceId)
+                // Match with the same report-id tolerance the router applies —
+                // a response the router queued must never be unmatchable here.
+                int n = ReportElicit.Elicit(
+                    _transport, _transport.TuningReports,
+                    new[] { request },
+                    (frame, len) =>
                     {
-                        var result = new byte[REPORT_LENGTH];
-                        Array.Copy(buf, result, Math.Min(bytesRead, REPORT_LENGTH));
-                        return result;
-                    }
+                        int s = Col03FrameClassifier.FindTuningSignature(frame, len);
+                        return s >= 0 && len > s + 2 && frame[s + 2] == deviceId;
+                    },
+                    READ_TIMEOUT_MS, buf, STALE_GRACE_MS);
+
+                if (n < 0)
+                {
+                    _logWarn("FanatecTuning: Read — no matching response within timeout");
+                    return null;
                 }
 
-                _logWarn("FanatecTuning: Read — no matching response within timeout");
-                return null;
+                // Normalize to signature-at-offset-0 so payload offsets (e.g. the
+                // encoder-mode byte) are stable regardless of a report-id prefix.
+                int sig = Col03FrameClassifier.FindTuningSignature(buf, n);
+                var result = new byte[REPORT_LENGTH];
+                Array.Copy(buf, sig, result, 0, Math.Min(n - sig, REPORT_LENGTH));
+                return result;
             }
             catch (Exception ex)
             {

--- a/FanaBridge/Protocol/ItmTelemetry.cs
+++ b/FanaBridge/Protocol/ItmTelemetry.cs
@@ -170,15 +170,12 @@ namespace FanaBridge.Protocol
             if (report == null) return result;
             if (len <= 0 || len > report.Length) len = report.Length;
 
-            // Find the FF 05 01 header (tolerate a leading report-ID in the first bytes).
-            int start = -1;
-            for (int i = 0; i <= 2 && i + 3 <= len; i++)
-                if (report[i] == 0xFF && report[i + 1] == 0x05 && report[i + 2] == 0x01)
-                {
-                    start = i + 3;
-                    break;
-                }
-            if (start < 0) return result;
+            // Find the FF 05 header via the shared family scan (same report-id
+            // tolerance the transport router applies), then require the 0x01
+            // subscription subcommand — the family alone also covers pages/acks.
+            int sig = Col03FrameClassifier.FindItmSignature(report, len);
+            if (sig < 0 || sig + 3 > len || report[sig + 2] != 0x01) return result;
+            int start = sig + 3;
 
             // Entries: [deviceId][fwHandle][idLo][idHi][dataType], 5 bytes each. Byte 0 is the
             // display-device id. Each driver targets one display, so skip entries for any other

--- a/FanaBridge/Protocol/ReportElicit.cs
+++ b/FanaBridge/Protocol/ReportElicit.cs
@@ -1,0 +1,72 @@
+using System;
+using FanaBridge.Transport;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>
+    /// The one request→response primitive over a per-family report stream:
+    /// flush stale frames, send the request(s) under a write batch, then await
+    /// the first frame the matcher accepts. Because the caller elicits on the
+    /// stream it OWNS, nothing competes for the response and the flush cannot
+    /// discard another consumer's frames — the failure modes of the old shared
+    /// col03 read loop.
+    /// </summary>
+    internal static class ReportElicit
+    {
+        /// <summary>
+        /// Runs one elicit. Returns the matched frame's length (copied into
+        /// <paramref name="response"/>), or -1 when no accepted frame arrived
+        /// within <paramref name="timeoutMs"/>. Non-matching frames on the same
+        /// stream (e.g. a stale response racing the flush) are skipped.
+        /// </summary>
+        /// <param name="io">Transport, for the sends and the write batch.</param>
+        /// <param name="stream">The caller-owned family stream carrying the response.</param>
+        /// <param name="requests">Frames to send, in order, before awaiting.</param>
+        /// <param name="match">Accepts (frame, length); return true to take the frame.</param>
+        /// <param name="timeoutMs">Overall deadline covering all awaited reads.</param>
+        /// <param name="response">Destination buffer for the matched frame.</param>
+        /// <param name="staleGraceMs">
+        /// When &gt; 0, before sending, keep reading (and discarding) stale frames
+        /// until the stream stays quiet for this long — absorbing a late response
+        /// still in flight from a previous timed-out elicit, which an instant
+        /// flush would miss and which would then be matched as THIS request's
+        /// reply. Use for request/response protocols where replies carry no
+        /// correlation id (tuning); 0 for push streams where a stale frame is
+        /// just old state (identity).
+        /// </param>
+        public static int Elicit(IDeviceTransport io, IReportStream stream, byte[][] requests,
+            Func<byte[], int, bool> match, int timeoutMs, byte[] response, int staleGraceMs = 0)
+        {
+            if (io == null || stream == null || response == null) return -1;
+
+            // The batch spans send→await so another writer can't interleave a
+            // frame between the request and the device's reply (reads themselves
+            // are lock-free; this serializes the WRITE sequence only).
+            using (io.BeginBatch())
+            {
+                if (staleGraceMs > 0)
+                    while (stream.TryRead(response, staleGraceMs) >= 0) { }
+                stream.Flush();
+
+                for (int i = 0; i < requests.Length; i++)
+                    if (!io.SendCol03(requests[i]))
+                        return -1;
+
+                int start = Environment.TickCount;
+                int remaining = timeoutMs;
+                while (remaining > 0)
+                {
+                    int n = stream.TryRead(response, remaining);
+                    if (n <= 0) return -1; // timed out or stream closed
+                    if (match(response, n)) return n;
+
+                    // Wrong frame (stale/other response on our own family) — keep
+                    // waiting out the same deadline. TickCount subtraction is
+                    // wrap-safe.
+                    remaining = timeoutMs - (Environment.TickCount - start);
+                }
+            }
+            return -1;
+        }
+    }
+}

--- a/FanaBridge/Protocol/SrmConverterIdentity.cs
+++ b/FanaBridge/Protocol/SrmConverterIdentity.cs
@@ -26,9 +26,9 @@ namespace FanaBridge.Protocol
         private const int Col03Len = 64;
 
         /// <summary>
-        /// Sends the <c>DE FA AD</c> query on col03 (report-id 0xFF, then 0x00). Send-only: the reply is
-        /// picked up by the shared col03 read dispatch, so it can never consume a genuine FF 08 frame.
-        /// Harmless to a genuine base (which does not answer).
+        /// Sends the <c>DE FA AD</c> query on col03 (report-id 0xFF, then 0x00). Send-only: the reply
+        /// arrives on the transport's SRM stream (<see cref="IDeviceTransport.SrmReports"/>), so it can
+        /// never consume a genuine FF 08 frame. Harmless to a genuine base (which does not answer).
         /// </summary>
         public void SendQuery(IDeviceTransport io)
         {
@@ -44,15 +44,15 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
-        /// Decode a col03 frame if it is a <c>0xDD</c> reply. The signature sits at offset 0 or 1 only,
-        /// so an FF 08 / FF 05 frame can never be mistaken for a converter reply.
+        /// Decode a col03 frame if it is a <c>0xDD</c> reply. The signature rule lives in
+        /// <see cref="Col03FrameClassifier.IsSrm"/> (offset 0 or 1 only, so an FF 08 / FF 05
+        /// frame can never be mistaken for a converter reply).
         /// </summary>
         public static bool TryDecodeFrame(byte[] buf, int n, out Result result)
         {
             result = default;
             if (buf == null) return false;
-            int sig = FindByte(buf, n, 0xDD, 2);
-            if (sig < 0 || n < sig + 6) return false;
+            if (!Col03FrameClassifier.IsSrm(buf, n, out int sig)) return false;
             result = Decode(buf, sig, n);
             return true;
         }
@@ -84,12 +84,5 @@ namespace FanaBridge.Protocol
             => wheelId == 0x00 ? null
              : wheelId == 0x17 ? "CSLESWWRC"
              : FanatecIdentity.DecodeCode(wheelId);
-
-        private static int FindByte(byte[] buf, int n, byte val, int within)
-        {
-            for (int i = 0; i < within && i < n; i++)
-                if (buf[i] == val) return i;
-            return -1;
-        }
     }
 }

--- a/FanaBridge/Protocol/SystemReportReader.cs
+++ b/FanaBridge/Protocol/SystemReportReader.cs
@@ -4,15 +4,16 @@ using FanaBridge.Transport;
 namespace FanaBridge.Protocol
 {
     /// <summary>
-    /// Reads the col03 <c>FF 08</c> system report — the wire-level side of identity.
-    /// Owns the enable/trigger byte patterns, the report offsets, and the signature
-    /// scan, leaving <see cref="FanatecWheelbase"/> to own identity STATE.
+    /// The col03 <c>FF 08</c> system-report codec — the wire-level side of identity.
+    /// Owns the enable/trigger byte patterns and the report decode, leaving
+    /// <see cref="FanatecWheelbase"/> to own identity STATE. Frame routing lives
+    /// in <see cref="Col03FrameClassifier"/>: the transport's reader thread feeds
+    /// <see cref="IDeviceTransport.IdentityReports"/> with FF 08 frames only, so
+    /// the helpers here just drain/elicit that one stream.
     ///
     /// After a single <see cref="Enable"/> the base PUSHES this report on every
     /// attachment change and is otherwise silent, so steady-state reads are a
     /// non-blocking drain — no triggering.
-    ///
-    /// TODO: migrate to a general purpose Col03 input pump that consistently dispatches by signature
     /// </summary>
     internal sealed class SystemReportReader
     {
@@ -32,8 +33,11 @@ namespace FanaBridge.Protocol
         }
 
         private const int ReportLength = 64;
-        private const int InitialReadTimeoutMs = 60;
-        private const int InitialMaxReadAttempts = 8; // axis reports interleave; skip past them
+        // Matches the old worst-case connect window (8 attempts × 60 ms while
+        // interleaved frames kept arriving). The identity stream is classifier-
+        // filtered, so one deadline covers it — and the elicit returns the
+        // moment the reply lands, so a fast base still connects in ~one read.
+        private const int InitialReadTimeoutMs = 480;
         private const int DrainTimeoutMs = 0;         // non-blocking
         private const int DrainMaxReports = 16;       // bound per drain
 
@@ -51,97 +55,43 @@ namespace FanaBridge.Protocol
         /// </summary>
         public bool ReadInitial(IDeviceTransport io, out Reading reading)
         {
-            reading = default;
-
-            // Hold the transport for the enable→trigger→read sequence so an
-            // interleaved LED write can't land between trigger and read.
-            using (io.BeginBatch())
-            {
-                io.SendCol03(BuildEnable());
-                io.SendCol03(BuildTrigger());
-
-                byte[] buf = Buffer(io);
-                for (int attempt = 0; attempt < InitialMaxReadAttempts; attempt++)
-                {
-                    int n = io.ReadCol03(buf, InitialReadTimeoutMs);
-                    if (n <= 0) break;
-
-                    int sig = FindSignature(buf, n);
-                    if (sig < 0) continue; // axis/other report — read again
-
-                    reading = Decode(buf, sig, n);
-                    return true;
-                }
-            }
-            return false;
+            Reading decoded = default;
+            byte[] buf = Buffer(io);
+            int n = ReportElicit.Elicit(
+                io, io.IdentityReports,
+                new[] { BuildEnable(), BuildTrigger() },
+                (frame, len) => TryDecode(frame, len, out decoded),
+                InitialReadTimeoutMs, buf);
+            reading = decoded;
+            return n > 0;
         }
 
         /// <summary>
-        /// Non-blocking drain of pushed col03 reports, dispatched by signature: FF 08 -> onReading,
-        /// SRM <c>0xDD</c> -> onSrmReport, FF 05 ITM -> onItmReport (each as a private copy). One read
-        /// loop routes all three, so nothing is stolen. Returns the number of FF 08 readings delivered.
+        /// Non-blocking drain of pushed FF 08 system reports; each decoded reading
+        /// goes to <paramref name="onReading"/>. Lock-free: the identity stream has
+        /// this reader as its single owner. Returns the number of readings delivered.
         /// </summary>
-        public int DrainPushes(IDeviceTransport io, Action<Reading> onReading,
-            Action<byte[]> onItmReport = null, Action<byte[]> onSrmReport = null)
+        public int DrainIdentity(IDeviceTransport io, Action<Reading> onReading)
         {
             int count = 0;
-            using (io.BeginBatch())
+            var stream = io.IdentityReports;
+            byte[] buf = Buffer(io);
+            for (int i = 0; i < DrainMaxReports; i++)
             {
-                byte[] buf = Buffer(io);
-                for (int i = 0; i < DrainMaxReports; i++)
+                int n = stream.TryRead(buf, DrainTimeoutMs);
+                if (n <= 0) break;
+
+                if (TryDecode(buf, n, out var reading))
                 {
-                    int n = io.ReadCol03(buf, DrainTimeoutMs);
-                    if (n <= 0) break;
-
-                    int sig = FindSignature(buf, n);
-                    if (sig >= 0)
-                    {
-                        onReading(Decode(buf, sig, n));
-                        count++;
-                        continue;
-                    }
-
-                    if (onSrmReport != null && IsSrmReport(buf, n))
-                    {
-                        var copy = new byte[n];
-                        Array.Copy(buf, copy, n);
-                        onSrmReport(copy);
-                        continue;
-                    }
-
-                    if (onItmReport != null && IsItmReport(buf, n))
-                    {
-                        var copy = new byte[n];
-                        Array.Copy(buf, copy, n);
-                        onItmReport(copy);
-                    }
+                    onReading(reading);
+                    count++;
                 }
             }
             return count;
         }
 
-        // True if the report carries the col03 ITM signature (FF 05), tolerating a
-        // leading report-ID byte. The firmware pushes these on ITM page changes.
-        private static bool IsItmReport(byte[] buf, int len)
-        {
-            for (int i = 0; i <= 2 && i + 1 < len; i++)
-                if (buf[i] == 0xFF && buf[i + 1] == 0x05)
-                    return true;
-            return false;
-        }
-
-        // True if the report is an SRM DE FA 0xDD identity reply: 0xDD at offset 0 (raw) or 1 (behind
-        // a report-id) — NOT deeper, so an FF 08 / FF 05 frame is never mistaken for one.
-        private static bool IsSrmReport(byte[] buf, int len)
-        {
-            for (int i = 0; i <= 1 && i < len; i++)
-                if (buf[i] == 0xDD)
-                    return len >= i + 6;
-            return false;
-        }
-
         /// <summary>
-        /// Times a few empty (idle) drains to confirm <c>ReadCol03(buf, 0)</c> is
+        /// Times a few empty (idle) drains to confirm an identity-stream poll is
         /// non-blocking — the per-frame drain depends on it; a blocking read would
         /// stall the frame thread. Returns the slowest sample in milliseconds.
         /// Call once after the initial read (when the input is quiet).
@@ -150,19 +100,33 @@ namespace FanaBridge.Protocol
         {
             double worst = 0;
             var sw = new System.Diagnostics.Stopwatch();
-            using (io.BeginBatch())
+            var stream = io.IdentityReports;
+            byte[] buf = Buffer(io);
+            for (int i = 0; i < samples; i++)
             {
-                byte[] buf = Buffer(io);
-                for (int i = 0; i < samples; i++)
-                {
-                    sw.Restart();
-                    io.ReadCol03(buf, DrainTimeoutMs); // expected empty → must return immediately
-                    sw.Stop();
-                    double ms = sw.Elapsed.TotalMilliseconds;
-                    if (ms > worst) worst = ms;
-                }
+                sw.Restart();
+                stream.TryRead(buf, DrainTimeoutMs); // expected empty → must return immediately
+                sw.Stop();
+                double ms = sw.Elapsed.TotalMilliseconds;
+                if (ms > worst) worst = ms;
             }
             return worst;
+        }
+
+        /// <summary>
+        /// Decodes a frame as an FF 08 system report (signature scan + length
+        /// check via <see cref="Col03FrameClassifier"/>). False for anything else.
+        /// </summary>
+        public static bool TryDecode(byte[] buf, int len, out Reading reading)
+        {
+            int sig = Col03FrameClassifier.FindIdentitySignature(buf, len);
+            if (sig < 0)
+            {
+                reading = default;
+                return false;
+            }
+            reading = Decode(buf, sig, len);
+            return true;
         }
 
         // Reusable read buffer, sized to the col03 input report length. Safe to
@@ -191,17 +155,6 @@ namespace FanaBridge.Protocol
                 ModRaw   = buf[sig + FanatecIdentity.OffModule],
                 Raw      = raw,
             };
-        }
-
-        // Locate the "FF 08" signature; tolerates a leading report-ID byte by
-        // scanning the first few positions.
-        private static int FindSignature(byte[] buf, int len)
-        {
-            int limit = len - (FanatecIdentity.OffModule + 1);
-            for (int i = 0; i <= limit && i <= 2; i++)
-                if (buf[i] == 0xFF && buf[i + 1] == 0x08)
-                    return i;
-            return -1;
         }
 
         private static byte[] BuildEnable()

--- a/FanaBridge/Protocol/SystemReportReader.cs
+++ b/FanaBridge/Protocol/SystemReportReader.cs
@@ -91,29 +91,6 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
-        /// Times a few empty (idle) drains to confirm an identity-stream poll is
-        /// non-blocking — the per-frame drain depends on it; a blocking read would
-        /// stall the frame thread. Returns the slowest sample in milliseconds.
-        /// Call once after the initial read (when the input is quiet).
-        /// </summary>
-        public double ProbeDrainLatencyMs(IDeviceTransport io, int samples)
-        {
-            double worst = 0;
-            var sw = new System.Diagnostics.Stopwatch();
-            var stream = io.IdentityReports;
-            byte[] buf = Buffer(io);
-            for (int i = 0; i < samples; i++)
-            {
-                sw.Restart();
-                stream.TryRead(buf, DrainTimeoutMs); // expected empty → must return immediately
-                sw.Stop();
-                double ms = sw.Elapsed.TotalMilliseconds;
-                if (ms > worst) worst = ms;
-            }
-            return worst;
-        }
-
-        /// <summary>
         /// Decodes a frame as an FF 08 system report (signature scan + length
         /// check via <see cref="Col03FrameClassifier"/>). False for anything else.
         /// </summary>

--- a/FanaBridge/Transport/Col03Family.cs
+++ b/FanaBridge/Transport/Col03Family.cs
@@ -1,0 +1,22 @@
+namespace FanaBridge.Transport
+{
+    /// <summary>
+    /// The frame families multiplexed on the col03 input endpoint, as routed by
+    /// the transport's reader thread (see <c>Col03FrameClassifier</c>). Each
+    /// family backs one <see cref="IReportStream"/> with a single owning consumer.
+    /// </summary>
+    internal enum Col03Family
+    {
+        /// <summary>FF 08 system report — base/rim/module identity pushes.</summary>
+        Identity,
+
+        /// <summary>FF 05 — ITM subscription/page pushes.</summary>
+        Itm,
+
+        /// <summary>0xDD — SRM Conversion Kit DE FA identity replies.</summary>
+        Srm,
+
+        /// <summary>FF 03 — tuning read/write responses.</summary>
+        Tuning,
+    }
+}

--- a/FanaBridge/Transport/Col03QueueSet.cs
+++ b/FanaBridge/Transport/Col03QueueSet.cs
@@ -1,0 +1,56 @@
+using FanaBridge.Protocol;
+
+namespace FanaBridge.Transport
+{
+    /// <summary>
+    /// The per-family input queues behind one col03 connection. The transport's
+    /// reader thread calls <see cref="Route"/> for every inbound frame; frames
+    /// that classify to no family (axis/noise) are dropped, exactly as the old
+    /// signature-skip drains dropped them. One instance per connection session.
+    /// </summary>
+    internal sealed class Col03QueueSet
+    {
+        // Capacities are drop-oldest bounds for the window when nothing drains
+        // (e.g. the plugin manager restarting between games while the hardware
+        // core stays up). Identity/Srm push rarely (attachment changes, one-shot
+        // replies); Tuning is strictly elicited; Itm can burst on page flips and
+        // must out-size the wheelbase's 32-report hand-off buffer.
+        private const int IdentityCapacity = 16;
+        private const int ItmCapacity = 64;
+        private const int SrmCapacity = 16;
+        private const int TuningCapacity = 8;
+
+        private readonly HidReportQueue _identity = new HidReportQueue(IdentityCapacity);
+        private readonly HidReportQueue _itm = new HidReportQueue(ItmCapacity);
+        private readonly HidReportQueue _srm = new HidReportQueue(SrmCapacity);
+        private readonly HidReportQueue _tuning = new HidReportQueue(TuningCapacity);
+
+        public HidReportQueue Get(Col03Family family)
+        {
+            switch (family)
+            {
+                case Col03Family.Identity: return _identity;
+                case Col03Family.Itm: return _itm;
+                case Col03Family.Srm: return _srm;
+                case Col03Family.Tuning: return _tuning;
+                default: throw new System.ArgumentOutOfRangeException(nameof(family));
+            }
+        }
+
+        /// <summary>Classifies and enqueues one inbound frame (reader thread).</summary>
+        public void Route(byte[] buf, int length)
+        {
+            if (Col03FrameClassifier.TryClassify(buf, length, out var family))
+                Get(family).Enqueue(buf, length);
+        }
+
+        /// <summary>Closes every family queue (wakes blocked readers with -1).</summary>
+        public void Close()
+        {
+            _identity.Close();
+            _itm.Close();
+            _srm.Close();
+            _tuning.Close();
+        }
+    }
+}

--- a/FanaBridge/Transport/ConnectionMonitor.cs
+++ b/FanaBridge/Transport/ConnectionMonitor.cs
@@ -21,6 +21,9 @@ namespace FanaBridge.Transport
         private int _frameCounter;
         private int _reconnectCooldown;
 
+        // Set by ForceReconnect (any thread), consumed by Update (frame thread).
+        private volatile bool _forceReconnectPending;
+
         // ── Heartbeat intervals (in frames) ────────────────────────────
         private const int HID_BUS_CHECK_INTERVAL = 120;
         private const int STREAM_CHECK_INTERVAL = 60;
@@ -88,6 +91,22 @@ namespace FanaBridge.Transport
         public bool Update()
         {
             _frameCounter++;
+
+            // Apply a pending ForceReconnect HERE, on the frame thread, so all
+            // connect/adopt/identity I/O stays single-threaded — running it on
+            // the requester's (UI) thread would race this method's own identity
+            // drain on the same buffers and streams.
+            if (_forceReconnectPending)
+            {
+                _forceReconnectPending = false;
+                if (_connected)
+                {
+                    _wheelbase.Disconnect();
+                    _connected = false;
+                    Disconnected?.Invoke();
+                }
+                _reconnectCooldown = 0;
+            }
 
             if (!_connected)
             {
@@ -161,30 +180,15 @@ namespace FanaBridge.Transport
         }
 
         /// <summary>
-        /// Forces a disconnect and immediate reconnect attempt.
+        /// Requests a disconnect + immediate reconnect. Safe from any thread
+        /// (e.g. the settings UI): the actual work runs on the next frame's
+        /// <see cref="Update"/>, keeping all device I/O on the frame thread.
+        /// Connected/Disconnected fire from Update as the reconnect proceeds.
         /// </summary>
         public void ForceReconnect()
         {
             _logInfo("FanaBridge: ForceReconnect requested");
-
-            if (_connected)
-            {
-                _wheelbase.Disconnect();
-                _connected = false;
-            }
-
-            _reconnectCooldown = 0;
-            _connected = _tryConnect();
-
-            if (_connected)
-            {
-                LastDisconnectReason = null;
-                Connected?.Invoke();
-            }
-            else
-            {
-                Disconnected?.Invoke();
-            }
+            _forceReconnectPending = true;
         }
     }
 }

--- a/FanaBridge/Transport/FanatecTransport.cs
+++ b/FanaBridge/Transport/FanatecTransport.cs
@@ -28,6 +28,27 @@ namespace FanaBridge.Transport
         private HidDevice _displayDevice;   // col01: 8-byte display/config
         private HidStream _displayStream;
 
+        // ── col03 input path ───────────────────────────────────────────────
+        // A dedicated thread parks in a blocking HID read and feeds this queue;
+        // ReadCol03 serves consumers from the queue without touching the HID
+        // handle. Polling the handle directly with a 0 ms timeout (the per-frame
+        // drain) made HidSharp throw a caught TimeoutException every frame, and
+        // SimHub's first-chance handler logs each throw as a full ERROR stack
+        // trace — a debug log grew ~8 MB/minute while everything worked.
+        private HidReportQueue _col03Queue;
+        private Thread _col03Reader;
+
+        // Effectively "wait for data": int.MaxValue ms (~24 days) avoids the
+        // (uint)-1 / Timeout.Infinite ambiguity inside HidSharp's overlapped
+        // wait. A blocked read is woken by Disconnect() disposing the stream
+        // (HidSharp signals its close event → ObjectDisposedException).
+        private const int COL03_READER_TIMEOUT_MS = int.MaxValue;
+
+        // Reports to retain when nothing drains (e.g. while the plugin manager
+        // restarts on game change and the hardware core idles). Oldest dropped
+        // first — a late consumer wants the freshest device state.
+        private const int COL03_QUEUE_CAPACITY = 256;
+
         // Windows API fallback for col01 writes
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool WriteFile(
@@ -230,6 +251,7 @@ namespace FanaBridge.Transport
 
                 _connectedProductId = productId;
                 LastConnectStatus = TransportConnectStatus.Connected;
+                StartCol03Reader();
                 SimHub.Logging.Current.Info("FanatecTransport: Connected to " + ProductName);
                 return true;
             }
@@ -343,29 +365,63 @@ namespace FanaBridge.Transport
 
         int IDeviceTransport.ReadCol03(byte[] buffer, int timeoutMs)
         {
-            lock (_writeLock)
-            {
-                // Capture under the lock: Disconnect() nulls/disposes the stream
-                // under the same lock, so a non-null local here stays valid for
-                // the duration of the read.
-                var stream = _ledStream;
-                if (stream == null) return -1;
+            // Served from the reader-thread queue, never from the HID handle —
+            // an idle timeout-0 poll is a lock-check, not a thrown-and-caught
+            // HidSharp TimeoutException. Callers keep the same contract:
+            // report length, or -1 when nothing arrived within the timeout.
+            // No _writeLock: elicit→response sequences already serialize via
+            // BeginBatch, and the queue is thread-safe on its own.
+            var queue = _col03Queue;
+            if (queue == null) return -1;
+            return queue.TryRead(buffer, timeoutMs);
+        }
 
-                int saved = stream.ReadTimeout;
+        // ── col03 reader thread ────────────────────────────────────────────
+
+        private void StartCol03Reader()
+        {
+            _col03Queue = new HidReportQueue(COL03_QUEUE_CAPACITY);
+
+            var stream = _ledStream;
+            var queue = _col03Queue;
+            int bufLen = ((IDeviceTransport)this).Col03MaxInputReportLength;
+
+            _col03Reader = new Thread(() => Col03ReadLoop(stream, queue, bufLen))
+            {
+                IsBackground = true,
+                Name = "FanaBridge col03 reader",
+            };
+            _col03Reader.Start();
+        }
+
+        private static void Col03ReadLoop(HidStream stream, HidReportQueue queue, int bufLen)
+        {
+            var buf = new byte[bufLen];
+            try { stream.ReadTimeout = COL03_READER_TIMEOUT_MS; } catch { }
+
+            while (true)
+            {
+                int n;
                 try
                 {
-                    stream.ReadTimeout = timeoutMs;
-                    return stream.Read(buffer, 0, buffer.Length);
+                    n = stream.Read(buf, 0, buf.Length);
+                }
+                catch (TimeoutException)
+                {
+                    continue; // ~24 days idle; just park again
                 }
                 catch
                 {
-                    return -1;
+                    // Stream closed (Disconnect) or device gone. Exit quietly:
+                    // ConnectionMonitor owns detection and reconnect, and a
+                    // reconnect starts a fresh reader on the new stream.
+                    break;
                 }
-                finally
-                {
-                    try { stream.ReadTimeout = saved; } catch { }
-                }
+
+                if (n > 0) queue.Enqueue(buf, n);
             }
+
+            queue.Close();
         }
 
         int IDeviceTransport.Col03MaxInputReportLength
@@ -451,19 +507,32 @@ namespace FanaBridge.Transport
 
         /// <summary>
         /// Closes all HID handles. Holds the write lock so teardown can't race
-        /// an in-flight send/read (which capture their stream under the same
-        /// lock), avoiding use-after-dispose on the HID streams.
+        /// an in-flight send (which captures its stream under the same lock).
+        /// The col03 reader thread reads outside the lock by design: disposing
+        /// the stream is HidSharp's sanctioned way to abort its blocked read
+        /// (the close event wakes it with ObjectDisposedException).
         /// </summary>
         public void Disconnect()
         {
             lock (_writeLock)
             {
+                // Wake any consumer blocked in an elicited ReadCol03 first,
+                // then dispose the stream to wake the reader thread itself.
+                try { _col03Queue?.Close(); } catch { }
+
                 try { _displayStream?.Close(); } catch { }
                 try { _displayStream?.Dispose(); } catch { }
                 try { _ledStream?.Close(); } catch { }
                 try { _ledStream?.Dispose(); } catch { }
                 try { _displayHandle?.Close(); } catch { }
                 try { _displayHandle?.Dispose(); } catch { }
+
+                // Reader never takes _writeLock, so joining here can't deadlock.
+                // Bounded wait: it's a background thread, a stuck join must not
+                // hang teardown.
+                try { _col03Reader?.Join(1000); } catch { }
+                _col03Reader = null;
+                _col03Queue = null;
 
                 _displayStream = null;
                 _ledStream = null;

--- a/FanaBridge/Transport/FanatecTransport.cs
+++ b/FanaBridge/Transport/FanatecTransport.cs
@@ -29,25 +29,55 @@ namespace FanaBridge.Transport
         private HidStream _displayStream;
 
         // ── col03 input path ───────────────────────────────────────────────
-        // A dedicated thread parks in a blocking HID read and feeds this queue;
-        // ReadCol03 serves consumers from the queue without touching the HID
-        // handle. Polling the handle directly with a 0 ms timeout (the per-frame
-        // drain) made HidSharp throw a caught TimeoutException every frame, and
-        // SimHub's first-chance handler logs each throw as a full ERROR stack
-        // trace — a debug log grew ~8 MB/minute while everything worked.
-        private HidReportQueue _col03Queue;
+        // A dedicated thread parks in a blocking HID read and routes every frame
+        // by wire signature into per-family queues (identity / ITM / SRM /
+        // tuning); consumers read their own family stream and never touch the
+        // HID handle. Polling the handle directly with a 0 ms timeout (the old
+        // per-frame drain) made HidSharp throw a caught TimeoutException every
+        // frame, and SimHub's first-chance handler logs each throw as a full
+        // ERROR stack trace — a debug log grew ~8 MB/minute while everything
+        // worked.
+        // volatile: published by Connect and read lock-free by FamilyStream
+        // consumers on other threads (release/acquire on the reference).
+        private volatile Col03QueueSet _col03Queues;   // one per connection session
         private Thread _col03Reader;
+
+        // Set by Disconnect BEFORE disposing the stream so the reader thread can
+        // tell intentional teardown from a device failure; reset by the next
+        // StartCol03Reader.
+        private volatile bool _col03Stopping;
+
+        // Set when the reader thread gives up after persistent read errors while
+        // the device still looks present. IsConnected reports false so the
+        // ConnectionMonitor tears down and reconnects (fresh stream + reader) —
+        // without this, input would be dead while writes still succeed.
+        private volatile bool _col03ReaderFaulted;
+
+        // A transient read error (USB suspend blip, driver hiccup) must not kill
+        // the input path — retry a few times before declaring the reader dead.
+        private const int COL03_READ_RETRY_MAX = 5;
+        private const int COL03_READ_RETRY_DELAY_MS = 50;
+
+        // Stable facades over the current session's queues, so consumers can
+        // cache IReportStream references across reconnects.
+        private readonly FamilyStream _identityReports;
+        private readonly FamilyStream _itmReports;
+        private readonly FamilyStream _srmReports;
+        private readonly FamilyStream _tuningReports;
+
+        public FanatecTransport()
+        {
+            _identityReports = new FamilyStream(this, Col03Family.Identity);
+            _itmReports = new FamilyStream(this, Col03Family.Itm);
+            _srmReports = new FamilyStream(this, Col03Family.Srm);
+            _tuningReports = new FamilyStream(this, Col03Family.Tuning);
+        }
 
         // Effectively "wait for data": int.MaxValue ms (~24 days) avoids the
         // (uint)-1 / Timeout.Infinite ambiguity inside HidSharp's overlapped
         // wait. A blocked read is woken by Disconnect() disposing the stream
         // (HidSharp signals its close event → ObjectDisposedException).
         private const int COL03_READER_TIMEOUT_MS = int.MaxValue;
-
-        // Reports to retain when nothing drains (e.g. while the plugin manager
-        // restarts on game change and the hardware core idles). Oldest dropped
-        // first — a late consumer wants the freshest device state.
-        private const int COL03_QUEUE_CAPACITY = 256;
 
         // Windows API fallback for col01 writes
         [DllImport("kernel32.dll", SetLastError = true)]
@@ -100,14 +130,19 @@ namespace FanaBridge.Transport
             UnexpectedError,
         }
 
-        /// <summary>True if the HID streams appear to be open.</summary>
+        /// <summary>
+        /// True if the HID streams appear to be open AND the col03 reader thread
+        /// is alive. A faulted reader means input is dead even though writes
+        /// still work — reporting false here is what makes the ConnectionMonitor
+        /// reconnect out of that state.
+        /// </summary>
         public bool IsConnected
         {
             get
             {
                 try
                 {
-                    return _ledStream != null && _ledStream.CanWrite;
+                    return _ledStream != null && _ledStream.CanWrite && !_col03ReaderFaulted;
                 }
                 catch
                 {
@@ -363,30 +398,62 @@ namespace FanaBridge.Transport
             }
         }
 
-        int IDeviceTransport.ReadCol03(byte[] buffer, int timeoutMs)
+        IReportStream IDeviceTransport.IdentityReports => _identityReports;
+        IReportStream IDeviceTransport.ItmReports => _itmReports;
+        IReportStream IDeviceTransport.SrmReports => _srmReports;
+        IReportStream IDeviceTransport.TuningReports => _tuningReports;
+
+        // Stable per-family facade: delegates to the current session's queue,
+        // or behaves as an empty closed stream while disconnected. Reads are
+        // lock-free — single ownership per family is the concurrency model
+        // (see IDeviceTransport docs).
+        private sealed class FamilyStream : IReportStream
         {
-            // Served from the reader-thread queue, never from the HID handle —
-            // an idle timeout-0 poll is a lock-check, not a thrown-and-caught
-            // HidSharp TimeoutException. Callers keep the same contract:
-            // report length, or -1 when nothing arrived within the timeout.
-            // No _writeLock: elicit→response sequences already serialize via
-            // BeginBatch, and the queue is thread-safe on its own.
-            var queue = _col03Queue;
-            if (queue == null) return -1;
-            return queue.TryRead(buffer, timeoutMs);
+            private readonly FanatecTransport _owner;
+            private readonly Col03Family _family;
+
+            public FamilyStream(FanatecTransport owner, Col03Family family)
+            {
+                _owner = owner;
+                _family = family;
+            }
+
+            public int TryRead(byte[] destination, int timeoutMs)
+            {
+                var queues = _owner._col03Queues;
+                return queues == null ? -1 : queues.Get(_family).TryRead(destination, timeoutMs);
+            }
+
+            public void Flush()
+            {
+                _owner._col03Queues?.Get(_family).Flush();
+            }
+
+            public IDisposable Tap(Action<byte[]> observer)
+            {
+                var queues = _owner._col03Queues;
+                return queues == null ? (IDisposable)new NoopToken() : queues.Get(_family).Tap(observer);
+            }
+
+            private sealed class NoopToken : IDisposable
+            {
+                public void Dispose() { }
+            }
         }
 
         // ── col03 reader thread ────────────────────────────────────────────
 
         private void StartCol03Reader()
         {
-            _col03Queue = new HidReportQueue(COL03_QUEUE_CAPACITY);
+            _col03Stopping = false;
+            _col03ReaderFaulted = false;
+            _col03Queues = new Col03QueueSet();
 
             var stream = _ledStream;
-            var queue = _col03Queue;
+            var queues = _col03Queues;
             int bufLen = ((IDeviceTransport)this).Col03MaxInputReportLength;
 
-            _col03Reader = new Thread(() => Col03ReadLoop(stream, queue, bufLen))
+            _col03Reader = new Thread(() => Col03ReadLoop(stream, queues, bufLen))
             {
                 IsBackground = true,
                 Name = "FanaBridge col03 reader",
@@ -394,34 +461,57 @@ namespace FanaBridge.Transport
             _col03Reader.Start();
         }
 
-        private static void Col03ReadLoop(HidStream stream, HidReportQueue queue, int bufLen)
+        private void Col03ReadLoop(HidStream stream, Col03QueueSet queues, int bufLen)
         {
             var buf = new byte[bufLen];
             try { stream.ReadTimeout = COL03_READER_TIMEOUT_MS; } catch { }
 
+            int consecutiveErrors = 0;
             while (true)
             {
                 int n;
                 try
                 {
                     n = stream.Read(buf, 0, buf.Length);
+                    consecutiveErrors = 0;
                 }
                 catch (TimeoutException)
                 {
                     continue; // ~24 days idle; just park again
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Stream closed (Disconnect) or device gone. Exit quietly:
-                    // ConnectionMonitor owns detection and reconnect, and a
-                    // reconnect starts a fresh reader on the new stream.
+                    // Intentional teardown: Disconnect sets the flag before
+                    // disposing the stream (the dispose is what wakes us).
+                    if (_col03Stopping) break;
+
+                    // Transient read error with the device possibly still fine —
+                    // retry before giving up, so one hiccup can't kill input for
+                    // the whole session (the old per-call read self-healed).
+                    if (++consecutiveErrors < COL03_READ_RETRY_MAX)
+                    {
+                        Thread.Sleep(COL03_READ_RETRY_DELAY_MS);
+                        continue;
+                    }
+
+                    // Persistent failure. Mark the transport faulted so the
+                    // ConnectionMonitor reconnects — but only if this thread is
+                    // still the CURRENT session's reader (a stale thread from a
+                    // torn-down session must not poison the new one).
+                    if (ReferenceEquals(_col03Queues, queues))
+                    {
+                        _col03ReaderFaulted = true;
+                        SimHub.Logging.Current.Warn(
+                            "FanatecTransport: col03 reader stopped after repeated read errors ("
+                            + ex.GetType().Name + ": " + ex.Message + ") — flagging for reconnect");
+                    }
                     break;
                 }
 
-                if (n > 0) queue.Enqueue(buf, n);
+                if (n > 0) queues.Route(buf, n);
             }
 
-            queue.Close();
+            queues.Close();
         }
 
         int IDeviceTransport.Col03MaxInputReportLength
@@ -446,8 +536,10 @@ namespace FanaBridge.Transport
         {
             lock (_writeLock)
             {
-                // Capture under the lock, mirroring ReadCol03: Disconnect() nulls/disposes
-                // the stream under the same lock, so a non-null local stays valid here.
+                // col01 keeps the direct locked read (diagnostics-only today; a
+                // pump would consume the gamepad axis stream for nothing).
+                // Capture under the lock: Disconnect() nulls/disposes the stream
+                // under the same lock, so a non-null local stays valid here.
                 var stream = _displayStream;
                 if (stream == null) return -1;
 
@@ -514,12 +606,15 @@ namespace FanaBridge.Transport
         /// </summary>
         public void Disconnect()
         {
+            // Wake any consumer blocked in an elicited stream read BEFORE taking
+            // the write lock: an elicit holds the batch (= this lock) while it
+            // waits, so closing the queues first is the only order that works —
+            // the woken elicit returns -1, releases the batch, and we proceed.
+            _col03Stopping = true;
+            try { _col03Queues?.Close(); } catch { }
+
             lock (_writeLock)
             {
-                // Wake any consumer blocked in an elicited ReadCol03 first,
-                // then dispose the stream to wake the reader thread itself.
-                try { _col03Queue?.Close(); } catch { }
-
                 try { _displayStream?.Close(); } catch { }
                 try { _displayStream?.Dispose(); } catch { }
                 try { _ledStream?.Close(); } catch { }
@@ -532,7 +627,7 @@ namespace FanaBridge.Transport
                 // hang teardown.
                 try { _col03Reader?.Join(1000); } catch { }
                 _col03Reader = null;
-                _col03Queue = null;
+                _col03Queues = null;
 
                 _displayStream = null;
                 _ledStream = null;

--- a/FanaBridge/Transport/FanatecWheelbase.cs
+++ b/FanaBridge/Transport/FanatecWheelbase.cs
@@ -62,7 +62,7 @@ namespace FanaBridge.Transport
         private readonly SystemReportReader _reportReader = new SystemReportReader();
         private readonly SrmConverterIdentity _srmReader = new SrmConverterIdentity();
         // Converter identity: while unidentified we ping the SRM DE FA channel (harmless — a genuine
-        // base does not answer). Its 0xDD reply arrives via the shared col03 drain into _ingestSrm.
+        // base does not answer). Its 0xDD reply arrives on the transport's SRM stream into _ingestSrm.
         private const int SrmQueryMs = 1000;              // re-ping cadence while unidentified
         private long _lastSrmQueryMs;
         private SrmConverterIdentity.Result? _pendingSrm;  // a 0xDD reply seen in the drain, committed after it
@@ -355,9 +355,9 @@ namespace FanaBridge.Transport
                 // If FF 08 was silent this might be an SRM kit (or a slow genuine base). No probe here:
                 // UpdateIdentity keeps reading FF 08 and pings DE FA while unidentified; whichever wins.
 
-                // Confirm the per-frame drain is non-blocking on this hardware — a
-                // blocking ReadCol03(buf, 0) would stall the frame thread. Done once
-                // now that the input is quiet; leaves a permanent regression guard.
+                // Confirm the per-frame drain is non-blocking — a blocking idle
+                // stream poll would stall the frame thread. Done once now that the
+                // input is quiet; leaves a permanent regression guard.
                 double drainMs = _reportReader.ProbeDrainLatencyMs(_transport, 5);
                 if (drainMs > 1.0)
                     SimHub.Logging.Current.Warn(string.Format(
@@ -461,12 +461,16 @@ namespace FanaBridge.Transport
                 catch { /* transient; the next tick retries */ }
             }
 
-            // One col03 read loop, dispatched by signature: FF 08 -> _ingest, 0xDD -> _ingestSrm, FF 05 -> ITM.
+            // Drain this device's three input streams (the transport's reader thread
+            // routes frames by signature). Lock-free: the wheelbase is the single
+            // owner of all three, and reads never touch the write lock.
             _drainNow = now;
-            _reportReader.DrainPushes(_transport, _ingest, _bufferItm, _ingestSrm);
+            _reportReader.DrainIdentity(_transport, _ingest);
+            DrainFamily(Transport.ItmReports, _bufferItm);
+            DrainFamily(Transport.SrmReports, _ingestSrm);
 
-            // Commit a converter identity the drain routed to us — after the batch, so WheelChanged
-            // isn't raised under the transport write lock.
+            // Commit a converter identity the drain routed to us — outside the drain,
+            // so WheelChanged isn't raised mid-drain.
             if (_pendingSrm.HasValue)
             {
                 var srm = _pendingSrm.Value;
@@ -491,14 +495,41 @@ namespace FanaBridge.Transport
             return changed;
         }
 
+        // Bounded, non-blocking drain of one raw-frame stream (ITM / SRM). Each
+        // frame is copied before the handler runs — handlers retain the bytes.
+        private const int FamilyDrainMaxReports = 16;
+        private byte[] _familyDrainBuf;
+
+        private void DrainFamily(IReportStream stream, Action<byte[]> handler)
+        {
+            int bufLen = Transport.Col03MaxInputReportLength;
+            if (bufLen < 64) bufLen = 64;
+            if (_familyDrainBuf == null || _familyDrainBuf.Length < bufLen)
+                _familyDrainBuf = new byte[bufLen];
+
+            for (int i = 0; i < FamilyDrainMaxReports; i++)
+            {
+                int n = stream.TryRead(_familyDrainBuf, 0);
+                if (n <= 0) break;
+
+                var copy = new byte[n];
+                Array.Copy(_familyDrainBuf, copy, n);
+                handler(copy);
+            }
+        }
+
         // Drain callback: record the reading and offer it to the settler. _drainNow
         // carries the current clock so the cached delegate needs no per-frame closure.
         private void OnDrainReading(SystemReportReader.Reading r) => IngestReading(r, _drainNow);
 
-        // Drain callback for a 0xDD frame: decode + stash; UpdateIdentity commits it after the batch.
+        // Drain callback for a 0xDD frame: decode + stash; UpdateIdentity commits it after the drain.
+        // The WheelDetected guard keeps "FF 08 wins if it answered" true even for 0xDD replies we
+        // didn't elicit — the diagnostics probe sends DE FA on demand, and its reply must not
+        // overwrite an identity the FF 08 path already committed (a read-only diagnostics run
+        // must never mutate runtime identity).
         private void OnDrainSrm(byte[] frame)
         {
-            if (IsSrmConverter || _pendingSrm.HasValue) return;
+            if (WheelDetected || IsSrmConverter || _pendingSrm.HasValue) return;
             if (SrmConverterIdentity.TryDecodeFrame(frame, frame.Length, out var srm))
                 _pendingSrm = srm;
         }

--- a/FanaBridge/Transport/FanatecWheelbase.cs
+++ b/FanaBridge/Transport/FanatecWheelbase.cs
@@ -354,17 +354,6 @@ namespace FanaBridge.Transport
                     IngestReading(reading, connectNow);
                 // If FF 08 was silent this might be an SRM kit (or a slow genuine base). No probe here:
                 // UpdateIdentity keeps reading FF 08 and pings DE FA while unidentified; whichever wins.
-
-                // Confirm the per-frame drain is non-blocking — a blocking idle
-                // stream poll would stall the frame thread. Done once now that the
-                // input is quiet; leaves a permanent regression guard.
-                double drainMs = _reportReader.ProbeDrainLatencyMs(_transport, 5);
-                if (drainMs > 1.0)
-                    SimHub.Logging.Current.Warn(string.Format(
-                        "FanatecWheelbase: idle identity drain took {0:F2} ms — expected non-blocking (<1 ms); per-frame identity polling may stutter.", drainMs));
-                else
-                    SimHub.Logging.Current.Info(string.Format(
-                        "FanatecWheelbase: identity drain is non-blocking ({0:F2} ms idle)", drainMs));
             }
             catch (Exception ex)
             {

--- a/FanaBridge/Transport/HidReportQueue.cs
+++ b/FanaBridge/Transport/HidReportQueue.cs
@@ -5,21 +5,25 @@ using System.Threading;
 namespace FanaBridge.Transport
 {
     /// <summary>
-    /// Bounded FIFO of HID input reports, bridging a blocking reader thread to
-    /// the per-frame consumers. <see cref="TryRead"/> never throws: it returns
-    /// the report length, or -1 when nothing arrives within the timeout
-    /// (0 = check and return immediately). This is what keeps the idle
-    /// per-frame drain exception-free — polling the HID handle directly with a
-    /// 0 ms timeout makes HidSharp throw a TimeoutException per call, and
-    /// SimHub's first-chance handler logs every throw as a full ERROR stack
-    /// trace (one per frame, ~8 MB of log per minute).
+    /// Bounded FIFO of HID input reports, bridging the blocking reader thread to
+    /// its single owning consumer (one queue per <see cref="Col03Family"/>).
+    /// <see cref="TryRead"/> never throws: it returns the report length, or -1
+    /// when nothing arrives within the timeout (0 = check and return
+    /// immediately). This is what keeps the idle per-frame drain exception-free —
+    /// polling the HID handle directly with a 0 ms timeout makes HidSharp throw
+    /// a TimeoutException per call, and SimHub's first-chance handler logs every
+    /// throw as a full ERROR stack trace (one per frame, ~8 MB of log per minute).
     /// </summary>
-    internal sealed class HidReportQueue
+    internal sealed class HidReportQueue : IReportStream
     {
         private readonly object _sync = new object();
         private readonly Queue<byte[]> _reports = new Queue<byte[]>();
         private readonly int _capacity;
         private bool _closed;
+
+        // Non-consuming observers (see IReportStream.Tap). Copy-on-write so the
+        // reader thread can snapshot without holding a lock during callbacks.
+        private volatile Action<byte[]>[] _taps = Array.Empty<Action<byte[]>>();
 
         public HidReportQueue(int capacity)
         {
@@ -45,6 +49,16 @@ namespace FanaBridge.Transport
                 if (_reports.Count >= _capacity) _reports.Dequeue();
                 _reports.Enqueue(copy);
                 Monitor.PulseAll(_sync);
+            }
+
+            // Observers get their own copy (the queued one belongs to the consumer)
+            // and run outside the lock so a slow observer can't stall TryRead.
+            var taps = _taps;
+            for (int i = 0; i < taps.Length; i++)
+            {
+                var tapCopy = new byte[length];
+                Array.Copy(report, tapCopy, length);
+                try { taps[i](tapCopy); } catch { /* observer's problem, not the pump's */ }
             }
         }
 
@@ -76,6 +90,66 @@ namespace FanaBridge.Transport
                 int n = Math.Min(report.Length, destination.Length);
                 Array.Copy(report, destination, n);
                 return n;
+            }
+        }
+
+        /// <summary>Drops any pending reports without closing the queue.</summary>
+        public void Flush()
+        {
+            lock (_sync)
+            {
+                _reports.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Registers a non-consuming observer of every enqueued report (its own
+        /// private copy, invoked on the reader thread). Dispose the token to
+        /// unregister. See <see cref="IReportStream.Tap"/>.
+        /// </summary>
+        public IDisposable Tap(Action<byte[]> observer)
+        {
+            if (observer == null) throw new ArgumentNullException(nameof(observer));
+            lock (_sync)
+            {
+                var taps = _taps;
+                var next = new Action<byte[]>[taps.Length + 1];
+                Array.Copy(taps, next, taps.Length);
+                next[taps.Length] = observer;
+                _taps = next;
+            }
+            return new TapToken(this, observer);
+        }
+
+        private void RemoveTap(Action<byte[]> observer)
+        {
+            lock (_sync)
+            {
+                var taps = _taps;
+                int idx = Array.IndexOf(taps, observer);
+                if (idx < 0) return;
+                var next = new Action<byte[]>[taps.Length - 1];
+                Array.Copy(taps, 0, next, 0, idx);
+                Array.Copy(taps, idx + 1, next, idx, taps.Length - idx - 1);
+                _taps = next;
+            }
+        }
+
+        private sealed class TapToken : IDisposable
+        {
+            private HidReportQueue _queue;
+            private readonly Action<byte[]> _observer;
+
+            public TapToken(HidReportQueue queue, Action<byte[]> observer)
+            {
+                _queue = queue;
+                _observer = observer;
+            }
+
+            public void Dispose()
+            {
+                _queue?.RemoveTap(_observer);
+                _queue = null;
             }
         }
 

--- a/FanaBridge/Transport/HidReportQueue.cs
+++ b/FanaBridge/Transport/HidReportQueue.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace FanaBridge.Transport
+{
+    /// <summary>
+    /// Bounded FIFO of HID input reports, bridging a blocking reader thread to
+    /// the per-frame consumers. <see cref="TryRead"/> never throws: it returns
+    /// the report length, or -1 when nothing arrives within the timeout
+    /// (0 = check and return immediately). This is what keeps the idle
+    /// per-frame drain exception-free — polling the HID handle directly with a
+    /// 0 ms timeout makes HidSharp throw a TimeoutException per call, and
+    /// SimHub's first-chance handler logs every throw as a full ERROR stack
+    /// trace (one per frame, ~8 MB of log per minute).
+    /// </summary>
+    internal sealed class HidReportQueue
+    {
+        private readonly object _sync = new object();
+        private readonly Queue<byte[]> _reports = new Queue<byte[]>();
+        private readonly int _capacity;
+        private bool _closed;
+
+        public HidReportQueue(int capacity)
+        {
+            if (capacity < 1) throw new ArgumentOutOfRangeException(nameof(capacity));
+            _capacity = capacity;
+        }
+
+        /// <summary>
+        /// Enqueues a private copy of the first <paramref name="length"/> bytes.
+        /// When full, the oldest report is dropped: if the consumer stalls (e.g.
+        /// the plugin manager is restarting between games), the freshest device
+        /// state is what a late reader needs.
+        /// </summary>
+        public void Enqueue(byte[] report, int length)
+        {
+            if (report == null || length <= 0) return;
+            if (length > report.Length) length = report.Length;
+            var copy = new byte[length];
+            Array.Copy(report, copy, length);
+            lock (_sync)
+            {
+                if (_closed) return;
+                if (_reports.Count >= _capacity) _reports.Dequeue();
+                _reports.Enqueue(copy);
+                Monitor.PulseAll(_sync);
+            }
+        }
+
+        /// <summary>
+        /// Dequeues the next report into <paramref name="destination"/>, waiting
+        /// up to <paramref name="timeoutMs"/> for one to arrive. Returns the
+        /// number of bytes copied, or -1 on empty timeout / after <see cref="Close"/>.
+        /// </summary>
+        public int TryRead(byte[] destination, int timeoutMs)
+        {
+            if (destination == null) return -1;
+            lock (_sync)
+            {
+                if (_reports.Count == 0)
+                {
+                    if (_closed || timeoutMs <= 0) return -1;
+                    // Environment.TickCount subtraction is wrap-safe
+                    int start = Environment.TickCount;
+                    int remaining = timeoutMs;
+                    while (_reports.Count == 0)
+                    {
+                        if (_closed || remaining <= 0) return -1;
+                        Monitor.Wait(_sync, remaining);
+                        remaining = timeoutMs - (Environment.TickCount - start);
+                    }
+                }
+
+                var report = _reports.Dequeue();
+                int n = Math.Min(report.Length, destination.Length);
+                Array.Copy(report, destination, n);
+                return n;
+            }
+        }
+
+        /// <summary>
+        /// Drops queued reports, refuses further input, and wakes blocked
+        /// readers (they return -1). A closed queue stays closed — Connect
+        /// creates a fresh instance per session.
+        /// </summary>
+        public void Close()
+        {
+            lock (_sync)
+            {
+                _closed = true;
+                _reports.Clear();
+                Monitor.PulseAll(_sync);
+            }
+        }
+    }
+}

--- a/FanaBridge/Transport/IDeviceTransport.cs
+++ b/FanaBridge/Transport/IDeviceTransport.cs
@@ -7,8 +7,14 @@ namespace FanaBridge.Transport
     /// (LEDs, display, tuning, etc.). Implemented by <see cref="FanatecTransport"/>.
     ///
     /// Individual sends are thread-safe — callers do not need to hold any lock
-    /// for single-report operations. For multi-report atomic sequences, use
-    /// <see cref="BeginBatch"/> to acquire exclusive access.
+    /// for single-report operations. For multi-report atomic WRITE sequences,
+    /// use <see cref="BeginBatch"/> to acquire exclusive access.
+    ///
+    /// Inbound col03 traffic is demultiplexed by the transport's reader thread
+    /// into per-family <see cref="IReportStream"/>s. Reads are lock-free: each
+    /// stream has exactly one owning consumer (Identity/Itm/Srm → the wheelbase's
+    /// frame-thread drains; Tuning → the tuning controller), so no reader can
+    /// steal another family's frames and no read ever holds the write lock.
     /// </summary>
     public interface IDeviceTransport
     {
@@ -21,13 +27,17 @@ namespace FanaBridge.Transport
         /// </summary>
         bool SendCol03(byte[] data);
 
-        /// <summary>
-        /// Reads a report from the LED/config interface (col03).
-        /// Returns the number of bytes read, or -1 on failure/timeout.
-        /// The <paramref name="timeoutMs"/> applies to this call only and
-        /// does not affect other callers.
-        /// </summary>
-        int ReadCol03(byte[] buffer, int timeoutMs);
+        /// <summary>col03 FF 08 system reports (identity pushes). Owner: the wheelbase.</summary>
+        IReportStream IdentityReports { get; }
+
+        /// <summary>col03 FF 05 ITM subscription/page pushes. Owner: the wheelbase (buffered for the ITM driver).</summary>
+        IReportStream ItmReports { get; }
+
+        /// <summary>col03 0xDD SRM DE FA identity replies. Owner: the wheelbase.</summary>
+        IReportStream SrmReports { get; }
+
+        /// <summary>col03 FF 03 tuning responses. Owner: the tuning controller.</summary>
+        IReportStream TuningReports { get; }
 
         /// <summary>
         /// Gets the maximum input report length for the col03 interface.
@@ -53,9 +63,10 @@ namespace FanaBridge.Transport
         int Col01MaxInputReportLength { get; }
 
         /// <summary>
-        /// Acquires exclusive access to the transport for multi-report
+        /// Acquires exclusive WRITE access to the transport for multi-report
         /// atomic sequences (e.g. staged LED commit, tuning read-modify-write).
-        /// Dispose the returned token to release.
+        /// Dispose the returned token to release. Reads never take this lock —
+        /// the per-family streams are single-owner by design.
         /// Re-entrant: sends made inside a batch on the same thread re-acquire
         /// the lock recursively, so they never block or deadlock.
         /// </summary>

--- a/FanaBridge/Transport/IReportStream.cs
+++ b/FanaBridge/Transport/IReportStream.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace FanaBridge.Transport
+{
+    /// <summary>
+    /// One family of inbound HID reports (e.g. col03 FF 08 identity), fed by the
+    /// transport's reader thread and consumed by exactly ONE owning component.
+    /// Single ownership is the concurrency model: because no two components pop
+    /// the same stream, reads need no lock and nothing can be stolen. A component
+    /// that needs to observe a family it does not own uses <see cref="Tap"/>.
+    /// </summary>
+    public interface IReportStream
+    {
+        /// <summary>
+        /// Dequeues the next report into <paramref name="destination"/>, waiting up
+        /// to <paramref name="timeoutMs"/> (0 = check and return). Returns the
+        /// report length, or -1 on empty timeout / disconnected. Never throws.
+        /// </summary>
+        int TryRead(byte[] destination, int timeoutMs);
+
+        /// <summary>Drops any pending reports (stale-response clearing before an elicit).</summary>
+        void Flush();
+
+        /// <summary>
+        /// Registers a non-consuming observer: it receives a private copy of every
+        /// report routed to this family until the returned token is disposed. The
+        /// owning consumer still receives every report. Callbacks run on the
+        /// transport reader thread — observers must be fast and must not call
+        /// back into the transport.
+        /// </summary>
+        IDisposable Tap(Action<byte[]> observer);
+    }
+}


### PR DESCRIPTION
## Problem

A user debug log (0.4.0-preview) showed 6,892 `System.TimeoutException: Operation timed out (0 ms)` first-chance errors — exactly one per DataUpdate frame, each logged by SimHub as a ~60-line ERROR stack, growing the log ~8 MB/minute while FanaBridge worked normally. The throw came from the per-frame idle drain: HidSharp implements every read timeout — including 0 ms — as a thrown `TimeoutException`, so polling the HID handle each frame is an exception per frame by design.

The deeper issue: col03 carries four frame families — FF 08 identity pushes, FF 05 ITM pushes, `0xDD` SRM replies, FF 03 tuning responses — consumed competitively from one shared stream by the frame thread (`DrainPushes`), UI-thread tuning reads (whose 50 ms pre-drain could swallow identity/ITM pushes), the UI-thread diagnostics probe, and the connect-time FF 08 elicit (which discarded ITM/SRM frames it skipped). Coordination was the coarse batch lock plus per-consumer skip logic, and every new family grew another callback parameter and another steal hazard.

## Design

One reader thread per connection parks in a blocking HID read (exception-free at idle; woken by stream disposal on disconnect) and routes every inbound frame by wire signature into bounded, drop-oldest per-family queues:

```
pump thread → Col03FrameClassifier → Identity (16) → wheelbase (frame thread)
                                     Itm      (64) → wheelbase → ITM driver hand-off
                                     Srm      (16) → wheelbase
                                     Tuning    (8) → tuning controller (UI thread)
```

- **Typed streams, single owners.** `IDeviceTransport.ReadCol03` is gone; consumers read `IdentityReports` / `ItmReports` / `SrmReports` / `TuningReports` (`IReportStream`). Each stream has exactly one owning consumer, so reads are lock-free and no reader can steal another family's frames — by construction, not by lock discipline.
- **`ReportElicit`** is the one request→response primitive: flush stale frames (with an optional quiet-window grace), send under a write batch, await the matching frame. Used by tuning reads and the connect-time FF 08 elicit.
- **Taps** let the diagnostics probe observe Identity/SRM frames it does not own — non-consuming copies fed from the pump — so a capture can neither starve nor be starved by the frame-thread drains.
- **`BeginBatch` now serializes writes only.** `Col03FrameClassifier` is the single home for signature rules, shared by the router and every decoder (`SystemReportReader`, `SrmConverterIdentity`, `ItmTelemetry`, the probe).
- Decoupling OS-ring relief from frame cadence also removes a silent input-loss window: previously, reports were only read while frames ticked, so game-change/plugin-restart stalls could overflow the ~32-report kernel ring buffer unobserved.
- col01 input deliberately keeps the direct locked read (it is the gamepad collection; its only reader today is diagnostics). The pump/queue design makes a col01 instantiation straightforward when something needs it.

## Review hardening

An 8-angle review pass surfaced 10 findings, all fixed in this PR, notably:

- The reader thread retries transient read errors and, if they persist, flags the transport disconnected so the `ConnectionMonitor` reconnects — otherwise one USB hiccup could kill all input for the session while writes kept working.
- `ConnectionMonitor.ForceReconnect` now defers the actual disconnect/reconnect to the next frame-thread `Update()`, keeping all connect/identity I/O single-threaded (running it on the settings UI thread raced the frame drain on shared state).
- A `0xDD` reply elicited by the diagnostics probe can no longer overwrite an identity the FF 08 path already committed (`OnDrainSrm` is gated on `!WheelDetected`) — a read-only diagnostics run must never mutate runtime identity.
- Tuning reads keep the old 50 ms stale-response grace (an instant flush would miss a late in-flight reply and mispair it with the new request) and now match/normalize responses with the same report-id tolerance the router applies.
- `Disconnect` closes the queues before taking the write lock, since a blocked elicit holds that lock — the only order that can actually wake it.
- The connect-time FF 08 window is 480 ms (matching the old 8×60 ms worst case); the elicit returns the moment the reply lands.

## Deliberate behavior deltas

- Cross-family arrival order is not preserved (one FIFO → four queues). Audited: the SRM commit is one-shot, ITM page state is absolute, the identity settler consumes only FF 08 — no consumer depends on cross-family order.
- Connect-time ITM/SRM frames now reach their owners instead of being discarded by the FF 08 read loop.
- The diagnostics DE FA scan uses the field-validated offset 0..1 signature rule (the probe alone previously scanned 0..2).
- The diagnostics probe no longer stalls frame-thread input processing during its ~1 s run (writes still serialize).

## Verification

- 387 unit tests (37 new: classifier routing/precedence/length rules, queue-set isolation and per-family drop-oldest, tap semantics, elicit flush/skip/timeout/batch, tuning no-steal).
- Standalone hardware run against a ClubSport DD+ driving the real transport: 400 idle polls across all four streams with zero first-chance exceptions, FF 08 elicit answered and decoded (Podium Hub + BME), tap observed without consuming, clean pump shutdown on disconnect.
- Live SimHub session with this build: zero `TimeoutException`s in ~100 MB of debug-logged frames, clean in-process plugin-manager restart (single expected disposal exception at pump teardown), reconnect + ITM enable + ParamDefs/value updates all normal.
