### PR TITLE
Build hygiene: unified C# dialect, editorconfig, test-project nullable, CI coverage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,57 @@
+# Top-most EditorConfig file for FanaBridge.
+# Deliberately conservative: encodes the style the codebase already uses so
+# IDEs and CI agree going forward, without forcing churn on existing files.
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.{csproj,props,targets,xaml}]
+indent_size = 2
+
+[*.md]
+# Trailing spaces are meaningful (hard line breaks).
+trim_trailing_whitespace = false
+
+[*.cs]
+# ── New-line / brace style (Allman, as used throughout) ──────────────
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+
+# ── Namespaces / usings ──────────────────────────────────────────────
+# The codebase uses block-scoped namespaces; keep new files consistent.
+csharp_style_namespace_declarations = block_scoped:suggestion
+dotnet_sort_system_directives_first = true
+
+# ── this. / var ──────────────────────────────────────────────────────
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:silent
+
+# ── Naming: private fields are _camelCase, constants ALL_CAPS-tolerant ──
+dotnet_naming_rule.private_fields_underscore.symbols = private_fields
+dotnet_naming_rule.private_fields_underscore.style = underscore_camel
+dotnet_naming_rule.private_fields_underscore.severity = suggestion
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_fields.required_modifiers =
+dotnet_naming_style.underscore_camel.capitalization = camel_case
+dotnet_naming_style.underscore_camel.required_prefix = _
+
+# ── Modifier / expression preferences (match existing idiom) ─────────
+dotnet_style_readonly_field = true:suggestion
+csharp_prefer_braces = when_multiline:silent
+csharp_style_expression_bodied_methods = when_on_single_line:silent
+csharp_style_expression_bodied_properties = when_on_single_line:silent

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,45 @@ jobs:
           & $Exe @Args
 
       - name: Test
-        run: dotnet test FanaBridge.Tests\FanaBridge.Tests.csproj --no-build -c ${{ inputs.configuration }} --verbosity normal
+        run: >-
+          dotnet test FanaBridge.Tests\FanaBridge.Tests.csproj --no-build
+          -c ${{ inputs.configuration }} --verbosity normal
+          --logger "trx;LogFileName=test-results.trx"
+          --collect "XPlat Code Coverage"
+          --results-directory TestResults
+
+      - name: Coverage summary
+        if: always()
+        shell: pwsh
+        run: |
+          # Surface line/branch coverage in the job summary without any
+          # external service. Cobertura XML is produced by coverlet.collector.
+          $Report = Get-ChildItem TestResults -Recurse -Filter 'coverage.cobertura.xml' |
+            Select-Object -First 1
+          if (-not $Report) {
+            Write-Host 'No coverage report found.'
+            exit 0
+          }
+          [xml]$Xml = Get-Content $Report.FullName
+          $LineRate = [math]::Round([double]$Xml.coverage.'line-rate' * 100, 1)
+          $BranchRate = [math]::Round([double]$Xml.coverage.'branch-rate' * 100, 1)
+          @(
+            '### Test coverage (FanaBridge.dll)',
+            '',
+            "| Lines | Branches |",
+            "|-------|----------|",
+            "| $LineRate% | $BranchRate% |"
+          ) | Add-Content $env:GITHUB_STEP_SUMMARY
+          Write-Host "Line coverage: $LineRate%  Branch coverage: $BranchRate%"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ inputs.artifact-label }}
+          path: TestResults/
+          retention-days: 30
+          if-no-files-found: ignore
 
       - name: Package artifact
         id: package

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,12 @@
 <Project>
   <PropertyGroup>
+    <!-- One compiler dialect for every project (the plugin previously pinned 8.0
+         while the test project silently defaulted to 7.3). net48 is a runtime
+         target — modern C# compiles fine against it except for features that
+         need runtime support (default interface members; records/init need the
+         IsExternalInit shim). -->
+    <LangVersion>latest</LangVersion>
+
     <!-- Single source of truth for product versioning. -->
     <VersionPrefix>0.5.0</VersionPrefix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>

--- a/FanaBridge.Tests/ControlMapperBridgeTests.cs
+++ b/FanaBridge.Tests/ControlMapperBridgeTests.cs
@@ -22,7 +22,7 @@ namespace FanaBridge.Tests
     public class ControlMapperBridgeTests
     {
         private static (ControlMapperBridge bridge, FakePluginManager pm, FakeVariantHelper helper, FakeRemapperWorker worker)
-            NewSetup(bool listInitialized = true, IVariantProvider stock = null)
+            NewSetup(bool listInitialized = true, IVariantProvider? stock = null)
         {
             IFakeControlMapper cm = CmFake.NewPlugin();
             if (listInitialized)
@@ -238,7 +238,7 @@ namespace FanaBridge.Tests
             var (bridge, pm, helper, worker) = NewSetup(stock: stock);
             Assert.True(bridge.EnsureRegistered(pm));
 
-            var cm = (IFakeControlMapper)pm.Plugin;
+            var cm = (IFakeControlMapper)pm.Plugin!;
             // A configured Fanatec source (what the user added in Control Mapper).
             cm.Settings.ControllerMappings.Add(new FakeControllerSourceMapping
             {
@@ -271,7 +271,7 @@ namespace FanaBridge.Tests
         public void IsRecognizeIndividualWheelsOn_ReflectsTheSetting()
         {
             var (bridge, pm, helper, worker) = NewSetup(stock: new FakeStockProvider("x"));
-            var cm = (IFakeControlMapper)pm.Plugin;
+            var cm = (IFakeControlMapper)pm.Plugin!;
 
             cm.Settings.RecognizeIndiviualWheels = true;
             Assert.True(bridge.IsRecognizeIndividualWheelsOn(pm));
@@ -351,7 +351,7 @@ namespace FanaBridge.Tests.CmFakes
         /// <summary>Invoked inside UpdateControllerList to model SimHub's synchronous
         /// Dispatcher.Invoke to the UI thread — used to assert the bridge isn't holding
         /// <c>_sync</c> while it re-enumerates (see the deadlock regression tests).</summary>
-        public System.Action OnUpdate;
+        public System.Action? OnUpdate;
         internal void UpdateControllerList()
         {
             UpdateControllerListCalls++;
@@ -365,11 +365,11 @@ namespace FanaBridge.Tests.CmFakes
     /// private <c>VariantProviders</c> list the bridge swaps.</summary>
     public class FakeVariantHelper
     {
-        private List<IVariantProvider> VariantProviders;
+        private List<IVariantProvider>? VariantProviders;
 
         public void InitList() => VariantProviders = new List<IVariantProvider>();
         public void NullList() => VariantProviders = null;
-        public List<IVariantProvider> Snapshot() => VariantProviders;
+        public List<IVariantProvider> Snapshot() => VariantProviders!;
         public void ResetToStockOnly(IVariantProvider stock)
             => VariantProviders = new List<IVariantProvider> { stock };
     }
@@ -388,11 +388,11 @@ namespace FanaBridge.Tests.CmFakes
     /// <c>GetPlugin&lt;T&gt;()</c> the bridge invokes by reflection.</summary>
     public class FakePluginManager
     {
-        private readonly object _plugin;
-        public FakePluginManager(object plugin) { _plugin = plugin; }
-        public T GetPlugin<T>() => (T)_plugin;
+        private readonly object? _plugin;
+        public FakePluginManager(object? plugin) { _plugin = plugin; }
+        public T GetPlugin<T>() => (T)_plugin!;
         /// <summary>Test-only accessor to the wrapped fake plugin.</summary>
-        public object Plugin => _plugin;
+        public object? Plugin => _plugin;
     }
 
     /// <summary>A PluginManager that lacks GetPlugin&lt;T&gt;(), to drive the
@@ -407,14 +407,14 @@ namespace FanaBridge.Tests.CmFakes
     {
         public int VendorID { get; set; }
         public int ProductId { get; set; }
-        public string ControllerName { get; set; }
-        public string Variant { get; set; }
+        public string? ControllerName { get; set; }
+        public string? Variant { get; set; }
     }
 
     /// <summary>Test double for ControllerSourceMapping (owns one description).</summary>
     public class FakeControllerSourceMapping
     {
-        public FakeControllerDescription ControllerDescription { get; set; }
+        public FakeControllerDescription? ControllerDescription { get; set; }
     }
 
     /// <summary>Mirrors the shape DescribeResolution reflects into:

--- a/FanaBridge.Tests/FanaBridge.Tests.csproj
+++ b/FanaBridge.Tests/FanaBridge.Tests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <IsPackable>false</IsPackable>
+    <!-- Nullable annotations start here (our own code, no unannotated SimHub
+         API pressure); production files opt in per-file as they are touched. -->
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FanaBridge.Tests/FanaBridge.Tests.csproj
+++ b/FanaBridge.Tests/FanaBridge.Tests.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FanaBridge.Tests/FanaBridgeVariantProviderTests.cs
+++ b/FanaBridge.Tests/FanaBridgeVariantProviderTests.cs
@@ -23,7 +23,7 @@ namespace FanaBridge.Tests
         [InlineData("PHUB", "PBME", "FS_WHEEL_SWTYPE_PHUB_PBME")]
         [InlineData("PHUB", "PBMR", "FS_WHEEL_SWTYPE_PHUB_PBMR")]
         [InlineData("CSSWFORMV3", null, "FS_WHEEL_SWTYPE_CSSWFORMV3")] // newer wheel stock never knew, emitted as-is
-        public void FormatStockVariant_BuildsStockCompatibleId(string wheel, string module, string expected)
+        public void FormatStockVariant_BuildsStockCompatibleId(string wheel, string? module, string expected)
             => Assert.Equal(expected, FanaBridgeVariantProvider.FormatStockVariant(wheel, module));
 
         [Fact]
@@ -34,7 +34,7 @@ namespace FanaBridge.Tests
         [Theory]
         [InlineData(null, null)]
         [InlineData("", "PBMR")]
-        public void FormatStockVariant_NoWheelCode_ReturnsNull(string wheel, string module)
+        public void FormatStockVariant_NoWheelCode_ReturnsNull(string? wheel, string? module)
             => Assert.Null(FanaBridgeVariantProvider.FormatStockVariant(wheel, module));
 
         // ── friendly display name (applied as CustomName) ────────────────
@@ -42,13 +42,13 @@ namespace FanaBridge.Tests
         [InlineData("PHUB", "PBMR", "Podium Hub + Button Module Rally")]
         [InlineData("PHUB", "PBME", "Podium Hub + Button Module Endurance")]
         [InlineData("PSWBMW", null, "Podium BMW M4 GT3")]
-        public void FormatFriendlyName_UsesTableNames(string wheel, string module, string expected)
+        public void FormatFriendlyName_UsesTableNames(string wheel, string? module, string expected)
             => Assert.Equal(expected, FanaBridgeVariantProvider.FormatFriendlyName(wheel, module));
 
         [Theory]
         [InlineData("ZZWHEEL", null, "ZZWHEEL")]
         [InlineData("ZZWHEEL", "ZZMOD", "ZZWHEEL + ZZMOD")]
-        public void FormatFriendlyName_UnknownCodes_FallBackToRawCode(string wheel, string module, string expected)
+        public void FormatFriendlyName_UnknownCodes_FallBackToRawCode(string wheel, string? module, string expected)
             => Assert.Equal(expected, FanaBridgeVariantProvider.FormatFriendlyName(wheel, module));
 
         [Fact]

--- a/FanaBridge.Tests/FanatecTuningControllerTests.cs
+++ b/FanaBridge.Tests/FanatecTuningControllerTests.cs
@@ -166,7 +166,7 @@ namespace FanaBridge.Tests
             var transport = new StubTransport();
             transport.ReadQueue.Enqueue(FakeReadResponse(0xFE)); // not a valid EncoderMode
 
-            string lastWarn = null;
+            string? lastWarn = null;
             var controller = new FanatecTuningController(transport, logWarn: msg => lastWarn = msg);
             var result = controller.ReadEncoderMode();
 

--- a/FanaBridge.Tests/HidReportQueueTests.cs
+++ b/FanaBridge.Tests/HidReportQueueTests.cs
@@ -214,7 +214,7 @@ namespace FanaBridge.Tests
         public void Tap_ObserverGetsCopy_ConsumerStillGetsFrame()
         {
             var queue = new HidReportQueue(16);
-            byte[] observed = null;
+            byte[]? observed = null;
             using (queue.Tap(f => observed = f))
             {
                 queue.Enqueue(Report(0xAB, 0xCD), 2);

--- a/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -22,7 +22,7 @@ namespace FanaBridge.Tests
             // Simulate a transport-level send failure (SendCol03 returns false).
             public bool SendReturns { get; set; } = true;
             // Optional per-frame accept/decline decision (null = use SendReturns).
-            public Func<byte[], bool> Decide { get; set; }
+            public Func<byte[], bool>? Decide { get; set; }
 
             public bool SendCol03(byte[] data)
             {
@@ -112,7 +112,7 @@ namespace FanaBridge.Tests
             Enable(driver, clock);
 
             Assert.True(driver.IsRunning);
-            Assert.Single(t.Sent.Where(IsEnable));
+            Assert.Single(t.Sent, IsEnable);
         }
 
         [Fact]

--- a/FanaBridge.Tests/ItmEncoderTests.cs
+++ b/FanaBridge.Tests/ItmEncoderTests.cs
@@ -300,7 +300,7 @@ namespace FanaBridge.Tests
 
         [Theory]
         [InlineData(null)]
-        public void SendValues_NullList_ReturnsFalse(IReadOnlyList<ItmValue> values)
+        public void SendValues_NullList_ReturnsFalse(IReadOnlyList<ItmValue>? values)
         {
             var encoder = MakeEncoder(out var t);
             Assert.False(encoder.SendValues(values));

--- a/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -460,7 +460,7 @@ namespace FanaBridge.Tests
             foreach (var g in relGaps)
             {
                 var opp = FormatterServices.GetUninitializedObject(OpponentType);
-                setter.Invoke(opp, new object[] { g });
+                setter.Invoke(opp, new object?[] { g });
                 list.Add(opp);
             }
             return list;

--- a/FanaBridge.Tests/LedChannelConverterTests.cs
+++ b/FanaBridge.Tests/LedChannelConverterTests.cs
@@ -9,7 +9,7 @@ namespace FanaBridge.Tests
         private static LedChannel Deserialize(string channelName)
         {
             string json = "{\"channel\":\"" + channelName + "\",\"hwIndex\":0,\"role\":\"rev\",\"label\":\"test\"}";
-            return JsonConvert.DeserializeObject<LedDefinition>(json).Channel;
+            return JsonConvert.DeserializeObject<LedDefinition>(json)!.Channel;
         }
 
         // ── V2 names (standard enum parse) ────────────────────────────

--- a/FanaBridge.Tests/ReportElicitTests.cs
+++ b/FanaBridge.Tests/ReportElicitTests.cs
@@ -50,7 +50,7 @@ namespace FanaBridge.Tests
 
             private sealed class Scope : IDisposable
             {
-                private StubTransport _t;
+                private StubTransport? _t;
                 public Scope(StubTransport t) { _t = t; }
                 public void Dispose() { if (_t != null) { _t._batchDepth--; _t = null; } }
             }

--- a/FanaBridge.Tests/SimHubEnumSnapshotTests.cs
+++ b/FanaBridge.Tests/SimHubEnumSnapshotTests.cs
@@ -27,7 +27,7 @@ namespace FanaBridge.Tests
         {
             string simHubDir = Assembly.GetExecutingAssembly()
                 .GetCustomAttributes<AssemblyMetadataAttribute>()
-                .FirstOrDefault(a => a.Key == "SimHubDir")?.Value;
+                .FirstOrDefault(a => a.Key == "SimHubDir")?.Value ?? "";
             Assert.False(string.IsNullOrWhiteSpace(simHubDir), "SimHubDir assembly metadata missing from test assembly.");
 
             string dllPath = Path.Combine(simHubDir, DllName);

--- a/FanaBridge.Tests/WheelProfileStoreTests.cs
+++ b/FanaBridge.Tests/WheelProfileStoreTests.cs
@@ -34,7 +34,7 @@ namespace FanaBridge.Tests
         [InlineData(null)]
         [InlineData("")]
         [InlineData("SOME_FUTURE_WHEEL")]
-        public void NormalizeWheelType_PassesThrough_UnknownValues(string wheelType)
+        public void NormalizeWheelType_PassesThrough_UnknownValues(string? wheelType)
         {
             Assert.Equal(wheelType, WheelProfileStore.NormalizeWheelType(wheelType));
         }
@@ -49,7 +49,7 @@ namespace FanaBridge.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void FindByWheelType_ReturnsNull_ForNullOrEmptyWheel(string wheelType)
+        public void FindByWheelType_ReturnsNull_ForNullOrEmptyWheel(string? wheelType)
         {
             Assert.Null(WheelProfileStore.FindByWheelType(wheelType));
         }

--- a/FanaBridge/FanaBridge.csproj
+++ b/FanaBridge/FanaBridge.csproj
@@ -8,7 +8,6 @@
     <Description>Fanatec wheel LED and display control plugin for SimHub</Description>
     <Product>FanaBridge</Product>
     <Copyright>Copyright (c) 2026</Copyright>
-    <LangVersion>8.0</LangVersion>
     <ProjectGuid>{77D40755-B5B5-4C53-BD35-1CDEF35AF422}</ProjectGuid>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
Infrastructure batch preceding the test-seams work. Three independent commits; solution builds with 0 warnings and all 414 tests pass.

## What's here

- **One C# dialect (`21add20`).** The plugin pinned `LangVersion` 8.0 while the test project silently compiled as C# 7.3 (the net48 SDK default) — an inconsistency nobody chose. `Directory.Build.props` now sets `latest` for both. net48 is a runtime target, not a compiler ceiling; the only real exclusions are features needing runtime support (default interface members; records/`init` want the `IsExternalInit` shim).
- **`.editorconfig` baseline (same commit).** Deliberately conservative — encodes the style the codebase already uses (Allman, block namespaces, `_camelCase` private fields, `var` when apparent) so IDEs and tooling agree going forward. No reformatting of existing files.
- **Nullable reference types in the test project (`34eb2aa`).** Tests are entirely our own code, so they lead the adoption; production files opt in per-file as they're touched. All 30 resulting warnings triaged mechanically — annotations on test doubles and theory parameters only, runtime types unchanged (the reflection-based Control Mapper fakes are unaffected). Also fixes the two pre-existing xUnit2031 lint hits.
- **CI coverage + test results (`156f693`).** `dotnet test` now emits a trx log and Cobertura coverage via `coverlet.collector`; both upload as a workflow artifact and line/branch coverage lands in the job summary. Validated locally: **35.1% line / 32.4% branch** — matching the known shape (protocol layer well covered; transport/orchestration/UI not), and giving the upcoming test-seams PR a visible baseline to move.

## Deliberately out of scope

Analyzers (`Microsoft.CodeAnalysis.NetAnalyzers`) and warnings-as-errors — those come after a triage pass, once the seams PR lands, so each step stays reviewable.