### PR TITLE
Stop SRM pings and 0xDD acceptance once the connection is identified

### DIFF
--- a/FanaBridge.Tests/FanatecWheelbaseTests.cs
+++ b/FanaBridge.Tests/FanatecWheelbaseTests.cs
@@ -366,6 +366,56 @@ namespace FanaBridge.Tests
             Assert.Equal("CSSWFORMV2", wb.WheelCode);
         }
 
+        [Fact]
+        public void Srm_NeverPingsAgain_AfterRimPull()
+        {
+            // Regression: pulling the wheel mid-operation made WheelDetected false
+            // again, which re-armed the DE FA ping loop on a base FF 08 had
+            // already identified — and since the query's report-id-0x00 frame is
+            // rejected by some bases' HID driver, the transport logged a write
+            // warning every second until a wheel came back. Once ANY identity has
+            // committed, the connection must never ping again.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+
+            CommitIdentity(wb, t, clock, Ff08(0x0C, 0x00));   // rim pulled
+            Assert.False(wb.WheelDetected);
+            Assert.True(wb.HasIdentity);                      // base still identified
+            t.Sent.Clear();
+
+            for (int i = 0; i < 10; i++)
+            {
+                clock.T += 1_100;                             // well past the ping cadence
+                wb.UpdateIdentity();
+            }
+
+            Assert.DoesNotContain(t.Sent, ContainsDeFa);
+        }
+
+        [Fact]
+        public void Srm_ElicitedReply_WithRimPulled_DoesNotConvertTheBase()
+        {
+            // A diagnostics run sends DE FA on demand; with the rim pulled the
+            // WheelDetected guard alone no longer protects the committed base
+            // identity — the 0xDD reply must still be ignored, or a read-only
+            // diagnostics capture would turn a genuine base into an SRM kit.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("PSWBMW")));
+            CommitIdentity(wb, t, clock, Ff08(0x0C, 0x00));   // rim pulled
+
+            t.Srm.Enqueue(SrmReply());
+            clock.T += 10;
+            wb.UpdateIdentity();
+
+            Assert.False(wb.IsSrmConverter);
+            Assert.Equal(0x0C, wb.BaseType);                  // base identity intact
+            Assert.Null(wb.SrmKitFirmware);
+        }
+
         // ── Disconnect: the full state reset ─────────────────────────────
 
         [Fact]

--- a/FanaBridge/Transport/FanatecWheelbase.cs
+++ b/FanaBridge/Transport/FanatecWheelbase.cs
@@ -473,8 +473,13 @@ namespace FanaBridge.Transport
                 CommitIdentity();
 
             // Still unidentified and idle? Ping the DE FA channel (harmless to a genuine base). Any 0xDD
-            // reply is picked up by the next drain. Once FF 08 identifies a base, we never get here.
-            if (!WheelDetected && _identityStable && !IsSrmConverter && now - _lastSrmQueryMs >= SrmQueryMs)
+            // reply is picked up by the next drain. Gated on the CONNECTION being unidentified
+            // (!HasIdentity), not on the wheel: once FF 08 has answered, the base has proven it is
+            // not a converter kit for the life of this connection — a later rim pull makes
+            // WheelDetected false again, but must NOT re-arm the ping loop. (Besides being
+            // pointless, the query's report-id-0x00 frame is rejected by some bases' HID driver,
+            // so re-armed pings logged a write warning every second until a wheel came back.)
+            if (!WheelDetected && !HasIdentity && _identityStable && now - _lastSrmQueryMs >= SrmQueryMs)
             {
                 _lastSrmQueryMs = now;
                 try { _srmReader.SendQuery(_transport); }
@@ -512,13 +517,15 @@ namespace FanaBridge.Transport
         private void OnDrainReading(SystemReportReader.Reading r) => IngestReading(r, _drainNow);
 
         // Drain callback for a 0xDD frame: decode + stash; UpdateIdentity commits it after the drain.
-        // The WheelDetected guard keeps "FF 08 wins if it answered" true even for 0xDD replies we
-        // didn't elicit — the diagnostics probe sends DE FA on demand, and its reply must not
+        // The guards keep "FF 08 wins if it answered" true even for 0xDD replies we didn't
+        // elicit — the diagnostics probe sends DE FA on demand, and its reply must not
         // overwrite an identity the FF 08 path already committed (a read-only diagnostics run
-        // must never mutate runtime identity).
+        // must never mutate runtime identity). HasIdentity (not just WheelDetected) closes the
+        // rim-pulled window: an identified base with no wheel attached is still a genuine base,
+        // and a diagnostics run in that state must not convert it into an SRM kit.
         private void OnDrainSrm(byte[] frame)
         {
-            if (WheelDetected || IsSrmConverter || _pendingSrm.HasValue) return;
+            if (WheelDetected || HasIdentity || _pendingSrm.HasValue) return;
             if (SrmConverterIdentity.TryDecodeFrame(frame, frame.Length, out var srm))
                 _pendingSrm = srm;
         }


### PR DESCRIPTION
Fixes the regression seen when pulling a wheel mid-operation: a repeating `LED write error: Operation failed early: The parameter is incorrect (suppressing repeats)` warning every second until a wheel is reattached.

## Root cause

The SRM converter ping loop (shipped with #47 in v0.5.0) is gated on `!WheelDetected` — so a rim pull on a fully identified base re-arms it. Each ping sends two frames (report-id `0xFF` and `0x00`); on some bases the `0x00` frame is rejected by the HID driver (`ERROR_INVALID_PARAMETER`), and because the accepted `0xFF` frame resets the transport's write-warning dedup, every ping produced a fresh warning line. Net effect: pointless DE FA traffic plus one log line per second, forever.

## Fix

- The ping gate now also requires `!HasIdentity`: once any identity has committed — FF 08 (genuine base) or 0xDD (converter kit) — the connection never pings again. A rim pull doesn't reopen the question (the base already proved it's not a kit; kits have hard-wired wheels so their `WheelDetected` never drops). `Disconnect` resets `BaseType`, so a reconnect probes fresh exactly as before.
- `OnDrainSrm` gets the same tightening: with the rim pulled, the `WheelDetected` guard alone no longer protected the committed identity, so a diagnostics-elicited 0xDD reply could have silently converted a genuine base into an SRM kit. `HasIdentity` closes that window.

## Tests

Two regression tests on the #62 wheelbase seams (462 total, all green):
- rim pull → 10 ping-cadence ticks → zero DE FA frames sent
- rim pull → 0xDD reply arrives → base identity intact, `IsSrmConverter` stays false

Hands-on confirmation: pull the wheel mid-session — the warnings should stop appearing (at most the one in-flight LED write error at the pull instant), and reattaching should re-commit identity normally.