### PR TITLE
Test seams: wheelbase transport/clock injection, plugin-generation resolver, reader-loop interface

### DIFF
--- a/FanaBridge.Tests/FanatecTransportReaderTests.cs
+++ b/FanaBridge.Tests/FanatecTransportReaderTests.cs
@@ -37,6 +37,12 @@ namespace FanaBridge.Tests
                 return this;
             }
 
+            public ScriptedSource Timeout()
+            {
+                _steps.Enqueue(_ => throw new TimeoutException("scripted idle timeout"));
+                return this;
+            }
+
             public int Read(byte[] buffer, int offset, int count)
             {
                 // Script exhausted: treat as a persistent device failure so the
@@ -143,6 +149,26 @@ namespace FanaBridge.Tests
             // blocked elicit during teardown instead of deadlocking it.
             var dest = new byte[64];
             Assert.Equal(-1, q.Get(Col03Family.Tuning).TryRead(dest, 5_000));
+        }
+
+        [Fact]
+        public void IdleTimeouts_ParkAgain_WithoutFaultingOrCountingAsErrors()
+        {
+            // A timeout is the reader's normal idle state (~24 days at the
+            // configured window) — it must neither fault the reader nor spend
+            // the transient-error retry budget.
+            var (t, q) = NewSession();
+            var source = new ScriptedSource()
+                .Timeout().Timeout().Timeout().Timeout().Timeout().Timeout()
+                .Frame(IdentityFrame())
+                .Error(t.SignalStoppingForTest);
+
+            var identityFrames = new List<byte[]>();
+            using (q.Get(Col03Family.Identity).Tap(identityFrames.Add))
+                t.Col03ReadLoop(source, q, 64);
+
+            Assert.Single(identityFrames);       // still reading after 6 timeouts
+            Assert.False(t.ReaderFaultedForTest);
         }
 
         [Fact]

--- a/FanaBridge.Tests/FanatecTransportReaderTests.cs
+++ b/FanaBridge.Tests/FanatecTransportReaderTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using FanaBridge.Transport;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// Pins the col03 reader loop's concurrency invariants, which previously
+    /// existed only as comments: transient errors retry before faulting, an
+    /// intentional teardown never faults, and a stale session's reader can't
+    /// poison the current one. The loop runs synchronously on the test thread
+    /// against a scripted stream source.
+    /// </summary>
+    public class FanatecTransportReaderTests
+    {
+        // Scripted ICol03Source: each step either returns a frame, throws, or
+        // performs a side effect first (e.g. flagging teardown mid-loop).
+        private sealed class ScriptedSource : FanatecTransport.ICol03Source
+        {
+            private readonly Queue<Func<byte[], int>> _steps = new Queue<Func<byte[], int>>();
+            public int ReadTimeout { set { } }
+
+            public ScriptedSource Frame(byte[] frame)
+            {
+                _steps.Enqueue(buf => { Array.Copy(frame, buf, frame.Length); return frame.Length; });
+                return this;
+            }
+
+            public ScriptedSource Error(Action beforeThrow = null)
+            {
+                _steps.Enqueue(_ =>
+                {
+                    beforeThrow?.Invoke();
+                    throw new System.IO.IOException("scripted read error");
+                });
+                return this;
+            }
+
+            public int Read(byte[] buffer, int offset, int count)
+            {
+                // Script exhausted: treat as a persistent device failure so the
+                // loop always terminates (tests never rely on this tail).
+                if (_steps.Count == 0) throw new System.IO.IOException("script exhausted");
+                return _steps.Dequeue()(buffer);
+            }
+        }
+
+        private static byte[] IdentityFrame()
+        {
+            var b = new byte[64];
+            b[0] = 0xFF; b[1] = 0x08;
+            return b;
+        }
+
+        private static (FanatecTransport t, Col03QueueSet q) NewSession()
+        {
+            var t = new FanatecTransport();
+            var q = new Col03QueueSet();
+            t.BeginReaderSessionForTest(q);
+            return (t, q);
+        }
+
+        [Fact]
+        public void TransientErrors_UnderRetryMax_Recover_WithoutFaulting()
+        {
+            var (t, q) = NewSession();
+            var source = new ScriptedSource()
+                .Frame(IdentityFrame())
+                .Error().Error().Error()                       // 3 < COL03_READ_RETRY_MAX
+                .Frame(IdentityFrame())                        // recovered
+                .Error(t.SignalStoppingForTest);               // clean exit tail
+
+            // Loop exit closes the queues (clearing them), so routing is observed
+            // through a non-consuming tap, as a live consumer would see it.
+            var identityFrames = new List<byte[]>();
+            using (q.Get(Col03Family.Identity).Tap(identityFrames.Add))
+                t.Col03ReadLoop(source, q, 64);
+
+            // Both frames made it through the hiccup, and the reader is healthy.
+            Assert.Equal(2, identityFrames.Count);
+            Assert.False(t.ReaderFaultedForTest);
+        }
+
+        [Fact]
+        public void PersistentErrors_FaultTheReader_SoIsConnectedReportsFalse()
+        {
+            var (t, q) = NewSession();
+            var source = new ScriptedSource();
+            for (int i = 0; i < FanatecTransport.COL03_READ_RETRY_MAX; i++)
+                source.Error();
+
+            t.Col03ReadLoop(source, q, 64);
+
+            // The fault flag is what drives IsConnected=false and, from there,
+            // the ConnectionMonitor's reconnect — input dead + writes alive is
+            // exactly the state this exists to escape.
+            Assert.True(t.ReaderFaultedForTest);
+        }
+
+        [Fact]
+        public void IntentionalTeardown_NeverFaults()
+        {
+            var (t, q) = NewSession();
+            // Disconnect sets the stopping flag BEFORE disposing the stream; the
+            // dispose is what wakes the parked read as an exception.
+            var source = new ScriptedSource().Error(t.SignalStoppingForTest);
+
+            t.Col03ReadLoop(source, q, 64);
+
+            Assert.False(t.ReaderFaultedForTest);
+        }
+
+        [Fact]
+        public void StaleSessionReader_CannotPoisonTheCurrentSession()
+        {
+            var (t, staleQueues) = NewSession();
+
+            // A new session replaces the queue set (as a reconnect does) while the
+            // old reader is still unwinding with persistent errors.
+            var currentQueues = new Col03QueueSet();
+            t.BeginReaderSessionForTest(currentQueues);
+
+            var source = new ScriptedSource();
+            for (int i = 0; i < FanatecTransport.COL03_READ_RETRY_MAX; i++)
+                source.Error();
+
+            t.Col03ReadLoop(source, staleQueues, 64);   // the STALE session's loop
+
+            // The stale reader must exit without flagging the fresh session dead.
+            Assert.False(t.ReaderFaultedForTest);
+        }
+
+        [Fact]
+        public void LoopExit_ClosesItsQueues_WakingBlockedConsumers()
+        {
+            var (t, q) = NewSession();
+            var source = new ScriptedSource().Error(t.SignalStoppingForTest);
+
+            t.Col03ReadLoop(source, q, 64);
+
+            // A closed queue returns -1 immediately — this is what wakes a
+            // blocked elicit during teardown instead of deadlocking it.
+            var dest = new byte[64];
+            Assert.Equal(-1, q.Get(Col03Family.Tuning).TryRead(dest, 5_000));
+        }
+
+        [Fact]
+        public void Frames_RouteByWireSignature_NotArrivalOrder()
+        {
+            var (t, q) = NewSession();
+            var itm = new byte[64]; itm[0] = 0xFF; itm[1] = 0x05;
+            var source = new ScriptedSource()
+                .Frame(itm)
+                .Frame(IdentityFrame())
+                .Error(t.SignalStoppingForTest);
+
+            var identityFrames = new List<byte[]>();
+            var itmFrames = new List<byte[]>();
+            using (q.Get(Col03Family.Identity).Tap(identityFrames.Add))
+            using (q.Get(Col03Family.Itm).Tap(itmFrames.Add))
+                t.Col03ReadLoop(source, q, 64);
+
+            Assert.Single(identityFrames);
+            Assert.Equal(0x08, identityFrames[0][1]);
+            Assert.Single(itmFrames);
+            Assert.Equal(0x05, itmFrames[0][1]);
+        }
+    }
+}

--- a/FanaBridge.Tests/FanatecTransportReaderTests.cs
+++ b/FanaBridge.Tests/FanatecTransportReaderTests.cs
@@ -27,7 +27,7 @@ namespace FanaBridge.Tests
                 return this;
             }
 
-            public ScriptedSource Error(Action beforeThrow = null)
+            public ScriptedSource Error(Action? beforeThrow = null)
             {
                 _steps.Enqueue(_ =>
                 {

--- a/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
+++ b/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FanaBridge;
+using FanaBridge.Adapters;
+using FanaBridge.Profiles;
+using FanaBridge.Protocol;
+using FanaBridge.Transport;
+using GameReaderCommon;
+using SimHub.Plugins.Devices;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// The issue-#37 transition matrix: how a DeviceInstance's state and driver
+    /// generation respond as the plugin singleton appears, matches, mismatches,
+    /// and is replaced. The original bug (game change → in-process plugin
+    /// restart → instances writing through a disposed transport) was hardware-
+    /// diagnosed and shipped with no regression tests; this pins the guard.
+    /// Runs against the PluginResolver seam plus a wheelbase built on the
+    /// injected-transport seam — no SimHub host, no hardware.
+    /// </summary>
+    public class FanatecWheelDeviceInstanceTests
+    {
+        // ── Wheelbase harness (same fakes as FanatecWheelbaseTests) ───────
+
+        private sealed class FakeTransport : IConnectableTransport
+        {
+            public bool Connected;
+            public FakeReportStream Identity { get; } = new FakeReportStream();
+            public bool Connect(int productId) { Connected = true; return true; }
+            public void Disconnect() => Connected = false;
+            public void Dispose() => Disconnect();
+            public bool IsConnected => Connected;
+            public bool IsDevicePresent => Connected;
+            public FanatecTransport.TransportConnectStatus LastConnectStatus =>
+                FanatecTransport.TransportConnectStatus.Connected;
+            public bool SendCol03(byte[] data) => true;
+            public bool SendCol01(byte[] data) => true;
+            public IReportStream IdentityReports => Identity;
+            public IReportStream ItmReports => FakeReportStream.Empty;
+            public IReportStream SrmReports => FakeReportStream.Empty;
+            public IReportStream TuningReports => FakeReportStream.Empty;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col03MaxInputReportLength => 64;
+            public int Col01MaxInputReportLength => 34;
+            public IDisposable BeginBatch() => new NoOp();
+            private sealed class NoOp : IDisposable { public void Dispose() { } }
+        }
+
+        private sealed class FakeBus : IHidBusEnumerator
+        {
+            public IReadOnlyList<HidDeviceInfo> GetDevices(ushort vendorId) =>
+                new[] { new HidDeviceInfo(0x0020, 64, 64, "Base") };
+        }
+
+        private sealed class Clock { public long T; public long Now() => T; }
+
+        private static byte WheelWire(string code) =>
+            FanatecDeviceTables.Wheels.First(kv => kv.Value == code).Key;
+
+        private static byte[] Ff08(byte baseType, byte wire)
+        {
+            var b = new byte[64];
+            b[0] = 0xFF; b[1] = 0x08;
+            b[FanatecIdentity.OffBaseType] = baseType;
+            b[FanatecIdentity.OffWireCode] = wire;
+            return b;
+        }
+
+        // A plugin generation whose core is a wheelbase with a committed,
+        // settled identity for the given wheel code (or none when null).
+        private static FanatecPlugin PluginWithWheel(string wheelCode, out FanatecWheelbase wheelbase)
+        {
+            var t = new FakeTransport();
+            var clock = new Clock();
+            wheelbase = new FanatecWheelbase(t, new FakeBus(), clock.Now);
+            Assert.True(wheelbase.AutoConnect());
+
+            if (wheelCode != null)
+            {
+                t.Identity.Enqueue(Ff08(0x0C, WheelWire(wheelCode)));
+                clock.T += 10;
+                wheelbase.UpdateIdentity();
+                clock.T += 250;
+                Assert.True(wheelbase.UpdateIdentity());
+            }
+
+            var plugin = new FanatecPlugin();
+            plugin.InstallWheelbaseForTest(wheelbase);
+            return plugin;
+        }
+
+        private static FanatecWheelDeviceInstance InstanceFor(string wheelCode)
+        {
+            var profile = WheelProfileStore.FindByWheelType(wheelCode);
+            Assert.NotNull(profile);
+            var config = new DeviceConfig
+            {
+                Profile = profile,
+                Capabilities = new WheelCapabilities(profile),
+            };
+            return new FanatecWheelDeviceInstance(config);
+        }
+
+        // ── GetDeviceState rows ────────────────────────────────────────────
+
+        [Fact]
+        public void NoPlugin_ReportsDisabled()
+        {
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+
+            Assert.Equal(DeviceState.Disabled, inst.GetDeviceState());
+        }
+
+        [Fact]
+        public void PluginWithoutCore_ReportsScanning()
+        {
+            var inst = InstanceFor("PSWBMW");
+            var bare = new FanatecPlugin();   // Init never ran — no wheelbase
+            inst.PluginResolver = () => bare;
+
+            Assert.Equal(DeviceState.Scanning, inst.GetDeviceState());
+        }
+
+        [Fact]
+        public void MatchingSettledIdentity_ReportsConnected()
+        {
+            var inst = InstanceFor("PSWBMW");
+            var plugin = PluginWithWheel("PSWBMW", out _);
+            inst.PluginResolver = () => plugin;
+
+            Assert.Equal(DeviceState.Connected, inst.GetDeviceState());
+        }
+
+        [Fact]
+        public void MismatchedIdentity_ReportsScanning()
+        {
+            var inst = InstanceFor("PSWBMW");
+            // Any other recognized wheel — resolved from the table, not guessed.
+            string other = FanatecDeviceTables.Wheels.Values.First(v => v != "PSWBMW");
+            var plugin = PluginWithWheel(other, out _);
+            inst.PluginResolver = () => plugin;
+
+            Assert.Equal(DeviceState.Scanning, inst.GetDeviceState());
+        }
+
+        [Fact]
+        public void SettlingIdentity_ReportsScanning_UntilCommitted()
+        {
+            // Mid-transition output suppression: while a changed reading is still
+            // settling the device must NOT present as Connected, or LED/display
+            // writes would land on a half-(re)connected wheel.
+            var t = new FakeTransport();
+            var clock = new Clock();
+            var wheelbase = new FanatecWheelbase(t, new FakeBus(), clock.Now);
+            Assert.True(wheelbase.AutoConnect());
+            var plugin = new FanatecPlugin();
+            plugin.InstallWheelbaseForTest(wheelbase);
+
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => plugin;
+
+            t.Identity.Enqueue(Ff08(0x0C, WheelWire("PSWBMW")));
+            clock.T += 10;
+            wheelbase.UpdateIdentity();              // offered — still settling
+            Assert.Equal(DeviceState.Scanning, inst.GetDeviceState());
+
+            clock.T += 250;
+            wheelbase.UpdateIdentity();              // committed
+            Assert.Equal(DeviceState.Connected, inst.GetDeviceState());
+        }
+
+        // ── Generation guard (DataUpdate) ──────────────────────────────────
+
+        [Fact]
+        public void FirstDataUpdate_BindsTheCurrentGeneration()
+        {
+            var inst = InstanceFor("PSWBMW");
+            var pluginA = PluginWithWheel(null, out _);   // no wheel → Scanning path
+            inst.PluginResolver = () => pluginA;
+
+            var data = new GameData();
+            inst.DataUpdate(null, ref data);
+
+            Assert.Same(pluginA, inst.BoundPluginForTest);
+        }
+
+        [Fact]
+        public void PluginReplaced_RebindsToTheNewGeneration()
+        {
+            // The issue-#37 core case: SimHub keeps the DeviceInstance alive while
+            // the plugin is replaced; cached drivers bound to the old (disposed)
+            // core must be dropped and the instance re-bound to the new one.
+            var inst = InstanceFor("PSWBMW");
+            var pluginA = PluginWithWheel(null, out _);
+            var pluginB = PluginWithWheel(null, out _);
+
+            var data = new GameData();
+            inst.PluginResolver = () => pluginA;
+            inst.DataUpdate(null, ref data);
+            Assert.Same(pluginA, inst.BoundPluginForTest);
+
+            inst.PluginResolver = () => pluginB;
+            inst.DataUpdate(null, ref data);
+            Assert.Same(pluginB, inst.BoundPluginForTest);
+        }
+
+        [Fact]
+        public void PluginGoneThenBack_KeepsLastBinding_WhileGone()
+        {
+            // The A → null → A sequence (plugin torn down mid-restart): with no
+            // current generation there is nothing to rebind against — the guard
+            // must neither rebind nor clear, and the state must report Disabled.
+            var inst = InstanceFor("PSWBMW");
+            var pluginA = PluginWithWheel(null, out _);
+
+            var data = new GameData();
+            inst.PluginResolver = () => pluginA;
+            inst.DataUpdate(null, ref data);
+
+            inst.PluginResolver = () => null;
+            inst.DataUpdate(null, ref data);
+            Assert.Same(pluginA, inst.BoundPluginForTest);   // unchanged while gone
+            Assert.Equal(DeviceState.Disabled, inst.GetDeviceState());
+
+            inst.PluginResolver = () => pluginA;
+            inst.DataUpdate(null, ref data);
+            Assert.Same(pluginA, inst.BoundPluginForTest);   // same generation — no rebind
+        }
+
+        [Fact]
+        public void SameGeneration_RepeatedUpdates_DoNotRebind()
+        {
+            var inst = InstanceFor("PSWBMW");
+            var pluginA = PluginWithWheel(null, out _);
+            inst.PluginResolver = () => pluginA;
+
+            var data = new GameData();
+            inst.DataUpdate(null, ref data);
+            inst.DataUpdate(null, ref data);
+            inst.DataUpdate(null, ref data);
+
+            Assert.Same(pluginA, inst.BoundPluginForTest);
+        }
+    }
+}

--- a/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
+++ b/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
@@ -71,7 +71,7 @@ namespace FanaBridge.Tests
 
         // A plugin generation whose core is a wheelbase with a committed,
         // settled identity for the given wheel code (or none when null).
-        private static FanatecPlugin PluginWithWheel(string wheelCode, out FanatecWheelbase wheelbase)
+        private static FanatecPlugin PluginWithWheel(string? wheelCode, out FanatecWheelbase wheelbase)
         {
             var t = new FakeTransport();
             var clock = new Clock();

--- a/FanaBridge.Tests/FanatecWheelbaseTests.cs
+++ b/FanaBridge.Tests/FanatecWheelbaseTests.cs
@@ -536,7 +536,7 @@ namespace FanaBridge.Tests
             bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
             Assert.True(wb.AutoConnect());
 
-            string requestedKey = null;
+            string? requestedKey = null;
             wb.ProfileOverrideResolver = key => { requestedKey = key; return "PHUB"; };
 
             CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));

--- a/FanaBridge.Tests/FanatecWheelbaseTests.cs
+++ b/FanaBridge.Tests/FanatecWheelbaseTests.cs
@@ -47,9 +47,17 @@ namespace FanaBridge.Tests
                 Connected ? FanatecTransport.TransportConnectStatus.Connected
                           : FanatecTransport.TransportConnectStatus.NoDeviceForPid;
 
+            // When set, each sent frame's replies are enqueued onto the Identity
+            // stream — models the device responding to the connect-time
+            // enable/trigger elicit (ReadInitial flushes the stream first, so
+            // pre-seeding cannot reach that path).
+            public Queue<byte[]> RespondOnSend { get; } = new Queue<byte[]>();
+
             public bool SendCol03(byte[] data)
             {
                 Sent.Add((byte[])data.Clone());
+                while (RespondOnSend.Count > 0)
+                    Identity.Enqueue(RespondOnSend.Dequeue());
                 return true;
             }
 
@@ -392,6 +400,221 @@ namespace FanaBridge.Tests
             Assert.Same(WheelCapabilities.None, wb.CurrentCapabilities);
             Assert.Null(wb.LastRawReport);
             Assert.Equal("No wheel attached", wb.DisplayName);
+        }
+
+        // ── Rim swap ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void RimSwap_CommitsTheNewWheel_AndFiresWheelChangedAgain()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+
+            int wheelChanged = 0;
+            wb.WheelChanged += _ => wheelChanged++;
+
+            string other = FanatecDeviceTables.Wheels.Values.First(v => v != "PSWBMW");
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire(other)));
+
+            Assert.Equal(other, wb.WheelCode);
+            Assert.Equal(1, wheelChanged);
+        }
+
+        [Fact]
+        public void RimSwapFlap_RevertingWithinTheSettleWindow_CommitsNothing()
+        {
+            // The firmware's transient reconnect flap: A → B → A inside the settle
+            // window must ride out silently — no commit, no WheelChanged, and the
+            // identity must still read as A once stable again.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+
+            int wheelChanged = 0;
+            wb.WheelChanged += _ => wheelChanged++;
+
+            string other = FanatecDeviceTables.Wheels.Values.First(v => v != "PSWBMW");
+            t.Identity.Enqueue(Ff08(0x0C, WheelWire(other)));      // flap out...
+            clock.T += 50;
+            wb.UpdateIdentity();
+            Assert.False(wb.IdentityStable);
+
+            t.Identity.Enqueue(Ff08(0x0C, WheelWire("PSWBMW")));   // ...and back
+            clock.T += 50;
+            wb.UpdateIdentity();
+
+            clock.T += 250;                                        // quiet again
+            wb.UpdateIdentity();
+
+            Assert.True(wb.IdentityStable);
+            Assert.Equal("PSWBMW", wb.WheelCode);
+            Assert.Equal(0, wheelChanged);
+        }
+
+        // ── Unrecognized hardware / diagnostics contract ──────────────────
+
+        [Fact]
+        public void UnrecognizedWire_DetectedButNotIdentified_WithReportableName()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+
+            byte unknown = (byte)Enumerable.Range(1, 254)
+                .First(i => !FanatecDeviceTables.Wheels.ContainsKey((byte)i)
+                         && !FanatecDeviceTables.Hubs.ContainsKey((byte)i)
+                         && i != 0xFF);
+            CommitIdentity(wb, t, clock, Ff08(0x0C, unknown));
+
+            Assert.True(wb.WheelDetected);       // something IS attached...
+            Assert.False(wb.WheelIdentified);    // ...but we can't name it
+            Assert.Null(wb.WheelCode);
+            Assert.Equal(unknown, wb.WheelWireCode);
+            Assert.Contains("Unknown (0x" + unknown.ToString("X2"), wb.DisplayName);
+            Assert.Same(WheelCapabilities.None, wb.CurrentCapabilities);
+        }
+
+        [Fact]
+        public void ExtInfoWire_0xFF_GetsTheDedicatedReportMarker()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+
+            CommitIdentity(wb, t, clock, Ff08(0x0C, 0xFF));
+
+            Assert.Contains("EXT_INFO", wb.DisplayName);
+        }
+
+        [Fact]
+        public void LastRawReport_UpdatesPerReading_EvenBeforeAnyCommit()
+        {
+            // Diagnostics contract: a capture taken on a sitting-still
+            // unrecognized wheel must reflect the live frame — retention happens
+            // on every drained reading, not only on settled commits.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            Assert.Null(wb.LastRawReport);
+
+            t.Identity.Enqueue(Ff08(0x0C, WheelWire("PSWBMW")));
+            clock.T += 10;
+            wb.UpdateIdentity();                 // offered — NOT yet committed
+
+            Assert.False(wb.WheelDetected);
+            Assert.NotNull(wb.LastRawReport);
+            Assert.Equal(0xFF, wb.LastRawReport[0]);
+        }
+
+        // ── Connect-time initial read ──────────────────────────────────────
+
+        [Fact]
+        public void ConnectTimeInitialRead_SeedsIdentity_FromTheEnableTriggerReply()
+        {
+            // ReadInitial elicits with enable+trigger and flushes stale frames
+            // first, so the reply arrives via respond-on-send, as from hardware.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            t.RespondOnSend.Enqueue(Ff08(0x0C, WheelWire("PSWBMW")));
+
+            Assert.True(wb.AutoConnect());       // reply consumed at connect
+
+            clock.T += 250;                      // settle the connect-time reading
+            Assert.True(wb.UpdateIdentity());
+            Assert.Equal("PSWBMW", wb.WheelCode);
+        }
+
+        // ── Capability resolution hooks ────────────────────────────────────
+
+        [Fact]
+        public void ProfileOverrideResolver_RedirectsCapabilityResolution()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+
+            string requestedKey = null;
+            wb.ProfileOverrideResolver = key => { requestedKey = key; return "PHUB"; };
+
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+
+            Assert.Equal("PSWBMW", requestedKey);            // asked with the match key
+            Assert.Equal("PHUB", wb.CurrentCapabilities.Profile?.Id);   // override won
+        }
+
+        [Fact]
+        public void CommittedIdentity_ResolvesTheMatchingProfileCapabilities()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+
+            Assert.Equal("PSWBMW", wb.CurrentCapabilities.Profile?.Id);
+            Assert.Equal(wb.CurrentCapabilities.Name, wb.DisplayName);
+        }
+
+        // ── ITM subscription buffering ─────────────────────────────────────
+
+        [Fact]
+        public void ItmReports_BufferedDuringDrain_HandedOffOnce()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+
+            t.Itm.Enqueue(new byte[] { 0xFF, 0x05, 0x01, 0x11 });
+            t.Itm.Enqueue(new byte[] { 0xFF, 0x05, 0x01, 0x22 });
+            clock.T += 10;
+            wb.UpdateIdentity();
+
+            var drained = new List<byte[]>();
+            wb.DrainItmReports(drained.Add);
+            Assert.Equal(2, drained.Count);
+            Assert.Equal(0x11, drained[0][3]);
+            Assert.Equal(0x22, drained[1][3]);
+
+            wb.DrainItmReports(drained.Add);     // buffer cleared by the hand-off
+            Assert.Equal(2, drained.Count);
+        }
+
+        [Fact]
+        public void ItmReports_BufferBounded_DropsOldestWhenFull()
+        {
+            // Cap is 32; a stalled consumer (e.g. during the wizard) must cost the
+            // OLDEST reports — only the latest subscription state matters.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+
+            // The per-tick drain is bounded, so feed across several ticks.
+            for (int i = 0; i < 40; i++)
+            {
+                t.Itm.Enqueue(new byte[] { 0xFF, 0x05, 0x01, (byte)i });
+                clock.T += 10;
+                wb.UpdateIdentity();
+            }
+
+            var drained = new List<byte[]>();
+            wb.DrainItmReports(drained.Add);
+
+            Assert.Equal(32, drained.Count);
+            Assert.Equal(39, drained[drained.Count - 1][3]);   // newest kept
+            Assert.Equal(8, drained[0][3]);                    // oldest 8 dropped
+        }
+
+        // ── Guard rails ────────────────────────────────────────────────────
+
+        [Fact]
+        public void UpdateIdentity_WhileDisconnected_IsANoOp()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            Assert.False(wb.UpdateIdentity());
+            Assert.Empty(t.Sent);
         }
 
         [Fact]

--- a/FanaBridge.Tests/FanatecWheelbaseTests.cs
+++ b/FanaBridge.Tests/FanatecWheelbaseTests.cs
@@ -1,0 +1,417 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FanaBridge.Profiles;
+using FanaBridge.Protocol;
+using FanaBridge.Transport;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// Tests for the wheelbase identity state machine — the layer where field
+    /// bugs have historically lived (settle/commit ordering, SRM precedence,
+    /// the full disconnect reset). Runs against injected fakes: a connectable
+    /// transport with scriptable family streams, a scripted HID bus, and a
+    /// manual clock.
+    /// </summary>
+    public class FanatecWheelbaseTests
+    {
+        // ── Test doubles ─────────────────────────────────────────────────
+
+        private sealed class FakeTransport : IConnectableTransport
+        {
+            public bool ConnectResult = true;
+            public int ConnectedPid;
+            public int DisconnectCount;
+            public bool Connected;
+
+            public FakeReportStream Identity { get; } = new FakeReportStream();
+            public FakeReportStream Itm { get; } = new FakeReportStream();
+            public FakeReportStream Srm { get; } = new FakeReportStream();
+            public List<byte[]> Sent { get; } = new List<byte[]>();
+
+            public bool Connect(int productId)
+            {
+                ConnectedPid = productId;
+                Connected = ConnectResult;
+                return ConnectResult;
+            }
+
+            public void Disconnect() { DisconnectCount++; Connected = false; }
+            public void Dispose() => Disconnect();
+
+            public bool IsConnected => Connected;
+            public bool IsDevicePresent => Connected;
+            public FanatecTransport.TransportConnectStatus LastConnectStatus =>
+                Connected ? FanatecTransport.TransportConnectStatus.Connected
+                          : FanatecTransport.TransportConnectStatus.NoDeviceForPid;
+
+            public bool SendCol03(byte[] data)
+            {
+                Sent.Add((byte[])data.Clone());
+                return true;
+            }
+
+            public bool SendCol01(byte[] data) => true;
+            public IReportStream IdentityReports => Identity;
+            public IReportStream ItmReports => Itm;
+            public IReportStream SrmReports => Srm;
+            public IReportStream TuningReports => FakeReportStream.Empty;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col03MaxInputReportLength => 64;
+            public int Col01MaxInputReportLength => 34;
+            public IDisposable BeginBatch() => new NoOp();
+            private sealed class NoOp : IDisposable { public void Dispose() { } }
+        }
+
+        private sealed class FakeBus : IHidBusEnumerator
+        {
+            public List<HidDeviceInfo> Devices = new List<HidDeviceInfo>();
+            public IReadOnlyList<HidDeviceInfo> GetDevices(ushort vendorId) => Devices;
+        }
+
+        private sealed class Clock { public long T; public long Now() => T; }
+
+        private static FanatecWheelbase Make(out FakeTransport t, out FakeBus bus, out Clock clock)
+        {
+            t = new FakeTransport();
+            bus = new FakeBus();
+            clock = new Clock();
+            return new FanatecWheelbase(t, bus, clock.Now);
+        }
+
+        // Wire codes resolved from the decode tables rather than hardcoded, so a
+        // table correction can't silently strand these tests on stale bytes.
+        private static byte WheelWire(string code) =>
+            FanatecDeviceTables.Wheels.First(kv => kv.Value == code).Key;
+        private static byte HubWire(string code) =>
+            FanatecDeviceTables.Hubs.First(kv => kv.Value == code).Key;
+
+        // A pushed FF 08 system report: signature at offset 0, identity bytes at
+        // the FanatecIdentity offsets.
+        private static byte[] Ff08(byte baseType, byte wire, byte module = 0)
+        {
+            var b = new byte[64];
+            b[0] = 0xFF; b[1] = 0x08;
+            b[FanatecIdentity.OffBaseType] = baseType;
+            b[FanatecIdentity.OffWireCode] = wire;
+            b[FanatecIdentity.OffModule] = module;
+            return b;
+        }
+
+        // Real 0xDD capture (kit fw 6.12, CSSWFORMV2) — same bytes pinned in
+        // SrmConverterIdentityTests.
+        private static byte[] SrmReply() =>
+            new byte[] { 0xFF, 0xDD, 0x06, 0x12, 0x0A, 0x2F, 0x00, 0x00 };
+
+        private static bool ContainsDeFa(byte[] frame)
+        {
+            for (int i = 0; i + 1 < frame.Length; i++)
+                if (frame[i] == 0xDE && frame[i + 1] == 0xFA) return true;
+            return false;
+        }
+
+        // Connects and commits a settled identity: enqueue → drain → settle → commit.
+        private static void CommitIdentity(FanatecWheelbase wb, FakeTransport t, Clock clock, byte[] frame)
+        {
+            t.Identity.Enqueue(frame);
+            clock.T += 10;
+            wb.UpdateIdentity();               // drained + offered to the settler
+            clock.T += 250;                    // ride out the 200 ms settle window
+            Assert.True(wb.UpdateIdentity());  // committed
+        }
+
+        // ── Discovery / base-PID selection ────────────────────────────────
+
+        [Fact]
+        public void AutoConnect_NoDevices_FailsWithReason()
+        {
+            var wb = Make(out var t, out _, out _);
+
+            Assert.False(wb.AutoConnect());
+            Assert.Contains("No Fanatec devices", wb.LastConnectError);
+            Assert.Equal(0, t.ConnectedPid);
+        }
+
+        [Fact]
+        public void AutoConnect_PicksTheCol03CapableDevice()
+        {
+            var wb = Make(out var t, out var bus, out _);
+            bus.Devices.Add(new HidDeviceInfo(0x1839, 8, 8, "Pedals"));          // accessory
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "ClubSport DD"));  // the base
+
+            Assert.True(wb.AutoConnect());
+            Assert.Equal(0x0020, t.ConnectedPid);
+            Assert.Equal(0x0020, wb.ConnectedProductId);
+            Assert.Equal("ClubSport DD", wb.ProductName);
+            Assert.Null(wb.LastConnectError);
+        }
+
+        [Fact]
+        public void AutoConnect_InputOnly64ByteInterface_StillAdopted()
+        {
+            // Looser than the transport's col03 check on purpose: a 64-byte INPUT
+            // qualifies, so an input-only base is adopted here and the transport
+            // reports NoCol03Interface instead of the base silently vanishing.
+            var wb = Make(out var t, out var bus, out _);
+            bus.Devices.Add(new HidDeviceInfo(0x0E03, 8, 64, "CSL Elite"));
+
+            Assert.True(wb.AutoConnect());
+            Assert.Equal(0x0E03, t.ConnectedPid);
+        }
+
+        [Fact]
+        public void PickBasePid_AllDescriptorQueriesFailed_FallsBackToFirstPid()
+        {
+            // -1 = descriptor query threw on a busy handle; unknown, not a mismatch.
+            var devices = new List<HidDeviceInfo>
+            {
+                new HidDeviceInfo(0x1111, -1, -1, null),
+                new HidDeviceInfo(0x2222, -1, -1, null),
+            };
+
+            Assert.Equal(0x1111, FanatecWheelbase.PickBasePid(devices));
+        }
+
+        [Fact]
+        public void Connect_TransportFailure_SurfacesCategorisedReason()
+        {
+            var wb = Make(out var t, out var bus, out _);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "ClubSport DD"));
+            t.ConnectResult = false;
+
+            Assert.False(wb.AutoConnect());
+            Assert.Contains("powered off, unplugged", wb.LastConnectError);
+        }
+
+        // ── FF 08 identity: drain → settle → commit ───────────────────────
+
+        [Fact]
+        public void Identity_CommitsOnlyAfterSettling()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+
+            int wheelChanged = 0;
+            wb.WheelChanged += _ => wheelChanged++;
+
+            t.Identity.Enqueue(Ff08(0x0C, WheelWire("PSWBMW")));
+            clock.T += 10;
+            Assert.False(wb.UpdateIdentity());   // offered, still settling
+            Assert.False(wb.IdentityStable);
+            Assert.False(wb.WheelDetected);      // nothing committed yet
+            Assert.Equal(0, wheelChanged);
+
+            clock.T += 250;                      // quiet past the 200 ms window
+            Assert.True(wb.UpdateIdentity());    // committed
+
+            Assert.True(wb.IdentityStable);
+            Assert.True(wb.WheelDetected);
+            Assert.True(wb.WheelIdentified);
+            Assert.True(wb.HasIdentity);
+            Assert.Equal("PSWBMW", wb.WheelCode);
+            Assert.Equal(0x0C, wb.BaseType);
+            Assert.False(wb.IsHub);
+            Assert.Null(wb.ModuleCode);
+            Assert.Equal(1, wheelChanged);
+        }
+
+        [Fact]
+        public void Identity_HubWithModule_DecodesBoth()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+
+            CommitIdentity(wb, t, clock, Ff08(0x0C, HubWire("PHUB"), module: 0x02));
+
+            Assert.True(wb.IsHub);
+            Assert.Equal("PHUB", wb.WheelCode);
+            Assert.Equal("PBMR", wb.ModuleCode);
+            Assert.Equal(0x02, wb.ModuleWireCode);
+        }
+
+        [Fact]
+        public void Identity_UnchangedRepush_DoesNotRecommit()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+
+            int wheelChanged = 0;
+            wb.WheelChanged += _ => wheelChanged++;
+
+            // The firmware re-pushing the same identity (reconnect flap) must not
+            // re-fire WheelChanged — that's what the settler's change detection is for.
+            t.Identity.Enqueue(Ff08(0x0C, WheelWire("PSWBMW")));
+            clock.T += 10;
+            Assert.False(wb.UpdateIdentity());
+            clock.T += 250;
+            Assert.False(wb.UpdateIdentity());
+            Assert.Equal(0, wheelChanged);
+            Assert.True(wb.IdentityStable);
+        }
+
+        [Fact]
+        public void Identity_ReEnableCadence_KeepsPushSubscriptionAlive()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            t.Sent.Clear();
+
+            clock.T += 9_000;
+            wb.UpdateIdentity();
+            Assert.DoesNotContain(t.Sent, f => f[0] == 0xFF && f[1] == 0x08 && f[2] == 0x01); // not yet
+
+            clock.T += 1_100;                    // past the 10 s re-enable cadence
+            wb.UpdateIdentity();
+            Assert.Contains(t.Sent, f => f[0] == 0xFF && f[1] == 0x08 && f[2] == 0x01);       // FF 08 enable
+        }
+
+        // ── SRM converter identity ────────────────────────────────────────
+
+        [Fact]
+        public void Srm_PingsOnlyWhileUnidentified()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0005, 64, 64, "CSL Elite"));
+            Assert.True(wb.AutoConnect());
+            t.Sent.Clear();
+
+            clock.T += 1_100;                    // past the 1 s ping cadence
+            wb.UpdateIdentity();
+            Assert.Contains(t.Sent, ContainsDeFa);   // unidentified → DE FA ping
+
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+            t.Sent.Clear();
+
+            clock.T += 5_000;
+            wb.UpdateIdentity();
+            Assert.DoesNotContain(t.Sent, ContainsDeFa);  // identified → never pings again
+        }
+
+        [Fact]
+        public void Srm_CommitsWhenFf08Silent()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0005, 64, 64, "CSL Elite"));
+            Assert.True(wb.AutoConnect());
+
+            int wheelChanged = 0;
+            wb.WheelChanged += _ => wheelChanged++;
+
+            t.Srm.Enqueue(SrmReply());
+            clock.T += 10;
+            wb.UpdateIdentity();
+
+            Assert.True(wb.IsSrmConverter);
+            Assert.Equal("CSSWFORMV2", wb.WheelCode);
+            Assert.Equal("6.12", wb.SrmKitFirmware);
+            Assert.True(wb.WheelDetected);
+            Assert.True(wb.HasIdentity);         // BaseType stays 0; SRM flag carries it
+            Assert.Equal(0, wb.BaseType);
+            Assert.True(wb.IdentityStable);      // fixed identity — always settled
+            Assert.Equal(1, wheelChanged);
+        }
+
+        [Fact]
+        public void Srm_ElicitedReply_MustNotOverwriteCommittedFf08Identity()
+        {
+            // A read-only diagnostics run sends DE FA on demand; its 0xDD reply
+            // must never mutate an identity the FF 08 path already committed.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+
+            t.Srm.Enqueue(SrmReply());
+            clock.T += 10;
+            wb.UpdateIdentity();
+
+            Assert.False(wb.IsSrmConverter);
+            Assert.Equal("PSWBMW", wb.WheelCode);
+            Assert.Null(wb.SrmKitFirmware);
+        }
+
+        [Fact]
+        public void Srm_OnceCommitted_IsFixedForTheConnection()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0005, 64, 64, "CSL Elite"));
+            Assert.True(wb.AutoConnect());
+
+            t.Srm.Enqueue(SrmReply());
+            clock.T += 10;
+            wb.UpdateIdentity();
+            Assert.True(wb.IsSrmConverter);
+
+            // Later FF 08 frames (impossible from a real kit, but defensive) and
+            // further ticks change nothing: the converter identity is a one-shot.
+            t.Identity.Enqueue(Ff08(0x0C, WheelWire("PSWBMW")));
+            clock.T += 500;
+            Assert.False(wb.UpdateIdentity());
+            Assert.True(wb.IsSrmConverter);
+            Assert.Equal("CSSWFORMV2", wb.WheelCode);
+        }
+
+        // ── Disconnect: the full state reset ─────────────────────────────
+
+        [Fact]
+        public void Disconnect_ResetsEveryIdentityProperty()
+        {
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            CommitIdentity(wb, t, clock, Ff08(0x0C, HubWire("PHUB"), module: 0x02));
+            Assert.NotNull(wb.LastRawReport);
+
+            wb.Disconnect();
+
+            // One missed field here is exactly a #37-class stale-state bug, so
+            // every public identity property is pinned.
+            Assert.False(wb.IsConnected);
+            Assert.Equal(0, wb.ConnectedProductId);
+            Assert.Null(wb.ProductName);
+            Assert.False(wb.WheelDetected);
+            Assert.False(wb.WheelIdentified);
+            Assert.Null(wb.WheelCode);
+            Assert.Equal(0, wb.WheelWireCode);
+            Assert.False(wb.IsHub);
+            Assert.Null(wb.ModuleCode);
+            Assert.Equal(0, wb.ModuleWireCode);
+            Assert.Equal(0, wb.BaseType);
+            Assert.Null(wb.BaseCode);
+            Assert.False(wb.IsSrmConverter);
+            Assert.Null(wb.SrmKitFirmware);
+            Assert.False(wb.HasIdentity);
+            Assert.True(wb.IdentityStable);
+            Assert.Same(WheelCapabilities.None, wb.CurrentCapabilities);
+            Assert.Null(wb.LastRawReport);
+            Assert.Equal("No wheel attached", wb.DisplayName);
+        }
+
+        [Fact]
+        public void Disconnect_ThenReconnect_SameWheelCommitsAgain()
+        {
+            // The settler is reset on disconnect, so the SAME rim must re-commit
+            // (and re-fire WheelChanged) on the next connection — encoders rely
+            // on that event to force a full resend after firmware reset the LEDs.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+
+            wb.Disconnect();
+            Assert.True(wb.AutoConnect());
+
+            int wheelChanged = 0;
+            wb.WheelChanged += _ => wheelChanged++;
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+            Assert.Equal(1, wheelChanged);
+        }
+    }
+}

--- a/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -78,6 +78,15 @@ namespace FanaBridge.Adapters
         // are dropped/rebuilt against the current generation.
         private FanatecPlugin _boundPlugin;
 
+        // Test seam for the issue-#37 generation matrix: resolves the current
+        // plugin generation everywhere this class would read the singleton.
+        // Production keeps the default; tests substitute plugin generations to
+        // drive the null→A, A→A, A→B, and connected→scanning transitions.
+        internal Func<FanatecPlugin> PluginResolver = () => FanatecPlugin.Instance;
+
+        /// <summary>Test hook: the generation the cached drivers were built against.</summary>
+        internal FanatecPlugin BoundPluginForTest => _boundPlugin;
+
         public FanatecWheelDeviceInstance(DeviceConfig config)
         {
             _config = config;
@@ -99,7 +108,7 @@ namespace FanaBridge.Adapters
             // the initialized flag unset so the next call retries — latching it
             // here would permanently kill this instance's LED module just
             // because it raced ahead of plugin Init.
-            var plugin = FanatecPlugin.Instance;
+            var plugin = PluginResolver();
             if (plugin == null) return;
 
             _ledModuleInitialized = true;
@@ -242,7 +251,7 @@ namespace FanaBridge.Adapters
 
         public override DeviceState GetDeviceState()
         {
-            var plugin = FanatecPlugin.Instance;
+            var plugin = PluginResolver();
             if (plugin == null)
                 return DeviceState.Disabled;
 
@@ -356,7 +365,7 @@ namespace FanaBridge.Adapters
             // Generation guard: if the plugin was replaced since our drivers were
             // built, drop them so they rebuild against the current hardware core
             // (see _boundPlugin). Must run before anything below touches them.
-            var currentPlugin = FanatecPlugin.Instance;
+            var currentPlugin = PluginResolver();
             if (currentPlugin != null && _boundPlugin != null
                 && !ReferenceEquals(_boundPlugin, currentPlugin))
             {
@@ -396,7 +405,7 @@ namespace FanaBridge.Adapters
 
             EnsureLedModuleInitialized();
 
-            var plugin = FanatecPlugin.Instance;
+            var plugin = PluginResolver();
             var device = plugin?.Transport;
             if (device == null || !device.IsConnected)
                 return;
@@ -523,7 +532,7 @@ namespace FanaBridge.Adapters
             SimHub.Logging.Current.Info(
                 "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: End called");
 
-            FanatecPlugin.Instance?.UnregisterDeviceInstance(this);
+            PluginResolver()?.UnregisterDeviceInstance(this);
             _displayManager?.Clear();
             _itmDisplay?.Stop();
             _ledModule?.FinalizeModule();

--- a/FanaBridge/FanatecPlugin.cs
+++ b/FanaBridge/FanatecPlugin.cs
@@ -149,6 +149,14 @@ namespace FanaBridge
             return config.Capabilities ?? WheelCapabilities.None;
         }
 
+        /// <summary>
+        /// Test hook: installs a wheelbase as this plugin's hardware core so
+        /// DeviceInstance state/generation logic can run against an injected
+        /// identity without a SimHub host. Production cores are built only by
+        /// InitializeCore.
+        /// </summary>
+        internal void InstallWheelbaseForTest(FanatecWheelbase wheelbase) => _wheelbase = wheelbase;
+
         /// <summary>Called by each <see cref="Adapters.FanatecWheelDeviceInstance"/> so the
         /// plugin can read the connected wheel's SimHub device name for the Control Mapper
         /// integration. Idempotent.</summary>

--- a/FanaBridge/Transport/FanatecTransport.cs
+++ b/FanaBridge/Transport/FanatecTransport.cs
@@ -13,7 +13,7 @@ namespace FanaBridge.Transport
     /// <see cref="IDeviceTransport"/> interface used by protocol encoders
     /// (LEDs, display, tuning).
     /// </summary>
-    public class FanatecTransport : IDisposable, IDeviceTransport
+    public class FanatecTransport : IDisposable, IDeviceTransport, IConnectableTransport
     {
         private const int DISPLAY_REPORT_LENGTH = 8;
 
@@ -55,8 +55,9 @@ namespace FanaBridge.Transport
 
         // A transient read error (USB suspend blip, driver hiccup) must not kill
         // the input path — retry a few times before declaring the reader dead.
-        private const int COL03_READ_RETRY_MAX = 5;
-        private const int COL03_READ_RETRY_DELAY_MS = 50;
+        // Internal so the reader-loop invariant tests pin the exact thresholds.
+        internal const int COL03_READ_RETRY_MAX = 5;
+        internal const int COL03_READ_RETRY_DELAY_MS = 50;
 
         // Stable facades over the current session's queues, so consumers can
         // cache IReportStream references across reconnects.
@@ -453,7 +454,7 @@ namespace FanaBridge.Transport
             var queues = _col03Queues;
             int bufLen = ((IDeviceTransport)this).Col03MaxInputReportLength;
 
-            _col03Reader = new Thread(() => Col03ReadLoop(stream, queues, bufLen))
+            _col03Reader = new Thread(() => Col03ReadLoop(new HidStreamSource(stream), queues, bufLen))
             {
                 IsBackground = true,
                 Name = "FanaBridge col03 reader",
@@ -461,7 +462,45 @@ namespace FanaBridge.Transport
             _col03Reader.Start();
         }
 
-        private void Col03ReadLoop(HidStream stream, Col03QueueSet queues, int bufLen)
+        /// <summary>
+        /// The minimal read surface the col03 reader loop needs from the HID
+        /// stream — seamed so the loop's retry/fault/teardown invariants (which
+        /// otherwise exist only as comments) are unit-testable without hardware.
+        /// </summary>
+        internal interface ICol03Source
+        {
+            int Read(byte[] buffer, int offset, int count);
+            int ReadTimeout { set; }
+        }
+
+        private sealed class HidStreamSource : ICol03Source
+        {
+            private readonly HidStream _stream;
+            public HidStreamSource(HidStream stream) { _stream = stream; }
+            public int Read(byte[] buffer, int offset, int count) => _stream.Read(buffer, offset, count);
+            public int ReadTimeout { set { _stream.ReadTimeout = value; } }
+        }
+
+        // ── Reader-loop test hooks ─────────────────────────────────────────
+        // The loop's invariants depend on instance state (_col03Stopping,
+        // _col03ReaderFaulted, the _col03Queues session identity); these hooks
+        // let tests arrange that state and run the loop synchronously.
+
+        /// <summary>Test hook: installs a queue set as the current reader session.</summary>
+        internal void BeginReaderSessionForTest(Col03QueueSet queues)
+        {
+            _col03Stopping = false;
+            _col03ReaderFaulted = false;
+            _col03Queues = queues;
+        }
+
+        /// <summary>Test hook: marks teardown in progress, as Disconnect does before disposing streams.</summary>
+        internal void SignalStoppingForTest() => _col03Stopping = true;
+
+        /// <summary>Test hook: whether the reader declared itself dead (drives IsConnected=false).</summary>
+        internal bool ReaderFaultedForTest => _col03ReaderFaulted;
+
+        internal void Col03ReadLoop(ICol03Source stream, Col03QueueSet queues, int bufLen)
         {
             var buf = new byte[bufLen];
             try { stream.ReadTimeout = COL03_READER_TIMEOUT_MS; } catch { }

--- a/FanaBridge/Transport/FanatecWheelbase.cs
+++ b/FanaBridge/Transport/FanatecWheelbase.cs
@@ -1,8 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FanaBridge.Profiles;
 using FanaBridge.Protocol;
-using HidSharp;
 
 namespace FanaBridge.Transport
 {
@@ -37,14 +37,35 @@ namespace FanaBridge.Transport
 
         // The wheelbase OWNS its HID transport (col01 + col03 I/O). Identity is
         // read through it, and encoders reach it via Transport.
-        private readonly FanatecTransport _transport = new FanatecTransport();
+        private readonly IConnectableTransport _transport;
+        private readonly IHidBusEnumerator _bus;
+        private readonly Func<long> _nowMs;
         private bool _disposed;
 
         public FanatecWheelbase()
+            : this(new FanatecTransport(), new HidSharpBusEnumerator(), null)
         {
+        }
+
+        /// <summary>
+        /// Test seam: the identity state machine (drain → settle → commit, SRM
+        /// precedence, disconnect reset) runs against these injected dependencies.
+        /// Production uses the parameterless constructor.
+        /// </summary>
+        internal FanatecWheelbase(IConnectableTransport transport, IHidBusEnumerator bus, Func<long> nowMs)
+        {
+            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+            _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+            _nowMs = nowMs ?? DefaultClock();
             _ingest = OnDrainReading;
             _ingestSrm = OnDrainSrm;
             _bufferItm = BufferItmReport;
+        }
+
+        private static Func<long> DefaultClock()
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            return () => sw.ElapsedMilliseconds;
         }
 
         /// <summary>The wheelbase's HID transport — used by LED/display/tuning encoders.</summary>
@@ -67,7 +88,6 @@ namespace FanaBridge.Transport
         private long _lastSrmQueryMs;
         private SrmConverterIdentity.Result? _pendingSrm;  // a 0xDD reply seen in the drain, committed after it
         private readonly IdentitySettler _settler = new IdentitySettler(IdentitySettleMs);
-        private readonly System.Diagnostics.Stopwatch _clock = System.Diagnostics.Stopwatch.StartNew();
         private readonly Action<SystemReportReader.Reading> _ingest;
         private readonly Action<byte[]> _ingestSrm;
         private long _lastEnableMs;
@@ -271,9 +291,7 @@ namespace FanaBridge.Transport
 
             try
             {
-                var fanatecDevices = DeviceList.Local.GetHidDevices()
-                    .Where(d => d.VendorID == FANATEC_VENDOR_ID)
-                    .ToList();
+                var fanatecDevices = _bus.GetDevices(FANATEC_VENDOR_ID);
 
                 if (fanatecDevices.Count == 0)
                     return FailConnect("No Fanatec devices (VID 0x0EB7) found on the HID bus.");
@@ -305,10 +323,7 @@ namespace FanaBridge.Transport
 
             try
             {
-                var fanatecDevices = DeviceList.Local.GetHidDevices()
-                    .Where(d => d.VendorID == FANATEC_VENDOR_ID)
-                    .ToList();
-                return Adopt(productId, fanatecDevices);
+                return Adopt(productId, _bus.GetDevices(FANATEC_VENDOR_ID));
             }
             catch (Exception ex)
             {
@@ -318,17 +333,10 @@ namespace FanaBridge.Transport
             }
         }
 
-        private bool Adopt(int productId, System.Collections.Generic.List<HidDevice> fanatecDevices)
+        private bool Adopt(int productId, IReadOnlyList<HidDeviceInfo> fanatecDevices)
         {
-            try
-            {
-                var device = fanatecDevices.FirstOrDefault(d => d.ProductID == productId);
-                ProductName = SafeProductName(device);
-            }
-            catch
-            {
-                ProductName = "Fanatec Device";
-            }
+            var device = fanatecDevices.FirstOrDefault(d => d.ProductId == productId);
+            ProductName = device?.ProductName ?? "Fanatec Device";
 
             // Open the HID transport for this base — identity + all I/O flow through it.
             if (!_transport.Connect(productId))
@@ -346,7 +354,7 @@ namespace FanaBridge.Transport
             // listens for pushes — no triggering.
             try
             {
-                long connectNow = _clock.ElapsedMilliseconds;
+                long connectNow = _nowMs();
                 _lastEnableMs = connectNow;
                 _lastSrmQueryMs = connectNow - SrmQueryMs;   // allow an immediate SRM ping if FF 08 is silent
                 _pendingSrm = null;
@@ -366,18 +374,16 @@ namespace FanaBridge.Transport
         // Deliberately looser than the transport's col03 check (which requires a 64-byte
         // OUTPUT): matching a 64-byte INPUT too lets an input-only base still be adopted,
         // so the transport can report NoCol03Interface rather than the base vanishing here.
-        private static int PickBasePid(System.Collections.Generic.List<HidDevice> devices)
+        internal static int PickBasePid(IReadOnlyList<HidDeviceInfo> devices)
         {
             foreach (var d in devices)
             {
-                try
-                {
-                    if (d.GetMaxOutputReportLength() >= 64 || d.GetMaxInputReportLength() >= 64)
-                        return d.ProductID;
-                }
-                catch { /* descriptor query can throw on busy handles */ }
+                // -1 means the descriptor query threw on a busy handle — treat
+                // as unknown, not as a mismatch, and keep scanning.
+                if (d.MaxOutputReportLength >= 64 || d.MaxInputReportLength >= 64)
+                    return d.ProductId;
             }
-            return devices.Select(d => d.ProductID).FirstOrDefault();
+            return devices.Select(d => d.ProductId).FirstOrDefault();
         }
 
         // Records the connect-failure reason for the live UI/status, logging it only when
@@ -416,12 +422,6 @@ namespace FanaBridge.Transport
             }
         }
 
-        private static string SafeProductName(HidDevice device)
-        {
-            try { return device?.GetProductName() ?? "Fanatec Device"; }
-            catch { return "Fanatec Device"; }
-        }
-
         // ── Identity ──────────────────────────────────────────────────────
 
         /// <summary>
@@ -440,7 +440,7 @@ namespace FanaBridge.Transport
             if (IsSrmConverter)
                 return false;
 
-            long now = _clock.ElapsedMilliseconds;
+            long now = _nowMs();
 
             // Keep the push-on-change subscription alive (the enable can lapse).
             if (now - _lastEnableMs >= IdentityReEnableMs)

--- a/FanaBridge/Transport/IConnectableTransport.cs
+++ b/FanaBridge/Transport/IConnectableTransport.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace FanaBridge.Transport
+{
+    /// <summary>
+    /// The connect-lifecycle surface of a device transport, layered on top of
+    /// <see cref="IDeviceTransport"/> (the send/read surface the encoders and
+    /// protocol readers use). <see cref="FanatecWheelbase"/> orchestrates against
+    /// this interface rather than the concrete <see cref="FanatecTransport"/>,
+    /// so its identity state machine (drain → settle → commit, SRM precedence,
+    /// disconnect reset) is unit-testable with a fake transport — the layer where
+    /// field bugs have historically lived.
+    /// </summary>
+    public interface IConnectableTransport : IDeviceTransport, IDisposable
+    {
+        /// <summary>Opens the HID interfaces for the given product ID.</summary>
+        bool Connect(int productId);
+
+        /// <summary>Closes the HID interfaces and stops the reader.</summary>
+        void Disconnect();
+
+        /// <summary>Whether the connected device is still present on the HID bus.</summary>
+        bool IsDevicePresent { get; }
+
+        /// <summary>Categorised outcome of the most recent <see cref="Connect"/> attempt.</summary>
+        FanatecTransport.TransportConnectStatus LastConnectStatus { get; }
+    }
+}

--- a/FanaBridge/Transport/IConnectableTransport.cs
+++ b/FanaBridge/Transport/IConnectableTransport.cs
@@ -11,7 +11,7 @@ namespace FanaBridge.Transport
     /// disconnect reset) is unit-testable with a fake transport — the layer where
     /// field bugs have historically lived.
     /// </summary>
-    public interface IConnectableTransport : IDeviceTransport, IDisposable
+    internal interface IConnectableTransport : IDeviceTransport, IDisposable
     {
         /// <summary>Opens the HID interfaces for the given product ID.</summary>
         bool Connect(int productId);

--- a/FanaBridge/Transport/IHidBusEnumerator.cs
+++ b/FanaBridge/Transport/IHidBusEnumerator.cs
@@ -10,7 +10,7 @@ namespace FanaBridge.Transport
     /// handles; a failed query is represented as -1 / null rather than an
     /// exception, so selection logic stays branch-testable.
     /// </summary>
-    public sealed class HidDeviceInfo
+    internal sealed class HidDeviceInfo
     {
         public HidDeviceInfo(int productId, int maxOutputReportLength, int maxInputReportLength, string productName)
         {
@@ -38,14 +38,14 @@ namespace FanaBridge.Transport
     /// for discovery so base-PID selection — which has historically bitten on
     /// interface-shape edge cases — is table-testable.
     /// </summary>
-    public interface IHidBusEnumerator
+    internal interface IHidBusEnumerator
     {
         /// <summary>Snapshots the HID devices for one vendor id.</summary>
         IReadOnlyList<HidDeviceInfo> GetDevices(ushort vendorId);
     }
 
     /// <summary>Production enumerator over HidSharp's <c>DeviceList.Local</c>.</summary>
-    public sealed class HidSharpBusEnumerator : IHidBusEnumerator
+    internal sealed class HidSharpBusEnumerator : IHidBusEnumerator
     {
         public IReadOnlyList<HidDeviceInfo> GetDevices(ushort vendorId)
         {

--- a/FanaBridge/Transport/IHidBusEnumerator.cs
+++ b/FanaBridge/Transport/IHidBusEnumerator.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using HidSharp;
+
+namespace FanaBridge.Transport
+{
+    /// <summary>
+    /// A lightweight snapshot of one HID device on the bus, with the descriptor
+    /// values device selection needs. Descriptor queries can throw on busy
+    /// handles; a failed query is represented as -1 / null rather than an
+    /// exception, so selection logic stays branch-testable.
+    /// </summary>
+    public sealed class HidDeviceInfo
+    {
+        public HidDeviceInfo(int productId, int maxOutputReportLength, int maxInputReportLength, string productName)
+        {
+            ProductId = productId;
+            MaxOutputReportLength = maxOutputReportLength;
+            MaxInputReportLength = maxInputReportLength;
+            ProductName = productName;
+        }
+
+        public int ProductId { get; }
+
+        /// <summary>Max output report length, or -1 when the descriptor query failed.</summary>
+        public int MaxOutputReportLength { get; }
+
+        /// <summary>Max input report length, or -1 when the descriptor query failed.</summary>
+        public int MaxInputReportLength { get; }
+
+        /// <summary>Product name from the HID descriptor, or null when unavailable.</summary>
+        public string ProductName { get; }
+    }
+
+    /// <summary>
+    /// Seam over HID bus enumeration (<c>DeviceList.Local</c> is a process-global
+    /// static that cannot be faked). <see cref="FanatecWheelbase"/> consumes this
+    /// for discovery so base-PID selection — which has historically bitten on
+    /// interface-shape edge cases — is table-testable.
+    /// </summary>
+    public interface IHidBusEnumerator
+    {
+        /// <summary>Snapshots the HID devices for one vendor id.</summary>
+        IReadOnlyList<HidDeviceInfo> GetDevices(ushort vendorId);
+    }
+
+    /// <summary>Production enumerator over HidSharp's <c>DeviceList.Local</c>.</summary>
+    public sealed class HidSharpBusEnumerator : IHidBusEnumerator
+    {
+        public IReadOnlyList<HidDeviceInfo> GetDevices(ushort vendorId)
+        {
+            return DeviceList.Local.GetHidDevices()
+                .Where(d => d.VendorID == vendorId)
+                .Select(Describe)
+                .ToList();
+        }
+
+        private static HidDeviceInfo Describe(HidDevice d)
+        {
+            // Each descriptor query is guarded individually — a busy handle can
+            // fail one query while the others still answer.
+            int maxOut, maxIn;
+            string name;
+            try { maxOut = d.GetMaxOutputReportLength(); } catch { maxOut = -1; }
+            try { maxIn = d.GetMaxInputReportLength(); } catch { maxIn = -1; }
+            try { name = d.GetProductName(); } catch { name = null; }
+            return new HidDeviceInfo(d.ProductID, maxOut, maxIn, name);
+        }
+    }
+}


### PR DESCRIPTION
The test-seams batch: three injection seams that bring the previously-untestable composition layer — where the field bugs (#37, #47-class identity behavior, the col03 reader rework) actually live — under unit test. No behavior changes; every seam keeps the production wiring as the default. **456 tests total, +42 new, all green.**

## 1. Transport connect surface + col03 reader loop (`c7c1ac5`)

- `IConnectableTransport` layers the connect lifecycle (Connect/Disconnect/presence/categorised status) on `IDeviceTransport`; `IHidBusEnumerator` + `HidDeviceInfo` seam `DeviceList.Local` (a process-global static), absorbing the per-device descriptor try/catch into the production enumerator.
- The reader loop reads through a minimal internal `ICol03Source`. Its concurrency invariants previously existed only as comments — **`FanatecTransportReaderTests` (7 tests) now pins**: transient errors retry before faulting; persistent errors fault the reader (driving `IsConnected=false` → reconnect); intentional teardown never faults; a stale session's reader can't poison the current one; loop exit closes the queues so a blocked elicit wakes instead of deadlocking; idle timeouts park again without faulting or spending the retry budget; frames route by wire signature.

## 2. `FanatecWheelbase` dependency injection (`af4cf98`)

The wheelbase newed up its transport, called `DeviceList.Local`, and hard-wired a `Stopwatch` — the single biggest missing seam, since every collaborator beneath it (`IdentitySettler`, `SystemReportReader`, `SrmConverterIdentity`) was already individually testable. An internal ctor injects all three. **`FanatecWheelbaseTests` (24 tests) pins**:

- base-PID selection with descriptor-failure fallback and the deliberate input-only adoption
- FF 08 drain→settle→commit ordering, `WheelChanged` firing exactly once, never on an unchanged re-push, and again on a genuine rim swap — while an A→B→A flap inside the settle window commits nothing
- connect-time `ReadInitial` seeding identity from the enable/trigger elicit reply (respond-on-send fake)
- the 10 s re-enable cadence keeping the push subscription alive
- SRM converter identity: DE FA pings only while unidentified, commit when FF 08 is silent, one-shot fixedness, and elicited-0xDD-must-never-overwrite-committed-identity
- unrecognized hardware: detected-but-not-identified state, the "Unknown (0xXX)" / EXT_INFO report markers, `LastRawReport` updating per-reading before any commit (the diagnostics contract)
- `ProfileOverrideResolver` redirecting capability resolution; committed identity resolving its matching profile
- ITM subscription buffering: one-shot hand-off + the cap-32 drop-oldest bound under a stalled consumer
- the full 15-field `Disconnect` reset; same-rim re-commit after reconnect

## 3. Plugin-generation resolver (`a0e799e`)

`FanatecWheelDeviceInstance` read `FanatecPlugin.Instance` at five sites, making the issue-#37 generation-rebind logic untestable — the one historical bug a unit test would realistically have caught. An internal per-instance `PluginResolver` stands in for the singleton. **`FanatecWheelDeviceInstanceTests` (9 tests) pins the transition matrix**: Disabled/Scanning/Connected state rows including mid-settle output suppression, and the generation rows (first-bind, replacement rebind, plugin-gone stability, same-generation stability).

## 4. Coverage-gap audit (`fa21b6e`)

A follow-up audit of what the seams made testable versus what the first pass tested found six gaps; all closed (they account for the rim-swap, unrecognized-hardware, ReadInitial, override-resolver, ITM-buffer, and idle-timeout items above). Deliberately not covered, so the decision is on record: the Connected→Scanning driver-cleanup row (needs encoder-installation seams — one seam further than this PR should reach) and the timeout-versus-error-counter interaction (current behavior is ambiguous by design; a test would cement a choice nobody has made).

## Notes for review

- The `TransportConnectStatus` enum stays nested in `FanatecTransport` to avoid churn; the planned organization pass can relocate it.
- Wire codes in tests are resolved from `FanatecDeviceTables` rather than hardcoded, so a table correction can't strand them.
- Coverage baseline before this PR: 35.1% line (per #61's CI summary) — this PR moves the orchestration layer onto the covered side.