### PR TITLE
Reliability fixes: ITM write acceptance, LED ForceDirty race, wizard mapping rebuild, display-test ownership

### DIFF
--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -21,13 +21,15 @@ namespace FanaBridge.Tests
             public List<byte[]> Sent { get; } = new List<byte[]>();
             // Simulate a transport-level send failure (SendCol03 returns false).
             public bool SendReturns { get; set; } = true;
+            // Optional per-frame accept/decline decision (null = use SendReturns).
+            public Func<byte[], bool> Decide { get; set; }
 
             public bool SendCol03(byte[] data)
             {
                 var copy = new byte[data.Length];
                 Array.Copy(data, copy, data.Length);
                 Sent.Add(copy);
-                return SendReturns;
+                return Decide?.Invoke(copy) ?? SendReturns;
             }
 
             public bool SendCol01(byte[] data) => true;
@@ -778,6 +780,108 @@ namespace FanaBridge.Tests
             clock.T += 500;
             driver.Update(EmptyData());        // dormant after success
             Assert.Empty(t.Sent);
+        }
+
+        // ── Bring-up / ParamDefs transport-acceptance retries ────────────
+
+        [Fact]
+        public void BringUp_DeclinedWrites_RetriedUntilAccepted_NotRunningUntilComplete()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            driver.Start();
+
+            t.SendReturns = false;             // whole bring-up declined
+            driver.Update(EmptyData());
+            Assert.False(driver.IsRunning);    // must NOT latch Running on declined writes
+            t.Sent.Clear();
+
+            t.SendReturns = true;
+            driver.Update(EmptyData());        // retried and accepted → Running
+            Assert.True(driver.IsRunning);
+            Assert.Contains(t.Sent, IsItmModeOn);
+            Assert.Contains(t.Sent, IsEnable);
+            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04);
+        }
+
+        [Fact]
+        public void BringUp_AcceptedSteps_NotResent_OnRetry()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            driver.Start();
+
+            // Gate + Enable accepted, PageSet declined: bring-up stalls before Running.
+            t.Decide = r => !(r[1] == 0x05 && r[2] == 0x04);
+            driver.Update(EmptyData());
+            Assert.False(driver.IsRunning);
+            t.Sent.Clear();
+
+            t.Decide = null;
+            driver.Update(EmptyData());        // only the missing step is retried
+            Assert.True(driver.IsRunning);
+            Assert.DoesNotContain(t.Sent, IsItmModeOn);   // already accepted last tick
+            Assert.DoesNotContain(t.Sent, IsEnable);      // already accepted last tick
+            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04);
+        }
+
+        [Fact]
+        public void ParamDefs_DeclinedSend_RetriedUntilAccepted()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+
+            // ParamDefs declined: the suffix signature must NOT latch, or the
+            // decoration would never be retried until the suffix set changes.
+            t.Decide = r => !IsParamDefs(r);
+            clock.T += 40;
+            driver.Update(EmptyData());
+            Assert.Contains(t.Sent, IsParamDefs);   // attempted
+            t.Sent.Clear();
+
+            t.Decide = null;
+            clock.T += 40;
+            driver.Update(EmptyData());             // unchanged suffix set — still retried
+            Assert.Contains(t.Sent, IsParamDefs);
+        }
+
+        [Fact]
+        public void ParamDefs_DoubleTap_Declined_RetriedNextTick()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+
+            clock.T += 40;
+            driver.Update(EmptyData());             // first ParamDefs accepted, tap scheduled
+            t.Sent.Clear();
+
+            t.Decide = r => !IsParamDefs(r);        // the tight second tap is declined
+            clock.T += 60;
+            driver.Update(EmptyData());
+            t.Sent.Clear();
+
+            t.Decide = null;
+            clock.T += 10;
+            driver.Update(EmptyData());             // tap retried once accepted
+            Assert.Contains(t.Sent, IsParamDefs);
+        }
+
+        [Fact]
+        public void DefaultPageChange_DeclinedPageSet_RetriedUntilAccepted()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            driver.Start();
+            driver.Update(NotRunningData());
+            t.Sent.Clear();
+
+            driver.DefaultPage = 3;
+            t.SendReturns = false;                  // live page switch declined
+            driver.Update(NotRunningData());
+            t.Sent.Clear();
+
+            t.SendReturns = true;
+            driver.Update(NotRunningData());        // edge still pending — retried
+            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[4] == 0x03);
         }
 
         // ── Stop / restart ───────────────────────────────────────────────

--- a/FanaBridge.Tests/LedEncoderTests.cs
+++ b/FanaBridge.Tests/LedEncoderTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FanaBridge.Protocol;
+using FanaBridge.Transport;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class LedEncoderTests
+    {
+        // ── Test stub ──────────────────────────────────────────────────
+
+        private class StubTransport : IDeviceTransport
+        {
+            public bool IsConnected { get; set; } = true;
+            public List<byte[]> Col03Reports { get; } = new List<byte[]>();
+            public int Col03MaxInputReportLength => 64;
+
+            public bool SendCol01(byte[] data) => true;
+
+            public bool SendCol03(byte[] data)
+            {
+                Col03Reports.Add((byte[])data.Clone());
+                return true;
+            }
+
+            public IReportStream IdentityReports => FakeReportStream.Empty;
+            public IReportStream ItmReports => FakeReportStream.Empty;
+            public IReportStream SrmReports => FakeReportStream.Empty;
+            public IReportStream TuningReports => FakeReportStream.Empty;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
+            public IDisposable BeginBatch() => new NoOpDisposable();
+
+            private class NoOpDisposable : IDisposable
+            {
+                public void Dispose() { }
+            }
+        }
+
+        private static byte[] LastReport(StubTransport t, byte subcmd)
+            => t.Col03Reports.Last(r => r[2] == subcmd);
+
+        // ── Intensity payload / commit-byte layout ─────────────────────
+
+        [Fact]
+        public void IntensityPayload_LastByte_ReachesWire_NotClobberedByCommit()
+        {
+            var t = new StubTransport();
+            var encoder = new LedEncoder(t);
+
+            // Payload with a distinctive value in the LAST slot: it must land at
+            // report offset 3 + (SIZE-1) = 17, with the commit flag after it at 18.
+            var intensities = new byte[LedEncoder.INTENSITY_PAYLOAD_SIZE];
+            intensities[intensities.Length - 1] = 5;
+
+            Assert.True(encoder.SetButtonLedState(null, intensities));
+
+            var report = LastReport(t, 0x03);
+            Assert.Equal(5, report[3 + LedEncoder.INTENSITY_PAYLOAD_SIZE - 1]);   // offset 17
+            Assert.Equal(1, report[3 + LedEncoder.INTENSITY_PAYLOAD_SIZE]);       // commit at 18
+        }
+
+        [Fact]
+        public void IntensityPayload_LastSlotChange_IsResent_AndVisibleOnWire()
+        {
+            var t = new StubTransport();
+            var encoder = new LedEncoder(t);
+
+            var intensities = new byte[LedEncoder.INTENSITY_PAYLOAD_SIZE];
+            encoder.SetButtonLedState(null, intensities);
+            t.Col03Reports.Clear();
+
+            // Change only the last slot — the resend must carry the change
+            // (historically the commit byte overwrote this slot, so the change
+            // was sent as identical bytes and then latched as delivered).
+            intensities[intensities.Length - 1] = 7;
+            Assert.True(encoder.SetButtonLedState(null, intensities));
+
+            var report = LastReport(t, 0x03);
+            Assert.Equal(7, report[3 + LedEncoder.INTENSITY_PAYLOAD_SIZE - 1]);
+        }
+
+        [Fact]
+        public void SetButtonLedState_WrongPayloadLength_Rejected()
+        {
+            var t = new StubTransport();
+            var encoder = new LedEncoder(t);
+
+            Assert.False(encoder.SetButtonLedState(null, new byte[LedEncoder.INTENSITY_PAYLOAD_SIZE + 1]));
+            Assert.False(encoder.SetButtonLedState(null, new byte[LedEncoder.INTENSITY_PAYLOAD_SIZE - 1]));
+            Assert.Empty(t.Col03Reports);
+        }
+
+        // ── Dirty tracking / ForceDirty ────────────────────────────────
+
+        [Fact]
+        public void SetRevLedColors_Unchanged_SkipsWire()
+        {
+            var t = new StubTransport();
+            var encoder = new LedEncoder(t);
+            var colors = new ushort[] { 0x1234, 0x5678 };
+
+            encoder.SetRevLedColors(colors);
+            t.Col03Reports.Clear();
+
+            Assert.True(encoder.SetRevLedColors(colors));
+            Assert.Empty(t.Col03Reports);
+        }
+
+        [Fact]
+        public void ForceDirty_UnchangedColors_AreResent()
+        {
+            var t = new StubTransport();
+            var encoder = new LedEncoder(t);
+            var colors = new ushort[] { 0x1234, 0x5678 };
+
+            encoder.SetRevLedColors(colors);
+            t.Col03Reports.Clear();
+
+            encoder.ForceDirty();
+            Assert.True(encoder.SetRevLedColors(colors));
+            Assert.Single(t.Col03Reports);
+        }
+
+        [Fact]
+        public void ForceDirty_UnchangedButtonState_IsResent()
+        {
+            var t = new StubTransport();
+            var encoder = new LedEncoder(t);
+            var colors = new ushort[] { 0x0F0F };
+            var intensities = new byte[LedEncoder.INTENSITY_PAYLOAD_SIZE];
+            intensities[0] = 7;
+
+            encoder.SetButtonLedState(colors, intensities);
+            t.Col03Reports.Clear();
+
+            encoder.ForceDirty();
+            Assert.True(encoder.SetButtonLedState(colors, intensities));
+            Assert.Contains(t.Col03Reports, r => r[2] == 0x02);   // colors resent
+            Assert.Contains(t.Col03Reports, r => r[2] == 0x03);   // intensities resent
+        }
+
+        [Fact]
+        public void ForceDirty_BetweenSends_IsNotLost()
+        {
+            // ForceDirty sets a flag consumed on the sender's own thread, so state
+            // is never mutated concurrently with a send. Two ForceDirty calls with
+            // no send in between still yield exactly one forced resend.
+            var t = new StubTransport();
+            var encoder = new LedEncoder(t);
+            var colors = new ushort[] { 0x1234 };
+
+            encoder.SetRevLedColors(colors);
+            encoder.ForceDirty();
+            encoder.ForceDirty();
+            t.Col03Reports.Clear();
+
+            encoder.SetRevLedColors(colors);
+            Assert.Single(t.Col03Reports);      // forced resend
+
+            t.Col03Reports.Clear();
+            encoder.SetRevLedColors(colors);
+            Assert.Empty(t.Col03Reports);       // flag consumed — back to dirty tracking
+        }
+    }
+}

--- a/FanaBridge.Tests/WizardStateTests.cs
+++ b/FanaBridge.Tests/WizardStateTests.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Linq;
+using FanaBridge.Profiles;
+using FanaBridge.UI;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class WizardStateTests
+    {
+        // ── InputMappingState.EnsureLeds — build / rebuild semantics ────
+
+        [Fact]
+        public void EnsureLeds_FirstBuild_LaysOutColorThenMono()
+        {
+            var m = new InputMappingState();
+            m.EnsureLeds(colorCount: 3, monoCount: 2);
+
+            Assert.Equal(5, m.Leds.Count);
+            Assert.All(m.Leds.Take(3), e => Assert.Equal(LedChannel.ButtonRgb, e.Channel));
+            Assert.All(m.Leds.Skip(3), e => Assert.Equal(LedChannel.ButtonAuxIntensity, e.Channel));
+            // Mono HwIndex continues after the color block (shared intensity payload).
+            Assert.Equal(new[] { 0, 1, 2, 3, 4 }, m.Leds.Select(e => e.HwIndex));
+            Assert.Equal(0, m.CurrentIndex);
+        }
+
+        [Fact]
+        public void EnsureLeds_UnchangedCounts_KeepsListAndCaptures()
+        {
+            var m = new InputMappingState();
+            m.EnsureLeds(2, 1);
+            m.Leds[0].ButtonInputId = "BTN_A";
+            m.CurrentIndex = 1;
+
+            m.EnsureLeds(2, 1);   // plain Back/Next round-trip — nothing changed
+
+            Assert.Equal("BTN_A", m.Leds[0].ButtonInputId);
+            Assert.Equal(1, m.CurrentIndex);   // untouched — not repositioned
+        }
+
+        [Fact]
+        public void EnsureLeds_ColorCountChanged_RebasesMonoHwIndexes()
+        {
+            // The E2 misattribution case: 3 color + 2 mono mapped, then the user
+            // goes Back and corrects the color count to 2. Stale mono entries
+            // carried HwIndex 3/4; the rebuilt list must carry 2/3, with the mono
+            // captures still attached to the same mono LEDs (by ordinal).
+            var m = new InputMappingState();
+            m.EnsureLeds(3, 2);
+            m.Leds[3].ButtonInputId = "MONO_1";
+            m.Leds[4].ButtonInputId = "MONO_2";
+
+            m.EnsureLeds(2, 2);
+
+            var mono = m.Leds.Where(e => e.Channel == LedChannel.ButtonAuxIntensity).ToList();
+            Assert.Equal(new[] { 2, 3 }, mono.Select(e => e.HwIndex));
+            Assert.Equal("MONO_1", mono[0].ButtonInputId);
+            Assert.Equal("MONO_2", mono[1].ButtonInputId);
+        }
+
+        [Fact]
+        public void EnsureLeds_CountGrown_NewLedIsUnmappedAndCurrent()
+        {
+            var m = new InputMappingState();
+            m.EnsureLeds(2, 0);
+            m.Leds[0].ButtonInputId = "A";
+            m.Leds[1].ButtonInputId = "B";
+            m.CurrentIndex = 2;   // mapping was complete
+
+            m.EnsureLeds(3, 0);   // user went Back: "it was 3, not 2"
+
+            Assert.Equal(3, m.Leds.Count);
+            Assert.Equal("A", m.Leds[0].ButtonInputId);
+            Assert.Equal("B", m.Leds[1].ButtonInputId);
+            Assert.Null(m.Leds[2].ButtonInputId);
+            Assert.Equal(2, m.CurrentIndex);    // positioned at the new, unmapped LED
+            Assert.False(m.IsComplete);
+        }
+
+        [Fact]
+        public void EnsureLeds_CountShrunk_DropsExtraCaptures_AndCompletes()
+        {
+            var m = new InputMappingState();
+            m.EnsureLeds(3, 0);
+            foreach (var e in m.Leds) e.ButtonInputId = "BTN_" + e.HwIndex;
+
+            m.EnsureLeds(2, 0);
+
+            Assert.Equal(2, m.Leds.Count);
+            Assert.Equal("BTN_0", m.Leds[0].ButtonInputId);
+            Assert.Equal("BTN_1", m.Leds[1].ButtonInputId);
+            Assert.True(m.IsComplete);   // everything remaining is mapped
+        }
+
+        [Fact]
+        public void EnsureLeds_Rebuild_ResetsClassificationState()
+        {
+            var m = new InputMappingState();
+            m.EnsureLeds(2, 0);
+            m.Phase = MappingPhase.Classifying;
+            m.ClassifyInputs.Add("BTN_X");
+
+            m.EnsureLeds(1, 0);
+
+            Assert.Equal(MappingPhase.WaitingForInput, m.Phase);
+            Assert.Empty(m.ClassifyInputs);
+        }
+
+        [Fact]
+        public void EnsureLeds_EncoderCaptures_CarryOver()
+        {
+            var m = new InputMappingState();
+            m.EnsureLeds(1, 1);
+            m.Leds[1].IsEncoder = true;
+            m.Leds[1].RelativeCW = "ROT_CW";
+            m.Leds[1].RelativeCCW = "ROT_CCW";
+            m.Leds[1].AbsoluteInputs = new List<string> { "POS_1", "POS_2" };
+
+            m.EnsureLeds(2, 1);   // color count corrected upward
+
+            var mono = m.Leds.Single(e => e.Channel == LedChannel.ButtonAuxIntensity);
+            Assert.Equal(2, mono.HwIndex);   // rebased: after the 2 color LEDs
+            Assert.True(mono.IsEncoder);
+            Assert.Equal("ROT_CW", mono.RelativeCW);
+            Assert.Equal("ROT_CCW", mono.RelativeCCW);
+            Assert.Equal(new[] { "POS_1", "POS_2" }, mono.AbsoluteInputs);
+        }
+    }
+}

--- a/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -58,6 +58,9 @@ namespace FanaBridge.Adapters
         // True once the legacy page has been blanked after switching to mode "None",
         // so it is cleared once on the transition rather than every frame.
         private bool _legacyBlanked;
+        // Tracks the settings page's display test so the handback edge (test just
+        // ended) can blank the residue and reset the driver's value latches.
+        private bool _displayTestWasActive;
 
         // Track connection state transitions for cleanup on disconnect.
         private bool _wasConnected;
@@ -404,6 +407,17 @@ namespace FanaBridge.Adapters
                 return;
 
             // ── Display ──────────────────────────────────────────────────
+            // While the settings page's display test owns the 7-segment display,
+            // skip the legacy col01 drive so the test text isn't overwritten each
+            // frame (LEDs and the col03 ITM display are unaffected). On handback,
+            // Clear() blanks the test residue AND resets the driver's value
+            // latches, so the live gear/speed repaints immediately instead of
+            // waiting for the next value change.
+            bool displayTest = plugin.DisplayTestActive;
+            if (!displayTest && _displayTestWasActive)
+                _displayManager?.Clear();
+            _displayTestWasActive = displayTest;
+
             var displayType = _config.Capabilities.Display;
             if (displayType == DisplayType.Itm)
             {
@@ -451,10 +465,11 @@ namespace FanaBridge.Adapters
                     {
                         if (_displayManager == null)
                             _displayManager = new FanatecDisplayDriver(plugin.Display, _displaySettings);
-                        _displayManager.Update(data);
+                        if (!displayTest)
+                            _displayManager.Update(data);
                         _legacyBlanked = false;
                     }
-                    else if (_displayManager != null && !_legacyBlanked)
+                    else if (_displayManager != null && !_legacyBlanked && !displayTest)
                     {
                         // Switched to None — blank the legacy page once. Only latch
                         // when the blanking write was accepted, so a transient
@@ -483,7 +498,8 @@ namespace FanaBridge.Adapters
                         "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: Created display manager");
                 }
 
-                _displayManager.Update(data);
+                if (!displayTest)
+                    _displayManager.Update(data);
             }
 
             // ── LEDs ─────────────────────────────────────────────────────

--- a/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -66,6 +66,11 @@ namespace FanaBridge.Adapters
         private long _lastValuesMs;
         private byte _lastPageApplied;   // last page we forced via SetPage — edge-detects a settings change
 
+        // Bring-up progress: each command is latched only once the transport accepts it,
+        // so a declined write is retried next tick instead of leaving the driver in
+        // Running against a display that never got its enable/page-set.
+        private bool _bringUpModeSent, _bringUpEnableSent, _bringUpPageSent;
+
         // Firmware-driven subscription map: host handle -> parameter ID. Kept sorted by
         // handle so the dirty-tracking comparison sees a stable order.
         private readonly SortedDictionary<byte, ushort> _subs = new SortedDictionary<byte, ushort>();
@@ -131,6 +136,9 @@ namespace FanaBridge.Adapters
             _defTap2Defs = null;
             _wasTelemetryLive = false;
             _pendingExitReset = false;
+            _bringUpModeSent = false;
+            _bringUpEnableSent = false;
+            _bringUpPageSent = false;
         }
 
         // Game-exit tracking: values must never be painted from SimHub's stale
@@ -179,11 +187,11 @@ namespace FanaBridge.Adapters
             // Tight double-tap: re-send the just-sent defs once, ~DefDoubleTapMs later.
             // ParamDefs is unacked and a single send is occasionally dropped by the firmware;
             // the tight second tap (matching the official app's ~49 ms) makes it stick.
+            // A declined tap keeps its due time so it retries next tick.
             if (_defTap2DueMs != 0 && now >= _defTap2DueMs)
             {
-                _defTap2DueMs = 0;
-                if (_defTap2Defs != null)
-                    _encoder.SetParamDefs(_defTap2Defs, _deviceId);
+                if (_defTap2Defs == null || _encoder.SetParamDefs(_defTap2Defs, _deviceId))
+                    _defTap2DueMs = 0;
             }
 
             List<ItmParamDef> defs = null;
@@ -221,15 +229,22 @@ namespace FanaBridge.Adapters
             string s = sig.ToString();
             if (s == _lastSlotDefsSig)
                 return;   // unchanged — nothing to send
-            _lastSlotDefsSig = s;
 
-            if (defs != null)
+            if (defs == null)
             {
-                _encoder.SetParamDefs(defs, _deviceId);
-                _defTap2Defs = defs;                  // schedule the tight second tap
-                _defTap2DueMs = now + DefDoubleTapMs;
-                _log("ITM: ParamDefs sent — suffixes: " + s);
+                _lastSlotDefsSig = s;   // nothing on the wire for this set — just record it
+                return;
             }
+
+            // Latch the signature only when the transport accepts the write — otherwise a
+            // declined ParamDefs send would never be retried until the suffix set happens
+            // to change again, leaving the display undecorated (blank/wrong suffixes).
+            if (!_encoder.SetParamDefs(defs, _deviceId))
+                return;
+            _lastSlotDefsSig = s;
+            _defTap2Defs = defs;                  // schedule the tight second tap
+            _defTap2DueMs = now + DefDoubleTapMs;
+            _log("ITM: ParamDefs sent — suffixes: " + s);
         }
 
         private bool ShowTotalFor(ushort paramId)
@@ -277,9 +292,28 @@ namespace FanaBridge.Adapters
                 // the configured default page (FF 05 04 <dev> <page>) so the display matches our
                 // seed and shows correct values right away. The wheel button navigates from there;
                 // detecting the wheel's current page on cold start instead is deferred — see #43.
-                _encoder.SetItmMode(true);              // FF 05 02 01 — firmware ITM gate on
-                _encoder.EnableItm();                   // FF 02 02 00 — start the display session
-                _encoder.SetPage(_deviceId, DefaultPage);  // force the configured default page
+                // Each command advances only once the transport accepts it — bring-up fires right
+                // as the rim settles, exactly when a transient write failure is most likely, and a
+                // dropped Enable/PageSet would otherwise leave the driver streaming values at a
+                // display that never started a session.
+                if (!_bringUpModeSent)
+                {
+                    if (!_encoder.SetItmMode(true))     // FF 05 02 01 — firmware ITM gate on
+                        return;
+                    _bringUpModeSent = true;
+                }
+                if (!_bringUpEnableSent)
+                {
+                    if (!_encoder.EnableItm())          // FF 02 02 00 — start the display session
+                        return;
+                    _bringUpEnableSent = true;
+                }
+                if (!_bringUpPageSent)
+                {
+                    if (!_encoder.SetPage(_deviceId, DefaultPage))  // force the configured default page
+                        return;
+                    _bringUpPageSent = true;
+                }
                 _lastPageApplied = DefaultPage;
                 SeedInitialSubscriptions();             // the default page's params
                 _log("ITM: enabled — seeded " + _subs.Count + " params, following firmware subscriptions");
@@ -320,14 +354,18 @@ namespace FanaBridge.Adapters
             // idle too — this is the settings panel's live preview.
             if (DefaultPage != _lastPageApplied)
             {
-                _encoder.SetPage(_deviceId, DefaultPage);
-                _lastPageApplied = DefaultPage;
-                // Deliberately DON'T reseed here — keep the current subscriptions until the firmware
-                // pushes the new page's set. Unlike bring-up (which has no prior state), a live switch
-                // has valid subs to lose: if the PageSet flakes, or targets the page already shown (no
-                // push comes back), a speculative reseed would strand the display on wrong-page handles
-                // with nothing to correct it. The existing subs stay valid for whatever is displayed.
-                _log("ITM: default page changed — forcing page " + DefaultPage);
+                // Latch only on an accepted write — a declined PageSet retries next tick
+                // (the edge condition stays true until it lands).
+                if (_encoder.SetPage(_deviceId, DefaultPage))
+                {
+                    _lastPageApplied = DefaultPage;
+                    // Deliberately DON'T reseed here — keep the current subscriptions until the firmware
+                    // pushes the new page's set. Unlike bring-up (which has no prior state), a live switch
+                    // has valid subs to lose: if the PageSet flakes, or targets the page already shown (no
+                    // push comes back), a speculative reseed would strand the display on wrong-page handles
+                    // with nothing to correct it. The existing subs stay valid for whatever is displayed.
+                    _log("ITM: default page changed — forcing page " + DefaultPage);
+                }
             }
 
             // Values only flow while a game is feeding telemetry: SimHub keeps the last

--- a/FanaBridge/FanatecPlugin.cs
+++ b/FanaBridge/FanatecPlugin.cs
@@ -76,9 +76,29 @@ namespace FanaBridge
         /// <summary>
         /// When true, device instances skip all LED and display output so the
         /// profile wizard can send probe signals without being overwritten by
-        /// SimHub's frame-by-frame updates.  Set by the wizard dialog.
+        /// SimHub's frame-by-frame updates.  Set by the wizard dialog (UI
+        /// thread), read by the device data loop — hence volatile.
         /// </summary>
-        public bool WizardActive { get; set; }
+        public bool WizardActive
+        {
+            get { return _wizardActive; }
+            set { _wizardActive = value; }
+        }
+        private volatile bool _wizardActive;
+
+        /// <summary>
+        /// When true, device instances skip driving the legacy 7-segment display
+        /// so the settings page's display test owns it (LEDs and the col03 ITM
+        /// display are unaffected). Set by the settings page (UI thread) on any
+        /// test send, released on Clear / Stop / page unload; read by the device
+        /// data loop — hence volatile.
+        /// </summary>
+        public bool DisplayTestActive
+        {
+            get { return _displayTestActive; }
+            set { _displayTestActive = value; }
+        }
+        private volatile bool _displayTestActive;
 
         /// <summary>Whether the Fanatec device is currently connected (for UI binding).</summary>
         public bool IsDeviceConnected => _connectionMonitor?.IsConnected == true;

--- a/FanaBridge/Protocol/DisplayEncoder.cs
+++ b/FanaBridge/Protocol/DisplayEncoder.cs
@@ -14,6 +14,11 @@ namespace FanaBridge.Protocol
         private readonly IDeviceTransport _transport;
 
         // ── Pooled buffers — avoid per-frame heap allocations ────────────
+        // Guarded by _sync: this encoder is shared between the frame thread
+        // (display driver) and UI-side callers (settings display test, finalize
+        // clear), and the transport lock only serializes the send — two callers
+        // interleaving buffer fills would put a torn frame on the wire.
+        private readonly object _sync = new object();
         private readonly byte[] _reportBuf = new byte[REPORT_LENGTH];
         private readonly byte[] _textSegs = new byte[3];
 
@@ -28,16 +33,19 @@ namespace FanaBridge.Protocol
         /// </summary>
         public bool SetDisplay(byte seg1, byte seg2, byte seg3)
         {
-            _reportBuf[0] = 0x01;  // Report ID
-            _reportBuf[1] = 0xF8;
-            _reportBuf[2] = 0x09;
-            _reportBuf[3] = 0x01;
-            _reportBuf[4] = 0x02;
-            _reportBuf[5] = seg1;
-            _reportBuf[6] = seg2;
-            _reportBuf[7] = seg3;
+            lock (_sync)
+            {
+                _reportBuf[0] = 0x01;  // Report ID
+                _reportBuf[1] = 0xF8;
+                _reportBuf[2] = 0x09;
+                _reportBuf[3] = 0x01;
+                _reportBuf[4] = 0x02;
+                _reportBuf[5] = seg1;
+                _reportBuf[6] = seg2;
+                _reportBuf[7] = seg3;
 
-            return _transport.SendCol01(_reportBuf);
+                return _transport.SendCol01(_reportBuf);
+            }
         }
 
         /// <summary>
@@ -101,27 +109,30 @@ namespace FanaBridge.Protocol
             if (string.IsNullOrEmpty(text))
                 return ClearDisplay();
 
-            int segCount = 0;
-            _textSegs[0] = SevenSegment.Blank;
-            _textSegs[1] = SevenSegment.Blank;
-            _textSegs[2] = SevenSegment.Blank;
-
-            foreach (char ch in text)
+            lock (_sync)
             {
-                if ((ch == '.' || ch == ',') && segCount > 0)
+                int segCount = 0;
+                _textSegs[0] = SevenSegment.Blank;
+                _textSegs[1] = SevenSegment.Blank;
+                _textSegs[2] = SevenSegment.Blank;
+
+                foreach (char ch in text)
                 {
-                    _textSegs[segCount - 1] |= SevenSegment.Dot;
-                }
-                else
-                {
-                    _textSegs[segCount] = SevenSegment.CharToSegment(ch);
-                    segCount++;
+                    if ((ch == '.' || ch == ',') && segCount > 0)
+                    {
+                        _textSegs[segCount - 1] |= SevenSegment.Dot;
+                    }
+                    else
+                    {
+                        _textSegs[segCount] = SevenSegment.CharToSegment(ch);
+                        segCount++;
+                    }
+
+                    if (segCount >= 3) break;
                 }
 
-                if (segCount >= 3) break;
+                return SetDisplay(_textSegs[0], _textSegs[1], _textSegs[2]);
             }
-
-            return SetDisplay(_textSegs[0], _textSegs[1], _textSegs[2]);
         }
     }
 }

--- a/FanaBridge/Protocol/LedEncoder.cs
+++ b/FanaBridge/Protocol/LedEncoder.cs
@@ -39,9 +39,16 @@ namespace FanaBridge.Protocol
 
         // ── Dirty tracking — skip redundant HID writes ───────────────────
         // Color tracking keyed by subcmd; missing entry = dirty (forces send).
+        // Only ever touched from send paths: ForceDirty is called cross-thread
+        // (WheelChanged can fire from the settings UI while a driver send task is
+        // in flight), so it must not mutate this dictionary directly — a concurrent
+        // Clear against TryGetValue/insert corrupts it on net48.
         private readonly Dictionary<byte, ushort[]> _lastColors = new Dictionary<byte, ushort[]>();
         // Button intensity tracking (separate: unique staging protocol, byte[] payload)
         private byte[] _lastIntensities;
+        // Set by ForceDirty (any thread), consumed at the top of each send path
+        // (sender thread) — see ForceDirty.
+        private volatile bool _forceDirty;
 
         // ── Pooled report buffer — avoid per-frame heap allocations ──────
         private readonly byte[] _reportBuf = new byte[REPORT_LENGTH];
@@ -70,6 +77,8 @@ namespace FanaBridge.Protocol
 
             using (_transport.BeginBatch())
             {
+                ConsumePendingForceDirty();
+
                 bool hasColors = colors != null && colors.Length > 0;
                 int ledCount = hasColors ? colors.Length : 0;
 
@@ -163,9 +172,21 @@ namespace FanaBridge.Protocol
         /// Marks LED state as dirty so the next send always writes to hardware.
         /// Call when the physical wheel changes — firmware resets LED state
         /// but our tracking arrays still hold the previous instance's output.
+        /// Safe from any thread: sets a flag consumed on the sender's own thread,
+        /// so the tracking state is never mutated concurrently with a send.
         /// </summary>
         public void ForceDirty()
         {
+            _forceDirty = true;
+        }
+
+        // Applies a pending ForceDirty on the sender's thread, before the dirty
+        // check. If ForceDirty lands mid-send, the flag simply stays set for the
+        // next send — a forced resend is never lost.
+        private void ConsumePendingForceDirty()
+        {
+            if (!_forceDirty) return;
+            _forceDirty = false;
             _lastColors.Clear();
             _lastIntensities = null;
         }
@@ -182,6 +203,8 @@ namespace FanaBridge.Protocol
         {
             int count = colors.Length;
             if (count == 0 || count > MAX_RGB565_PER_REPORT) return false;
+
+            ConsumePendingForceDirty();
 
             // Dirty check: missing entry or size mismatch forces a send
             ushort[] last;

--- a/FanaBridge/Protocol/LedEncoder.cs
+++ b/FanaBridge/Protocol/LedEncoder.cs
@@ -32,8 +32,12 @@ namespace FanaBridge.Protocol
         /// Total bytes in the subcmd 0x03 intensity payload.
         /// Includes per-button intensity slots plus additional slots whose
         /// meaning varies by wheel (e.g. encoder indicator LEDs).
+        /// Derived from the commit offset: the payload occupies report offsets
+        /// 3..17 and the commit flag sits at offset 18, immediately after it —
+        /// a 16th slot would be overwritten by the commit byte on every send,
+        /// so the two constants must never drift apart.
         /// </summary>
-        public const int INTENSITY_PAYLOAD_SIZE = 16;
+        public const int INTENSITY_PAYLOAD_SIZE = BUTTON_INTENSITY_COMMIT_OFFSET - HEADER_SIZE;  // 15
 
         private readonly IDeviceTransport _transport;
 

--- a/FanaBridge/Protocol/LegacyLedEncoder.cs
+++ b/FanaBridge/Protocol/LegacyLedEncoder.cs
@@ -39,6 +39,10 @@ namespace FanaBridge.Protocol
         private ushort _lastRevStripeColor = 0xFFFF;
         private uint _lastRev3BitPacked = 0xFFFFFFFF; // Sentinel for per-LED 3-bit rev
         private uint _lastFlag3BitPacked = 0xFFFFFFFF; // Sentinel for per-LED 3-bit flag
+        // Set by ForceDirty (any thread), consumed at the top of each send path on
+        // the sender's own thread — a ForceDirty landing mid-send must not be
+        // overwritten by that send's re-latch of the old state.
+        private volatile bool _forceDirty;
 
         // ── State tracking for enable sequences ────────────────────────────
         private bool _globalEnabled;
@@ -62,6 +66,8 @@ namespace FanaBridge.Protocol
         public bool SetLegacyRevOnOff(bool[] onOff)
         {
             if (onOff == null || onOff.Length == 0 || onOff.Length > 9) return false;
+
+            ConsumePendingForceDirty();
 
             // Pack the 9-LED bitmask in the wire's RGB333 bit order:
             //   byte[4] = LED0 (bit 0)
@@ -106,6 +112,8 @@ namespace FanaBridge.Protocol
         /// </summary>
         public bool SetRevStripeColor(ushort rgb333)
         {
+            ConsumePendingForceDirty();
+
             // Dirty check
             if (rgb333 == _lastRevStripeColor)
                 return true;
@@ -142,6 +150,8 @@ namespace FanaBridge.Protocol
         public bool SetLegacyRev3Bit(byte[] rgbBools)
         {
             if (rgbBools == null || rgbBools.Length == 0 || rgbBools.Length > 27) return false;
+
+            ConsumePendingForceDirty();
 
             // Pack 27 booleans into 4 bytes, LSB-first
             uint packed = 0;
@@ -187,6 +197,8 @@ namespace FanaBridge.Protocol
         public bool SetLegacyFlag3Bit(byte[] rgbBools)
         {
             if (rgbBools == null || rgbBools.Length == 0 || rgbBools.Length > 18) return false;
+
+            ConsumePendingForceDirty();
 
             // Pack 18 booleans into 4 bytes, LSB-first
             uint packed = 0;
@@ -244,10 +256,21 @@ namespace FanaBridge.Protocol
 
         /// <summary>
         /// Marks state as dirty so the next send always writes to hardware.
-        /// Call when the physical wheel changes.
+        /// Call when the physical wheel changes. Safe from any thread: sets a
+        /// flag consumed on the sender's own thread.
         /// </summary>
         public void ForceDirty()
         {
+            _forceDirty = true;
+        }
+
+        // Applies a pending ForceDirty on the sender's thread, before the dirty
+        // check. If ForceDirty lands mid-send, the flag stays set for the next
+        // send — a forced resend is never lost.
+        private void ConsumePendingForceDirty()
+        {
+            if (!_forceDirty) return;
+            _forceDirty = false;
             _lastBitmask = 0xFFFF;
             _lastRevStripeColor = 0xFFFF;
             _lastRev3BitPacked = 0xFFFFFFFF;

--- a/FanaBridge/UI/SettingsControl.xaml.cs
+++ b/FanaBridge/UI/SettingsControl.xaml.cs
@@ -1037,6 +1037,13 @@ namespace FanaBridge.UI
 
             StopScroll();
 
+            // Take ownership of the 7-segment display: with a game running, the
+            // per-frame gear/speed drive would otherwise overwrite the test text
+            // (and its buffer fills would race ours). StopScroll is the single
+            // release point (Clear / Stop Scroll / unload / disconnect all funnel
+            // through it) — the game driver then blanks and repaints live.
+            Plugin.DisplayTestActive = true;
+
             string text = txtDisplayTest.Text;
             if (string.IsNullOrEmpty(text)) text = "---";
 
@@ -1140,6 +1147,13 @@ namespace FanaBridge.UI
 
         private void StopScroll()
         {
+            // Single release point for display-test ownership: every way a test
+            // ends (Clear, Stop Scroll, a new Send, page unload, disconnect
+            // auto-stop) funnels through here. The device instance blanks and
+            // repaints the live gear/speed on the released edge.
+            if (Plugin != null)
+                Plugin.DisplayTestActive = false;
+
             if (_scrollTimer != null)
             {
                 _scrollTimer.Stop();

--- a/FanaBridge/UI/WheelProfileWizardDialog.xaml.cs
+++ b/FanaBridge/UI/WheelProfileWizardDialog.xaml.cs
@@ -639,7 +639,21 @@ namespace FanaBridge.UI
             // Build the LED list — or rebuild it if the color/mono counts changed
             // via Back-navigation (stale HwIndex values would mis-bind mappings);
             // an unchanged-count re-entry keeps the list and its captures.
-            mapping.EnsureLeds(_state.Color.Count, _state.Mono.Count);
+            // Clamp mono to the intensity payload capacity with the same rule
+            // BuildProfile applies, so the mapping step never walks the user
+            // through LEDs that can't light and won't survive into the profile.
+            int colorCount = _state.Color.Count;
+            int monoCount = _state.Mono.Count;
+            int maxMono = Math.Max(0, LedEncoder.INTENSITY_PAYLOAD_SIZE - colorCount);
+            if (monoCount > maxMono)
+            {
+                SimHub.Logging.Current.Warn(
+                    string.Format("WheelProfileWizard: Clamping mono LED count from {0} to {1} for mapping " +
+                                  "(colorCount={2} + monoCount must not exceed INTENSITY_PAYLOAD_SIZE={3})",
+                                  monoCount, maxMono, colorCount, LedEncoder.INTENSITY_PAYLOAD_SIZE));
+                monoCount = maxMono;
+            }
+            mapping.EnsureLeds(colorCount, monoCount);
 
             if (mapping.Leds.Count == 0)
             {

--- a/FanaBridge/UI/WheelProfileWizardDialog.xaml.cs
+++ b/FanaBridge/UI/WheelProfileWizardDialog.xaml.cs
@@ -626,30 +626,10 @@ namespace FanaBridge.UI
         {
             var mapping = _state.Mapping;
 
-            // Only build the LED list once (re-entering from Back keeps it)
-            if (mapping.Leds.Count == 0)
-            {
-                for (int i = 0; i < _state.Color.Count; i++)
-                {
-                    mapping.Leds.Add(new InputMappingEntry
-                    {
-                        Channel = LedChannel.ButtonRgb,
-                        HwIndex = i,
-                        Label = "Color LED " + (i + 1),
-                    });
-                }
-
-                int monoStart = _state.Color.Count;
-                for (int i = 0; i < _state.Mono.Count; i++)
-                {
-                    mapping.Leds.Add(new InputMappingEntry
-                    {
-                        Channel = LedChannel.ButtonAuxIntensity,
-                        HwIndex = monoStart + i,
-                        Label = "Mono LED " + (i + 1),
-                    });
-                }
-            }
+            // Build the LED list — or rebuild it if the color/mono counts changed
+            // via Back-navigation (stale HwIndex values would mis-bind mappings);
+            // an unchanged-count re-entry keeps the list and its captures.
+            mapping.EnsureLeds(_state.Color.Count, _state.Mono.Count);
 
             if (mapping.Leds.Count == 0)
             {

--- a/FanaBridge/UI/WheelProfileWizardDialog.xaml.cs
+++ b/FanaBridge/UI/WheelProfileWizardDialog.xaml.cs
@@ -45,6 +45,7 @@ namespace FanaBridge.UI
         private volatile CancellationTokenSource _probeCts;
         private volatile CancellationTokenSource _blinkCts;
         private readonly ManualResetEventSlim _blinkDone = new ManualResetEventSlim(true);
+        private readonly ManualResetEventSlim _probeBlinkDone = new ManualResetEventSlim(true);
         private bool _listeningForInput;
         private Action<string> _inputHandler;
         private DispatcherTimer _classifyTimer;
@@ -342,6 +343,7 @@ namespace FanaBridge.UI
                 intensities[i] = 7;
             SetAllLeds(buttonIntensities: intensities);
 
+            _probeBlinkDone.Reset();
             ThreadPool.QueueUserWorkItem(_ =>
             {
                 try
@@ -366,6 +368,10 @@ namespace FanaBridge.UI
                     }
                 }
                 catch { /* device disconnect */ }
+                finally
+                {
+                    _probeBlinkDone.Set();
+                }
             });
         }
 
@@ -377,6 +383,10 @@ namespace FanaBridge.UI
                 cts.Cancel();
                 _probeCts = null;
             }
+            // Wait for the blink worker to finish so a write that slipped past the
+            // token check can't land a full-intensity frame after the next section's
+            // probe has already painted — the exact join CancelBlink already does.
+            _probeBlinkDone.Wait(500);
         }
 
         // ── Color-format sub-test ────────────────────────────────────────

--- a/FanaBridge/UI/WizardState.cs
+++ b/FanaBridge/UI/WizardState.cs
@@ -135,6 +135,75 @@ namespace FanaBridge.UI
 
         public bool IsComplete => CurrentIndex >= Leds.Count;
         public int MappedCount => Leds.Count(m => m.HasAny);
+
+        // The counts the Leds list was built from; -1 = never built. Back-navigation
+        // can change either count, and stale entries carry HwIndex values derived
+        // from the old color count — the profile-build join would then bind inputs
+        // to the wrong LEDs, silently drop mappings, and leave newly added LEDs
+        // unmappable.
+        private int _builtColorCount = -1;
+        private int _builtMonoCount = -1;
+
+        /// <summary>
+        /// Builds the LED list for the given counts, or rebuilds it when the counts
+        /// changed since the last build (Back-navigation into a discovery section).
+        /// An unchanged-count re-entry keeps the list — and its captured mappings —
+        /// untouched. On rebuild, captures carry over by channel + ordinal (mono
+        /// HwIndex values shift with the color count), so shrinking or growing one
+        /// section preserves every mapping that still has a matching LED.
+        /// </summary>
+        public void EnsureLeds(int colorCount, int monoCount)
+        {
+            if (_builtColorCount == colorCount && _builtMonoCount == monoCount)
+                return;
+
+            // Carry existing captures over by (channel, ordinal-within-channel).
+            var oldColor = Leds.Where(m => m.Channel == LedChannel.ButtonRgb).ToList();
+            var oldMono = Leds.Where(m => m.Channel == LedChannel.ButtonAuxIntensity).ToList();
+
+            Leds.Clear();
+            for (int i = 0; i < colorCount; i++)
+            {
+                var entry = new InputMappingEntry
+                {
+                    Channel = LedChannel.ButtonRgb,
+                    HwIndex = i,
+                    Label = "Color LED " + (i + 1),
+                };
+                if (i < oldColor.Count) CopyCapture(oldColor[i], entry);
+                Leds.Add(entry);
+            }
+            for (int i = 0; i < monoCount; i++)
+            {
+                var entry = new InputMappingEntry
+                {
+                    Channel = LedChannel.ButtonAuxIntensity,
+                    HwIndex = colorCount + i,
+                    Label = "Mono LED " + (i + 1),
+                };
+                if (i < oldMono.Count) CopyCapture(oldMono[i], entry);
+                Leds.Add(entry);
+            }
+
+            _builtColorCount = colorCount;
+            _builtMonoCount = monoCount;
+
+            // Reset the mini state machine: resume at the first unmapped LED (or
+            // the end when everything carried over) — never a stale index/phase.
+            Phase = MappingPhase.WaitingForInput;
+            ClassifyInputs.Clear();
+            int firstUnmapped = Leds.FindIndex(m => !m.HasAny);
+            CurrentIndex = firstUnmapped >= 0 ? firstUnmapped : Leds.Count;
+        }
+
+        private static void CopyCapture(InputMappingEntry from, InputMappingEntry to)
+        {
+            to.IsEncoder = from.IsEncoder;
+            to.ButtonInputId = from.ButtonInputId;
+            to.RelativeCW = from.RelativeCW;
+            to.RelativeCCW = from.RelativeCCW;
+            to.AbsoluteInputs = from.AbsoluteInputs;
+        }
     }
 
     // ── Main wizard state ────────────────────────────────────────────────


### PR DESCRIPTION
First batch of fixes from a reliability review of v0.5.0. Six independent fixes; full suite is green (413 tests, +20 new).

## 1. ITM: retry declined bring-up, PageSet, and ParamDefs writes (`ace59e4`)

Bring-up latched `Phase.Running` without checking whether `SetItmMode`/`EnableItm`/`SetPage` were accepted by the transport. A single declined write during rim-attach settling — exactly when bring-up fires — left the driver streaming values at a display that never started a session, unrecoverable short of a reconnect or a manual ITM off/on toggle.

ParamDefs had the mirror-image gap: the suffix signature was latched *before* the unchecked send, so a declined decoration write was never retried until the suffix set happened to change. Since suffixes are the one ITM output with no per-tick retry, this is the strongest code-level candidate so far for the long-standing "suffixes intermittently missing after bring-up" symptom.

Bring-up now advances step-by-step on acceptance (accepted steps are not re-sent), the live page switch latches only on an accepted PageSet, and ParamDefs latches its signature only on an accepted send (a declined double-tap keeps its due time).

## 2. LED `ForceDirty` made thread-safe (`c1a5dce`)

`ForceDirty` cleared the dirty-tracking `Dictionary` directly, but it can run on the settings UI thread (profile change/delete fires `WheelChanged` synchronously) while an LED write task reads/inserts the same dictionary on a pool thread. On net48 a concurrent `Clear` can corrupt the dictionary — worst case a non-terminating lookup that permanently wedges the LED pipeline's in-flight task, silently dropping every later frame. Milder flavor in both encoders: an in-flight send re-latching pre-clear state, losing the forced resend so a freshly swapped rim stays dark/stale.

`ForceDirty` now sets a volatile flag consumed at the top of each send path on the sender's own thread. A `ForceDirty` landing mid-send stays pending for the next send instead of being lost.

## 3. Intensity payload can no longer collide with the commit flag (`1aec6d6`)

The subcmd 0x03 payload was declared 16 bytes (offsets 3..18) but the staged-commit flag is written at offset 18 — the 16th slot was overwritten with `0x01` on every send, while dirty tracking recorded the intended value as delivered. Latent (shipped profiles top out at slot 14), but the wizard's clamp allowed authoring a 16-slot layout. `INTENSITY_PAYLOAD_SIZE` is now derived from the commit offset (15 bytes) so the constants can't drift; the driver and wizard all size from the constant, including the wizard's mono-count clamp.

## 4. Wizard: rebuild the mapping list when LED counts change via Back (`3296668`)

Going Back from Input Mapping to correct a color/mono count and re-entering reused the stale LED list, whose mono `HwIndex` values were derived from the old color count. The profile builder's channel+HwIndex join then silently bound inputs to the wrong LEDs, dropped mappings, and made newly added LEDs unmappable — in a structurally valid profile, so nothing looked wrong. `InputMappingState` now records the counts the list was built from, rebuilds on change, and carries captures over by channel+ordinal. The build logic moved into the state class where it's unit-testable.

## 5. Wizard: join the mono-probe blink worker on cancel (`5f3345e`)

`CancelProbeBlink` cancelled and returned; a write slipping past the token check could land a full-intensity frame after the next section's probe had painted — and with production output suspended for the wizard session, the stale all-lit pattern persisted through the exact "count the lit LEDs" moment. Now mirrors the join the mapping blink already had (done-event signaled from `finally`, bounded 500 ms wait).

## 6. The display test now owns the 7-segment display while active (`cdd906c`)

With a game running, the display test and the per-frame gear/speed driver fought over the display: test text was overwritten on every value change, and because both callers fill `DisplayEncoder`'s shared pooled buffer before the transport lock serializes the send, the scroll timer's pool thread interleaving with the frame thread could put a torn frame on the wire (which then persisted until the next value change, since the driver latches intended values on success).

`DisplayEncoder` now fills and sends under one lock; a volatile `FanatecPlugin.DisplayTestActive` flag suppresses only the legacy col01 drive while a test is active (LEDs and the col03 ITM display are unaffected), with `StopScroll` as the single release funnel (Clear / Stop Scroll / a new Send / page unload / disconnect auto-stop). On release the device instance blanks the residue via `Clear()`, whose latch reset makes live gear/speed repaint immediately. `WizardActive` is now volatile too (same cross-thread pattern).

---

New coverage: 5 ITM acceptance-retry tests, 8 LedEncoder tests (wire layout of the payload/commit boundary + ForceDirty contract), 7 WizardState rebuild tests.

Hands-on checks worth doing before merge: an ITM bring-up + suffix session, and the display test with a game feeding telemetry (test text should hold; live gear/speed should return immediately on Clear/Stop).