### PR TITLE
fix: ITM value rounding + suffix drop across game exit/resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ Directory.Build.props.user
 # Local personal files
 TODO.txt
 .claude/settings.local.json
+.claude/worktrees/
+
+# USB packet captures belong in the fanatec-re project, not here
+usbcap/
 
 # User-specific files
 *.rsuser

--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -377,6 +377,50 @@ namespace FanaBridge.Tests
             Assert.Equal((byte)'C', pd[8]);            // Celsius
         }
 
+        // A game-exit DisplayReset clears the firmware's suffix; on resume the suffix set is
+        // unchanged, so the sig-latch would suppress the re-send and the suffix would never
+        // come back (value renders, suffix doesn't). The exit reset must clear the sig so the
+        // def re-decorates when telemetry returns.
+        [Fact]
+        public void GameExitThenResume_ReDecoratesSuffix()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);   // 'C' suffix on the tyre page
+            clock.T += 1000;
+            driver.Update(EmptyData());                   // telemetry live -> def sent
+            Assert.Contains(t.Sent, IsParamDefs);
+
+            driver.Update(NotRunningData());              // game exit -> DisplayReset
+            t.Sent.Clear();
+
+            clock.T += 1000;
+            driver.Update(EmptyData());                   // resume, same suffix set -> MUST re-send
+            Assert.Contains(t.Sent, IsParamDefs);
+        }
+
+        // ParamDefs is fire-and-forget (no ack): a single send is occasionally dropped by the
+        // firmware, so every def is sent as a tight double-tap (~50 ms), matching the official
+        // app's priming. Exactly one extra send, then silence until the suffix set changes.
+        [Fact]
+        public void ParamDefs_AreTightDoubleTapped()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+            clock.T += 1000;
+            driver.Update(EmptyData());                    // first def (tap 1)
+            Assert.Equal(1, t.Sent.Count(IsParamDefs));
+
+            clock.T += driver.DefDoubleTapMs;              // ~50 ms later
+            driver.Update(EmptyData());                    // the tight second tap
+            Assert.Equal(2, t.Sent.Count(IsParamDefs));
+
+            clock.T += 5000;                               // suffix unchanged -> no further sends
+            driver.Update(EmptyData());
+            Assert.Equal(2, t.Sent.Count(IsParamDefs));
+        }
+
         [Fact]
         public void LapAndPosition_SendParamDefsTotalSuffix()
         {

--- a/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -289,6 +289,44 @@ namespace FanaBridge.Tests
             Assert.Equal((byte)0, AsU8(v[5]));
         }
 
+        // ── Value rounding (dodge the firmware's per-digit carry bug) ─────
+        // The ITM firmware renders a decimal field as whole.round(frac*10^N) with NO
+        // carry into the integer part, so an unrounded value just below a round-up
+        // boundary misrenders (16.9692 -> "16.10"). The official app pre-rounds each
+        // float to its display precision; we match it. Fuel = 1 decimal; delta and the
+        // car-gap fields = 2 decimals. Time fields truncate in firmware, so they are
+        // deliberately left unrounded.
+
+        [Fact]
+        public void Fuel_IsRoundedToOneDecimal()
+        {
+            var s = NewStatus();
+            Set(s, "Fuel", 16.9692);
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.Fuel, 8, Wrap(s), out var v));
+            Assert.Equal(17.0f, AsF32(v), 3);   // 16.9692 -> 17.0, not the raw boundary value
+        }
+
+        [Fact]
+        public void DeltaOwnBest_IsRoundedToTwoDecimals()
+        {
+            var s = NewStatus();
+            Set(s, "DeltaToSessionBest", (double?)1.997);
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.DeltaOwnBest, 12, Wrap(s), out var v));
+            Assert.Equal(2.0f, AsF32(v), 3);
+        }
+
+        [Fact]
+        public void CarGaps_AreRoundedToTwoDecimals()
+        {
+            var s = NewStatus();
+            Set(s, "OpponentsAheadOnTrack", OpponentList(1.997));    // -> 2.00, negated (you're behind them)
+            Set(s, "OpponentsBehindOnTrack", OpponentList(1.992));   // -> 1.99
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.CarAhead, 10, Wrap(s), out var ahead));
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.CarBehind, 11, Wrap(s), out var behind));
+            Assert.Equal(-2.0f, AsF32(ahead), 3);
+            Assert.Equal(1.99f, AsF32(behind), 3);
+        }
+
         // ── TyreTemps encoding ───────────────────────────────────────────
 
         // ── Subscription report parsing (firmware-driven path) ───────────

--- a/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -33,6 +33,13 @@ namespace FanaBridge.Adapters
         /// <summary>Minimum spacing between value-update sends (caps the rate).</summary>
         public int ValueIntervalMs { get; set; } = 40;
 
+        /// <summary>
+        /// Gap before the tight second ParamDefs send (double-tap). ParamDefs is unacked
+        /// and a single send is occasionally dropped by the firmware; the official app
+        /// double-taps ~49ms apart to prime the decoration so it sticks.
+        /// </summary>
+        public int DefDoubleTapMs { get; set; } = 50;
+
         /// <summary>Whether to show the "/total laps" suffix on the lap field.</summary>
         public bool ShowLapTotal { get; set; } = true;
 
@@ -65,6 +72,8 @@ namespace FanaBridge.Adapters
         private ItmValue[] _lastValues;
         private bool _loggedFirstValues;
         private string _lastSlotDefsSig = "";   // last ParamDefs suffix set, to skip redundant writes
+        private long _defTap2DueMs;               // when to fire the tight second def tap (0 = none)
+        private List<ItmParamDef> _defTap2Defs;   // the defs to re-send as that second tap
         // Reused per-tick send buffer (avoids a per-frame allocation).
         private readonly List<ItmValue> _valueBuf = new List<ItmValue>();
         // Subscribed paramIds we've already warned have no encoder — log each once.
@@ -118,6 +127,8 @@ namespace FanaBridge.Adapters
             _lastValues = null;
             _loggedFirstValues = false;
             _lastSlotDefsSig = "";
+            _defTap2DueMs = 0;
+            _defTap2Defs = null;
             _wasTelemetryLive = false;
             _pendingExitReset = false;
         }
@@ -163,8 +174,18 @@ namespace FanaBridge.Adapters
         // the value renders from ValueUpdate regardless. Slot ID = 0x80 | handle, per
         // the capture. Only writes when the suffix set actually changes (subscription
         // change or a moving total), so it does not flood the bus.
-        private void UpdateSlotDefs(GameData data)
+        private void UpdateSlotDefs(GameData data, long now)
         {
+            // Tight double-tap: re-send the just-sent defs once, ~DefDoubleTapMs later.
+            // ParamDefs is unacked and a single send is occasionally dropped by the firmware;
+            // the tight second tap (matching the official app's ~49 ms) makes it stick.
+            if (_defTap2DueMs != 0 && now >= _defTap2DueMs)
+            {
+                _defTap2DueMs = 0;
+                if (_defTap2Defs != null)
+                    _encoder.SetParamDefs(_defTap2Defs, _deviceId);
+            }
+
             List<ItmParamDef> defs = null;
             var sig = new System.Text.StringBuilder();
 
@@ -205,6 +226,8 @@ namespace FanaBridge.Adapters
             if (defs != null)
             {
                 _encoder.SetParamDefs(defs, _deviceId);
+                _defTap2Defs = defs;                  // schedule the tight second tap
+                _defTap2DueMs = now + DefDoubleTapMs;
                 _log("ITM: ParamDefs sent — suffixes: " + s);
             }
         }
@@ -284,6 +307,9 @@ namespace FanaBridge.Adapters
                 _pendingExitReset = false;
                 _wasTelemetryLive = false;
                 _lastValues = null;                // repaint everything when telemetry returns
+                _lastSlotDefsSig = "";             // the reset cleared the firmware suffix — force a
+                                                   // re-decorate on resume (same page/suffix set won't
+                                                   // otherwise trip the sig change, so it'd stay blank)
                 _log("ITM: game exited — display reset (fields back to placeholders)");
                 return;
             }
@@ -310,7 +336,7 @@ namespace FanaBridge.Adapters
             if (!telemetryLive)
                 return;
 
-            UpdateSlotDefs(data);   // refresh unit/total suffixes when they change
+            UpdateSlotDefs(data, now);   // refresh unit/total suffixes; tight double-tap so they stick
             if (now - _lastValuesMs >= ValueIntervalMs)
             {
                 SendSubscribedValues(data);

--- a/FanaBridge/Adapters/ItmTelemetryMapper.cs
+++ b/FanaBridge/Adapters/ItmTelemetryMapper.cs
@@ -57,11 +57,16 @@ namespace FanaBridge.Adapters
                 [ItmParam.LastLapTime] = F32(ItmParam.LastLapTime, d => Seconds(d.LastLapTime)),
 
                 // Fuel / ERS / DRS
-                [ItmParam.Fuel] = F32(ItmParam.Fuel, d => (float)d.Fuel),
+                // Round each displayed float to its field's precision on the host: the firmware
+                // renders a decimal field as whole.round(frac*10^N) with NO carry, so an
+                // unrounded value just below a boundary misrenders (16.9692 -> "16.10"). The
+                // official app pre-rounds the same way. Fuel = 1 dp; delta/gaps = 2 dp; time
+                // fields truncate in firmware and are left unrounded.
+                [ItmParam.Fuel] = F32(ItmParam.Fuel, d => (float)Math.Round(d.Fuel, 1)),
                 [ItmParam.ErsLevel] = I32(ItmParam.ErsLevel, d => SafeRound(d.ERSPercent)),
                 [ItmParam.DrsZone] = U8(ItmParam.DrsZone, d => (byte)(d.DRSAvailable != 0 ? 1 : 0)),
                 [ItmParam.DrsActive] = U8(ItmParam.DrsActive, d => (byte)(d.DRSEnabled != 0 ? 1 : 0)),
-                [ItmParam.DeltaOwnBest] = F32(ItmParam.DeltaOwnBest, d => (float)(d.DeltaToSessionBest ?? 0.0)),
+                [ItmParam.DeltaOwnBest] = F32(ItmParam.DeltaOwnBest, d => (float)Math.Round(d.DeltaToSessionBest ?? 0.0, 2)),
 
                 // Car Settings
                 [ItmParam.TcSetting] = U8(ItmParam.TcSetting, d => ClampByte(d.TCLevel)),
@@ -76,8 +81,8 @@ namespace FanaBridge.Adapters
                 // Lap Times
                 [ItmParam.BestLapTime] = F32(ItmParam.BestLapTime, d => Seconds(d.BestLapTime)),
                 // Car ahead is shown as a negative gap (you're behind them); car behind positive.
-                [ItmParam.CarAhead] = F32(ItmParam.CarAhead, d => -NearestGap(d.OpponentsAheadOnTrack)),
-                [ItmParam.CarBehind] = F32(ItmParam.CarBehind, d => NearestGap(d.OpponentsBehindOnTrack)),
+                [ItmParam.CarAhead] = F32(ItmParam.CarAhead, d => -(float)Math.Round(NearestGap(d.OpponentsAheadOnTrack), 2)),
+                [ItmParam.CarBehind] = F32(ItmParam.CarBehind, d => (float)Math.Round(NearestGap(d.OpponentsBehindOnTrack), 2)),
 
                 // Tyre Temps
                 [ItmParam.TyreFlTemp] = U8(ItmParam.TyreFlTemp, d => ClampByte(d.TyreTemperatureFrontLeft)),


### PR DESCRIPTION
## Summary

Two ITM display fixes on the firmware-driven path.

### 1. Value rounding (fuel, delta, car gaps)

The ITM firmware formats a decimal field as `whole.round(frac × 10^N)` with no carry into the integer part, so a value just below a round-up boundary misrenders — e.g. fuel `16.9692` shows as `16.10` instead of `17.0`. The host now pre-rounds each displayed float to its field precision: **fuel → 1 decimal, delta and the car-ahead/behind gaps → 2 decimals**. Time fields truncate in firmware and are deliberately left unrounded.

### 2. Suffix drop across game exit/resume

The unit/total suffix (fuel `/45`, temp `C`/`F`, lap `/34`) would go missing after a game/replay exit — the value renders, the suffix does not. Two independent causes:

- The game-exit `DisplayReset` clears the firmware's on-screen suffix, but `UpdateSlotDefs` only re-sends a `ParamDefs` when the suffix signature changes. The exit reset did not clear the signature, so on resume (same page, same suffix set) the def was never re-sent. The exit reset now clears `_lastSlotDefsSig`, so the suffix re-decorates on resume.
- `ParamDefs` is fire-and-forget (no ack) and a single send is occasionally dropped by the firmware. Each def is now sent as a tight ~50 ms double-tap (`DefDoubleTapMs`), so a dropped first send self-heals.

## Tests

- Rounding: fuel → 1 dp, delta/gaps → 2 dp (`ItmTelemetryTests`).
- Suffix re-decorates after exit → resume; the `ParamDefs` double-tap fires once then goes quiet until the suffix set changes (`ItmDisplayDriverTests`).
- Full suite green (392 tests).

## Notes

- Rebased on #55 (typed col03 input streams).
- In-game validation on a game-start-while-already-on-the-page scenario is recommended before merge.
