### PR TITLE
Display overrides take effect live (type + ITM device id)

### DIFF
--- a/FanaBridge.Tests/WheelProfileItmDeviceTests.cs
+++ b/FanaBridge.Tests/WheelProfileItmDeviceTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FanaBridge.Profiles;
 using FanaBridge.Protocol;
 using Xunit;
@@ -24,13 +25,34 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void GetRestartReason_ItmDeviceChange_RequiresRestart()
+        public void GetRestartReason_DisplayChanges_SwitchLive_NoRestart()
         {
+            // Display type and the ITM device id are resolved override-aware each
+            // frame (the ITM driver hot-swaps on an id change), so neither is a
+            // restart reason anymore — only LED-layout changes are, because
+            // SimHub sizes the LED editor from registration-time counts.
             var dev3 = new WheelCapabilities(new WheelProfile { Display = "itm", ItmDeviceIdRaw = 3 });
             var dev4 = new WheelCapabilities(new WheelProfile { Display = "itm", ItmDeviceIdRaw = 4 });
+            var basic = new WheelCapabilities(new WheelProfile { Display = "basic" });
 
-            Assert.NotNull(dev4.GetRestartReason(dev3));   // ITM display device changed → restart
-            Assert.Null(dev4.GetRestartReason(dev4));       // identical caps → no restart
+            Assert.Null(dev4.GetRestartReason(dev3));      // ITM id change → live hot-swap
+            Assert.Null(basic.GetRestartReason(dev3));     // display type change → live
+            Assert.Null(dev4.GetRestartReason(dev4));      // identical caps → no restart
+        }
+
+        [Fact]
+        public void GetRestartReason_LedLayoutChange_StillRequiresRestart()
+        {
+            var noLeds = new WheelCapabilities(new WheelProfile { Display = "itm" });
+            var nineRev = new WheelCapabilities(new WheelProfile
+            {
+                Display = "itm",
+                Leds = System.Linq.Enumerable.Range(0, 9)
+                    .Select(i => new LedDefinition { Channel = LedChannel.RevRgb, HwIndex = i })
+                    .ToList(),
+            });
+
+            Assert.NotNull(nineRev.GetRestartReason(noLeds));
         }
     }
 }

--- a/FanaBridge/Adapters/FanatecDevicesRegistry.cs
+++ b/FanaBridge/Adapters/FanatecDevicesRegistry.cs
@@ -55,9 +55,12 @@ namespace FanaBridge.Adapters
         /// Builds the deduplicated set of device configs that back the
         /// registered descriptors — one per device match key. When multiple
         /// profiles share the same match (e.g. built-in + user test variants),
-        /// the built-in profile wins for the device descriptor (name, type ID).
-        /// The actual LED/display capabilities used at runtime come from the
-        /// currently-active profile (see FanatecLedManager.GetDriver).
+        /// the built-in profile wins for the device descriptor (name, type ID,
+        /// LED editor sizing). The capabilities used at runtime — LED layout AND
+        /// display type / ITM device id — come from the currently-active profile
+        /// via FanatecPlugin.ResolveCapsFor (see FanatecLedManager.GetDriver and
+        /// the display section of FanatecWheelDeviceInstance.DataUpdate), so a
+        /// user override losing this dedupe still takes effect live.
         ///
         /// Shared by descriptor registration (<see cref="GetDevices"/>) and the
         /// settings page's add-device prompt so both resolve a detected wheel

--- a/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -53,6 +53,9 @@ namespace FanaBridge.Adapters
 
         // ITM display driver — null until a wheel with an ITM display is driven.
         private ItmDisplayDriver _itmDisplay;
+        // The display id the ITM driver was built against; an override changing
+        // it hot-swaps the driver (deviceId is a ctor-fixed value).
+        private byte _itmDeviceId;
         private bool _itmWasRunning;
         private bool _itmErrorLogged;
         // True once the legacy page has been blanked after switching to mode "None",
@@ -427,14 +430,43 @@ namespace FanaBridge.Adapters
                 _displayManager?.Clear();
             _displayTestWasActive = displayTest;
 
-            var displayType = _config.Capabilities.Display;
+            // Resolve THIS descriptor's caps override-aware — the same rule the
+            // LED pipeline already follows via ResolveCapsFor (the single guard).
+            // Registration caps froze the built-in profile's display type and ITM
+            // device id, so a user override changing either was honored by LEDs
+            // but silently ignored by the display drivers — restart or not,
+            // because the registry's dedupe keeps the built-in for registration.
+            var displayCaps = plugin.ResolveCapsFor(_config);
+            var displayType = displayCaps.Display;
+
+            // Switched away from ITM (e.g. override to a basic-display profile):
+            // stop the session so the next Itm selection re-runs bring-up.
+            if (displayType != DisplayType.Itm && _itmDisplay != null)
+            {
+                _itmDisplay.Stop();
+                _itmDisplay = null;
+                _itmWasRunning = false;
+            }
+
             if (displayType == DisplayType.Itm)
             {
+                // Override retargeted the ITM display id — the driver's deviceId
+                // is ctor-fixed, so hot-swap it like the LED pipeline does.
+                if (_itmDisplay != null && _itmDeviceId != displayCaps.ItmDeviceId)
+                {
+                    _itmDisplay.Stop();
+                    _itmDisplay = null;
+                    SimHub.Logging.Current.Info(
+                        "FanatecWheelDeviceInstance[" + _config.Capabilities.Name +
+                        "]: ITM display id changed (" + _itmDeviceId + " → " +
+                        displayCaps.ItmDeviceId + ") — rebuilding ITM driver");
+                }
                 if (_itmDisplay == null)
                 {
+                    _itmDeviceId = displayCaps.ItmDeviceId;
                     _itmDisplay = new ItmDisplayDriver(plugin.Itm,
                         log: msg => SimHub.Logging.Current.Info("FanaBridge: " + msg),
-                        deviceId: _config.Capabilities.ItmDeviceId);
+                        deviceId: _itmDeviceId);
                     SimHub.Logging.Current.Info(
                         "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: Created ITM display driver");
                 }

--- a/FanaBridge/Profiles/WheelCapabilities.cs
+++ b/FanaBridge/Profiles/WheelCapabilities.cs
@@ -102,14 +102,12 @@ namespace FanaBridge.Profiles
             if (other == null)
                 return null;
 
+            // Only LED-layout changes still need a restart: SimHub sizes the LED
+            // editor's module from the registration-time counts. Display type and
+            // the ITM device id switch live — the device instance resolves them
+            // override-aware each frame and hot-swaps the ITM driver on change.
             if (RevFlagCount != other.RevFlagCount || ButtonLedCount != other.ButtonLedCount)
                 return "LED count changed (" + other.AllLedCount + " → " + AllLedCount + ")";
-
-            if (Display != other.Display)
-                return "Display type changed (" + other.Display + " → " + Display + ")";
-
-            if (Display == DisplayType.Itm && ItmDeviceId != other.ItmDeviceId)
-                return "ITM display device changed (" + other.ItmDeviceId + " → " + ItmDeviceId + ")";
 
             return null;
         }


### PR DESCRIPTION
Fixes the display-override gap found during the reliability review: user profile overrides changing display type or ITM device id were honored by LEDs but never by the display pipeline — and the restart the UI promised didn't fix it either, because the registry's built-in-wins dedupe means registration caps never reflect an override shadowing a built-in. 460 tests, all green.

## The fix

The display section of `DataUpdate` now resolves capabilities through `ResolveCapsFor` each frame — the same single-guard rule the LED pipeline already follows:

- **Display type switches live.** Leaving `Itm` stops the session cleanly so a later return re-runs bring-up.
- **An ITM device-id change hot-swaps the driver** (its `deviceId` is ctor-fixed), mirroring `HotSwapIfNeeded` on the LED side.

With both live, the display entries in `GetRestartReason` are obsolete and removed — only LED-layout changes still prompt for a restart (SimHub sizes the LED editor from registration-time counts), and the restart dialog's "output has switched immediately" wording is now actually true.

**Deliberately unchanged:** the registry dedupe. Registration legitimately sizes the descriptor (name, type ID, LED editor slots) from the built-in profile, and a same-ID user profile isn't necessarily the *selected* override — flipping the dedupe would apply unselected profiles. The dedupe's doc comment now explains why it no longer masks overrides at runtime.

## Tests

Updated the pinned `GetRestartReason` contract (ITM id and display-type changes → no restart; LED-layout change → still restarts). The live-resolution path itself runs through `ResolveCapsFor`, which is exercised by the #62 seam tests; a hands-on check worth doing: with a wheel connected, point an override at a profile with a different `itmDeviceId` and confirm the ITM display retargets without a restart.
