### PR TITLE
Control Mapper integration: visible failure state + transient-failure retry

### DIFF
--- a/FanaBridge.Tests/ControlMapperBridgeTests.cs
+++ b/FanaBridge.Tests/ControlMapperBridgeTests.cs
@@ -291,6 +291,71 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void TransientGetPluginFailure_QuietlyRetries_ThenRecovers()
+        {
+            // The plugin collection can be in flux during startup — a throwing
+            // GetPlugin<T> is a transient there, and one bad tick must not kill
+            // the integration for the whole session (it previously latched
+            // give-up on the first throw).
+            IFakeControlMapper cm = CmFake.NewPlugin();
+            cm.Worker.Helper.InitList();
+            cm.Settings.RecognizeIndiviualWheels = true;
+            var pm = new FakePluginManagerFlaky(cm, throwsRemaining: 3);
+            var bridge = new ControlMapperBridge();
+
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.Null(bridge.IsRecognizeIndividualWheelsOn(pm));  // failed this tick...
+                Assert.False(bridge.IsGivenUp);                         // ...but not dead
+            }
+
+            Assert.True(bridge.IsRecognizeIndividualWheelsOn(pm));      // recovered
+            Assert.False(bridge.IsGivenUp);
+        }
+
+        [Fact]
+        public void PersistentGetPluginFailure_EscalatesToGiveUp()
+        {
+            // A genuine shape change fails deterministically on every call, so
+            // the persistent-failure threshold still reaches give-up — the
+            // escalation exists so transients don't, not so shape changes never do.
+            IFakeControlMapper cm = CmFake.NewPlugin();
+            cm.Worker.Helper.InitList();
+            var pm = new FakePluginManagerFlaky(cm, throwsRemaining: int.MaxValue);
+            var bridge = new ControlMapperBridge();
+
+            for (int i = 0; i < ControlMapperBridge.LIVE_RESOLVE_FAILURES_BEFORE_GIVE_UP; i++)
+            {
+                Assert.False(bridge.IsGivenUp);
+                bridge.IsRecognizeIndividualWheelsOn(pm);
+            }
+
+            Assert.True(bridge.IsGivenUp);
+        }
+
+        [Fact]
+        public void SuccessBetweenFailures_ResetsTheEscalationCounter()
+        {
+            IFakeControlMapper cm = CmFake.NewPlugin();
+            cm.Worker.Helper.InitList();
+            var bridge = new ControlMapperBridge();
+
+            // Almost reach the threshold, recover once, then fail again just as
+            // long — the counter must have reset, so give-up is never latched.
+            int almost = ControlMapperBridge.LIVE_RESOLVE_FAILURES_BEFORE_GIVE_UP - 1;
+            var pm = new FakePluginManagerFlaky(cm, throwsRemaining: almost);
+            for (int i = 0; i < almost; i++)
+                bridge.IsRecognizeIndividualWheelsOn(pm);
+            bridge.IsRecognizeIndividualWheelsOn(pm);      // succeeds — resets
+
+            pm.ThrowsRemaining = almost;
+            for (int i = 0; i < almost; i++)
+                bridge.IsRecognizeIndividualWheelsOn(pm);
+
+            Assert.False(bridge.IsGivenUp);
+        }
+
+        [Fact]
         public void DescribeResolution_ControlMapperNotLoaded_DoesNotThrow()
         {
             var pm = new FakePluginManager(null); // GetPlugin<T>() returns null
@@ -399,6 +464,31 @@ namespace FanaBridge.Tests.CmFakes
     /// bridge's graceful give-up path.</summary>
     public class FakePluginManagerNoGetPlugin
     {
+    }
+
+    /// <summary>A PluginManager whose GetPlugin&lt;T&gt;() throws for the first N
+    /// calls (startup plugin-collection flux), then answers normally — drives the
+    /// bridge's transient-vs-persistent escalation.</summary>
+    public class FakePluginManagerFlaky
+    {
+        private readonly object _plugin;
+        public int ThrowsRemaining;
+
+        public FakePluginManagerFlaky(object plugin, int throwsRemaining)
+        {
+            _plugin = plugin;
+            ThrowsRemaining = throwsRemaining;
+        }
+
+        public T GetPlugin<T>()
+        {
+            if (ThrowsRemaining > 0)
+            {
+                ThrowsRemaining--;
+                throw new System.InvalidOperationException("plugin collection in flux");
+            }
+            return (T)_plugin;
+        }
     }
 
     /// <summary>Test double for SimHub's ControllerDescription — the public

--- a/FanaBridge/Adapters/ControlMapperBridge.cs
+++ b/FanaBridge/Adapters/ControlMapperBridge.cs
@@ -534,13 +534,33 @@ namespace FanaBridge.Adapters
             }
         }
 
+        // A throwing GetPlugin<T> during startup usually means the plugin
+        // collection is still in flux — a transient, not a shape change. Shape
+        // changes (the LogGiveUp calls in ResolveHandles) fail deterministically
+        // on every call, so a persistent-failure threshold still catches them
+        // here without letting one bad tick at startup kill the integration for
+        // the whole session. Internal so tests pin the exact threshold.
+        internal const int LIVE_RESOLVE_FAILURES_BEFORE_GIVE_UP = 10;
+        private int _liveResolveFailures;
+
         /// <summary>Resolve the live ControlMapperPlugin instance (null if not loaded).</summary>
         private object LiveControlMapper()
         {
-            try { return _getPluginCM.Invoke(_pm, null); }
+            try
+            {
+                object cm = _getPluginCM.Invoke(_pm, null);
+                _liveResolveFailures = 0;   // any non-throwing call proves the path works
+                return cm;
+            }
             catch (Exception ex)
             {
-                LogGiveUp("GetPlugin<ControlMapperPlugin> threw: " + ex.GetBaseException().Message);
+                if (++_liveResolveFailures >= LIVE_RESOLVE_FAILURES_BEFORE_GIVE_UP)
+                    LogGiveUp("GetPlugin<ControlMapperPlugin> failing persistently ("
+                        + _liveResolveFailures + " consecutive): " + ex.GetBaseException().Message);
+                else
+                    SimHub.Logging.Current.Debug(
+                        "FanaBridge: GetPlugin<ControlMapperPlugin> threw (attempt "
+                        + _liveResolveFailures + ", will retry): " + ex.GetBaseException().Message);
                 return null;
             }
         }

--- a/FanaBridge/FanatecPlugin.cs
+++ b/FanaBridge/FanatecPlugin.cs
@@ -219,6 +219,15 @@ namespace FanaBridge
             catch { return null; }
         }
 
+        /// <summary>
+        /// Whether the Control Mapper integration has permanently disabled itself
+        /// for this session (SimHub internals no longer match what the bridge
+        /// reflects into). Surfaced in the settings UI so enabled-but-dead is
+        /// distinguishable from "Control Mapper not installed".
+        /// </summary>
+        public bool IsControlMapperIntegrationGivenUp =>
+            _controlMapperBridge?.IsGivenUp == true;
+
         /// <summary>The connected wheelbase — used by DeviceInstance wrappers to query wheel identity.</summary>
         // ARCHITECTURE: single-device assumption. When multi-device support lands
         // (pedals/shifter/SRM), this becomes a DeviceManager owning a collection;

--- a/FanaBridge/UI/SettingsControl.xaml.cs
+++ b/FanaBridge/UI/SettingsControl.xaml.cs
@@ -126,6 +126,7 @@ namespace FanaBridge.UI
         private static readonly Brush DotConnected = MakeBrush(0x4C, 0xAF, 0x50);  // green
         private static readonly Brush DotConnecting = MakeBrush(0xE0, 0xA8, 0x00); // amber
         private static readonly Brush DotIdle = MakeBrush(0x99, 0x99, 0x99);       // gray
+        private static readonly Brush DotError = MakeBrush(0xE0, 0x5A, 0x50);      // red — broken, needs the log
 
         private static Brush MakeBrush(byte r, byte g, byte b)
         {
@@ -214,6 +215,21 @@ namespace FanaBridge.UI
             if (!Plugin.Settings.EnableControlMapperIntegration)
             {
                 txtControlMapperStatus.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            // Given-up beats everything: the checkbox is on but the integration is
+            // dead (a SimHub update changed the internals the bridge reflects
+            // into). Without this branch that state renders exactly like "Control
+            // Mapper not installed" — invisible — and the first symptom users see
+            // is per-rim mappings silently not following the rim.
+            if (Plugin.IsControlMapperIntegrationGivenUp)
+            {
+                txtControlMapperStatus.Text =
+                    "Control Mapper integration unavailable — SimHub internals changed "
+                    + "(see the SimHub log). Mappings still work, but won't follow rim changes.";
+                txtControlMapperStatus.Foreground = DotError;
+                txtControlMapperStatus.Visibility = Visibility.Visible;
                 return;
             }
 


### PR DESCRIPTION
Fixes the two failure-handling gaps in the Control Mapper reflection bridge. 459 tests, +3 new, all green.

## The problem

The bridge is designed to self-disable when SimHub's internals change shape — but that state was **invisible**: the settings page rendered it identically to "Control Mapper not installed" (collapsed status), so the day a SimHub update renames `remapperWorker`, every user's per-rim mapping stops silently and the only trace is one Warn line in the startup log. Compounding it, `LiveControlMapper` treated *any* `GetPlugin<T>` exception as a permanent shape change — yet it runs during early startup when the plugin collection is most likely to be in flux, so one bad tick could kill the integration for the whole session.

## The fix

- **Visible failure state:** the settings status area now shows a red "Control Mapper integration unavailable — SimHub internals changed (see the SimHub log)" line keyed on `IsGivenUp`, which takes precedence over every other status. Surfaced through a new `FanatecPlugin.IsControlMapperIntegrationGivenUp` facade.
- **Transient-failure survivability:** `GetPlugin<T>` exceptions now quiet-retry (Debug log with attempt count), escalating to give-up only after 10 consecutive failures; any non-throwing call resets the counter. Genuine shape changes still latch immediately via the `ResolveHandles` paths, and still reach give-up here too — they fail deterministically, so the threshold arrives fast.

## Tests

Transient-failure recovery (throws 3× then works — never given up, answers correctly after recovery); persistent-failure escalation at exactly the threshold; counter reset on success between two near-threshold failure bursts.

Support-burden note: this converts "mappings randomly stopped following my rim" tickets into a self-explanatory red status line.
