### PR TITLE
ITM: fix blank gear on Formula V3 and GT Extreme wheels

### DIFF
--- a/src/FanaBridge.Core/Protocol/ItmTelemetry.cs
+++ b/src/FanaBridge.Core/Protocol/ItmTelemetry.cs
@@ -77,12 +77,22 @@ namespace FanaBridge.Protocol
         /// <summary>Subscribed parameter ID, or 0xFFFF for an unsubscribe.</summary>
         public ushort ParamId { get; }
 
+        /// <summary>
+        /// The firmware's declared wire type for the slot (report byte 4 of the entry),
+        /// or 0 when unknown (e.g. a host-seeded subscription). The low nibble is the
+        /// type: 1 = ASCII text, 2/3 = u8, 4/5 = i16, 6/7/9 = i32, 8/10 = f32. The same
+        /// parameter can differ per display — GEAR is u8 (0x12) on a PBME but text on a
+        /// Formula V3 — so value encoding must follow this, not the paramId alone.
+        /// </summary>
+        public byte DataType { get; }
+
         public bool IsUnsubscribe => ParamId == ItmParam.Unsubscribe;
 
-        public ItmSubscription(byte firmwareHandle, ushort paramId)
+        public ItmSubscription(byte firmwareHandle, ushort paramId, byte dataType = 0)
         {
             Handle = (byte)(firmwareHandle & 0x7F);
             ParamId = paramId;
+            DataType = dataType;
         }
     }
 
@@ -186,9 +196,17 @@ namespace FanaBridge.Protocol
                 if (report[i] != deviceId) continue;   // entry for a different display — skip it
                 byte fwHandle = report[i + 1];
                 ushort pid = (ushort)(report[i + 2] | (report[i + 3] << 8));
-                result.Add(new ItmSubscription(fwHandle, pid));
+                result.Add(new ItmSubscription(fwHandle, pid, report[i + 4]));
             }
             return result;
         }
+
+        /// <summary>
+        /// Whether a firmware-declared slot type (<see cref="ItmSubscription.DataType"/>) is
+        /// ASCII text (low nibble 1). Hardware-verified both ways on GEAR: a PBME declares
+        /// 0x12 (u8) and ignores ASCII bytes; a Formula V3 receives ASCII chars
+        /// ('n', '1'..'9', 'r') from the official software.
+        /// </summary>
+        public static bool IsTextType(byte dataType) => (dataType & 0x0F) == 1;
     }
 }

--- a/src/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/src/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -34,6 +34,17 @@ namespace FanaBridge.Adapters
         public int ValueIntervalMs { get; set; } = 40;
 
         /// <summary>
+        /// Maximum age of the on-display values before they are re-sent even when unchanged.
+        /// ValueUpdate is unacked, so a lost frame would otherwise stay wrong until the value
+        /// next changes — which in practice only matters when the whole set is static (any
+        /// single changed value already re-sends the full buffer at <see cref="ValueIntervalMs"/>
+        /// cadence). Cheap insurance: one report per interval. Same rationale as the ParamDefs
+        /// double-tap; there is no confirmed observation of a dropped ValueUpdate (an earlier
+        /// lab sighting turned out to be col03 co-driver contention).
+        /// </summary>
+        public int RefreshIntervalMs { get; set; } = 500;
+
+        /// <summary>
         /// Gap before the tight second ParamDefs send (double-tap). ParamDefs is unacked
         /// and a single send is occasionally dropped by the firmware; the official app
         /// double-taps ~49ms apart to prime the decoration so it sticks.
@@ -71,10 +82,13 @@ namespace FanaBridge.Adapters
         // Running against a display that never got its enable/page-set.
         private bool _bringUpModeSent, _bringUpEnableSent, _bringUpPageSent;
 
-        // Firmware-driven subscription map: host handle -> parameter ID. Kept sorted by
-        // handle so the dirty-tracking comparison sees a stable order.
-        private readonly SortedDictionary<byte, ushort> _subs = new SortedDictionary<byte, ushort>();
+        // Firmware-driven subscription map: host handle -> subscription (parameter ID plus
+        // the firmware's declared slot dataType, which steers per-display value encoding —
+        // GEAR is numeric on a PBME but ASCII text on a Formula V3). Kept sorted by handle
+        // so the dirty-tracking comparison sees a stable order.
+        private readonly SortedDictionary<byte, ItmSubscription> _subs = new SortedDictionary<byte, ItmSubscription>();
         private ItmValue[] _lastValues;
+        private long _lastSendOkMs;   // last accepted value send — drives the periodic re-assert
         private bool _loggedFirstValues;
         private string _lastSlotDefsSig = "";   // last ParamDefs suffix set, to skip redundant writes
         private long _defTap2DueMs;               // when to fire the tight second def tap (0 = none)
@@ -168,7 +182,7 @@ namespace FanaBridge.Adapters
                 if (s.IsUnsubscribe)
                     _subs.Remove(s.Handle);
                 else
-                    _subs[s.Handle] = s.ParamId;
+                    _subs[s.Handle] = s;
             }
 
             _lastValues = null;   // subscription set changed — force a fresh value send
@@ -199,22 +213,23 @@ namespace FanaBridge.Adapters
 
             foreach (var kv in _subs)
             {
+                ushort paramId = kv.Value.ParamId;
                 string suffix;
-                if (ItmTelemetryMapper.TryGetUnitSuffix(kv.Value, data, out suffix))
+                if (ItmTelemetryMapper.TryGetUnitSuffix(paramId, data, out suffix))
                 {
                     // Static unit label (e.g. "C").
                 }
-                else if (ItmTelemetryMapper.IsTotalParam(kv.Value))
+                else if (ItmTelemetryMapper.IsTotalParam(paramId))
                 {
                     // Lap/position/fuel: always emit an entry so a total that disappears is
                     // actively cleared — a zero-length suffix does NOT overwrite the firmware's
                     // default "/0", so we write a blank " " to clear it. Fuel is special: with no
                     // tank capacity it falls back to the unit label ("L"/"G") rather than a blank,
                     // so a bare fuel value still reads as fuel.
-                    suffix = ShowTotalFor(kv.Value)
-                          && ItmTelemetryMapper.TryGetTotalSuffix(kv.Value, data, out var total)
+                    suffix = ShowTotalFor(paramId)
+                          && ItmTelemetryMapper.TryGetTotalSuffix(paramId, data, out var total)
                         ? total
-                        : (kv.Value == ItmParam.Fuel ? ItmTelemetryMapper.FuelUnitLabel(data) : " ");
+                        : (paramId == ItmParam.Fuel ? ItmTelemetryMapper.FuelUnitLabel(data) : " ");
                 }
                 else
                 {
@@ -377,7 +392,7 @@ namespace FanaBridge.Adapters
             UpdateSlotDefs(data, now);   // refresh unit/total suffixes; tight double-tap so they stick
             if (now - _lastValuesMs >= ValueIntervalMs)
             {
-                SendSubscribedValues(data);
+                SendSubscribedValues(data, now);
                 _lastValuesMs = now;
             }
         }
@@ -392,7 +407,9 @@ namespace FanaBridge.Adapters
                 return;
             var ids = SeedParamsForPage(DefaultPage);
             for (int h = 0; h < ids.Count; h++)
-                _subs[(byte)h] = ids[h];
+                // dataType 0 = unknown: values encode with the default (numeric) forms until
+                // the firmware's push supplies each slot's declared type.
+                _subs[(byte)h] = new ItmSubscription((byte)h, ids[h]);
         }
 
         // The params the given page carries on this driver's device (empty for an unknown page
@@ -405,7 +422,7 @@ namespace FanaBridge.Adapters
             return Array.Empty<ushort>();
         }
 
-        private void SendSubscribedValues(GameData data)
+        private void SendSubscribedValues(GameData data, long now)
         {
             if (_subs.Count == 0)
                 return;
@@ -413,16 +430,20 @@ namespace FanaBridge.Adapters
             _valueBuf.Clear();
             foreach (var kv in _subs)
             {
-                if (ItmTelemetryMapper.TryEncodeParam(kv.Value, kv.Key, data, out var v))
+                if (ItmTelemetryMapper.TryEncodeParam(kv.Value.ParamId, kv.Key, data, kv.Value.DataType, out var v))
                     _valueBuf.Add(v);
-                else if (_unencodableWarned.Add(kv.Value))
+                else if (_unencodableWarned.Add(kv.Value.ParamId))
                     // Firmware subscribed a parameter outside our page layouts — it will
                     // render as dashes. Note it once so the gap is diagnosable.
-                    _log("ITM: no encoder for subscribed param " + kv.Value +
+                    _log("ITM: no encoder for subscribed param " + kv.Value.ParamId +
                          " (handle " + kv.Key + ") — field will show dashes");
             }
 
-            if (_valueBuf.Count == 0 || !HasChanged(_valueBuf))
+            // Re-assert even unchanged values every RefreshIntervalMs: ValueUpdate is unacked,
+            // and change-gated sending alone would leave a lost frame wrong on the display
+            // until the value next changes.
+            bool refresh = now - _lastSendOkMs >= RefreshIntervalMs;
+            if (_valueBuf.Count == 0 || (!refresh && !HasChanged(_valueBuf)))
                 return;
 
             // Only record the values as last-sent (and log the first update) when the send
@@ -431,6 +452,7 @@ namespace FanaBridge.Adapters
             if (!_encoder.SendValues(_valueBuf, _deviceId))
                 return;
 
+            _lastSendOkMs = now;
             Remember(_valueBuf);
 
             if (!_loggedFirstValues)
@@ -441,7 +463,8 @@ namespace FanaBridge.Adapters
         }
 
         private string Describe()
-            => string.Join(" ", _subs.Select(kv => "h" + kv.Key + "=p" + kv.Value));
+            => string.Join(" ", _subs.Select(kv => "h" + kv.Key + "=p" + kv.Value.ParamId
+                + (kv.Value.DataType != 0 ? ":t" + kv.Value.DataType.ToString("X2") : "")));
 
         private bool HasChanged(IReadOnlyList<ItmValue> values)
         {

--- a/src/FanaBridge/Adapters/ItmTelemetryMapper.cs
+++ b/src/FanaBridge/Adapters/ItmTelemetryMapper.cs
@@ -187,10 +187,30 @@ namespace FanaBridge.Adapters
         /// parameter has no known encoder.
         /// </summary>
         public static bool TryEncodeParam(ushort paramId, byte handle, GameData data, out ItmValue value)
+            => TryEncodeParam(paramId, handle, data, 0, out value);
+
+        /// <summary>
+        /// Encodes a single subscribed parameter honouring the firmware's declared slot type
+        /// (<paramref name="dataType"/>, from the subscription push; 0 = unknown). The type
+        /// matters for GEAR, whose wire form differs per display: a PBME declares u8 (0x12)
+        /// and ignores ASCII, while a Formula V3 takes ASCII chars ('n', '1'..'9', 'r') — both
+        /// hardware/capture-verified against the official software. Other parameters encode
+        /// the same regardless.
+        /// </summary>
+        public static bool TryEncodeParam(ushort paramId, byte handle, GameData data, byte dataType, out ItmValue value)
         {
             value = default;
             var status = data?.NewData;
-            if (status == null || !Registry.TryGetValue(paramId, out var encode))
+            if (status == null)
+                return false;
+
+            if (paramId == ItmParam.Gear && ItmTelemetry.IsTextType(dataType))
+            {
+                value = ItmValue.Ascii(handle, ItmParam.Gear, GearText(status.Gear));
+                return true;
+            }
+
+            if (!Registry.TryGetValue(paramId, out var encode))
                 return false;
             value = encode(status, handle);
             return true;
@@ -292,13 +312,18 @@ namespace FanaBridge.Adapters
             return map.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
 
-        /// <summary>Reverse sentinel: -1 as a Uint8, which the firmware renders as "r".</summary>
+        /// <summary>
+        /// Reverse sentinel: -1 as a Uint8, which the firmware renders as "r"
+        /// (hardware-verified on a PBME under clean single-writer conditions).
+        /// </summary>
         private const byte GearReverse = 0xFF;
 
         /// <summary>
         /// Parses SimHub's gear string to the ITM Uint8 gear value: "N"/empty = 0, "1".."9" =
         /// that number, "R" = <see cref="GearReverse"/>. Forward gears are literal, confirmed
-        /// against an official-software capture (N=0, 2=2, 3=3).
+        /// against official-software PBME captures (N=0, gears 1..4 literal). Used when the
+        /// firmware declares GEAR as a numeric slot (or the type is unknown); text-declared
+        /// displays take <see cref="GearText"/> instead.
         /// </summary>
         private static byte EncodeGear(string gear)
         {
@@ -310,6 +335,26 @@ namespace FanaBridge.Adapters
             if (gear == "N" || gear == "NEUTRAL") return 0;
 
             return int.TryParse(gear, out int g) && g >= 0 && g <= 254 ? (byte)g : (byte)0;
+        }
+
+        /// <summary>
+        /// Parses SimHub's gear string to the ITM ASCII gear form used by text-declared
+        /// displays (e.g. Formula V3): lowercase "n" for neutral, lowercase "r" for reverse,
+        /// forward gears as their decimal digits — exactly the characters the official
+        /// software puts on the wire (capture-verified: 'n', '5'..'1', 'r').
+        /// </summary>
+        private static string GearText(string gear)
+        {
+            if (string.IsNullOrEmpty(gear))
+                return "n";
+
+            gear = gear.Trim().ToUpperInvariant();
+            if (gear == "R" || gear == "REVERSE") return "r";
+            if (gear == "N" || gear == "NEUTRAL") return "n";
+
+            return int.TryParse(gear, out int g) && g >= 1 && g <= 99
+                ? g.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                : "n";
         }
     }
 }

--- a/tests/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/tests/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -579,6 +579,73 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void Values_Unchanged_ReassertedAfterRefreshInterval()
+        {
+            // ValueUpdate is unacked, so unchanged values are re-asserted every
+            // RefreshIntervalMs as insurance against a lost frame sticking.
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+
+            var s = NewStatus();
+            Set(s, "TyreTemperatureFrontLeft", 80.0);
+            clock.T += 40;
+            driver.Update(Data(s));
+            t.Sent.Clear();
+
+            clock.T += driver.RefreshIntervalMs;   // past the refresh window, telemetry unchanged
+            driver.Update(Data(s));
+
+            Assert.Contains(t.Sent, IsValueUpdate);
+        }
+
+        // The gear entry's value byte from a ValueUpdate frame
+        // (header [FF 05 01], entries [dev][handle][idLo][idHi][size][val...]).
+        private static byte? GearValue(byte[] r)
+        {
+            for (int i = 3; i + 6 <= r.Length && r[i] != 0; i += 5 + r[i + 4])
+                if (r[i + 2] == 0x04 && r[i + 3] == 0x00) return r[i + 5];
+            return null;
+        }
+
+        [Fact]
+        public void Gear_NumericSlot_SendsNumericByte()
+        {
+            // TyreSubReport declares GEAR with dataType 0x12 (u8, as a PBME does):
+            // gear "3" goes on the wire as numeric 0x03.
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(TyreSubReport);
+            t.Sent.Clear();
+
+            var s = NewStatus();
+            Set(s, "Gear", "3");
+            clock.T += 40;
+            driver.Update(Data(s));
+
+            Assert.Equal((byte)0x03, GearValue(t.Sent.First(IsValueUpdate)));
+        }
+
+        [Fact]
+        public void Gear_TextSlot_SendsAsciiChar()
+        {
+            // A display that declares GEAR as text (low nibble 1, as a Formula V3 does)
+            // gets the ASCII form: gear "3" goes on the wire as '3' (0x33).
+            var textSub = HexToBytes("ff0501" + "0300010034" + "0301040011");
+            var driver = MakeDriver(out var t, out var clock);
+            Enable(driver, clock);
+            driver.OnSubscriptionReport(textSub);
+            t.Sent.Clear();
+
+            var s = NewStatus();
+            Set(s, "Gear", "3");
+            clock.T += 40;
+            driver.Update(Data(s));
+
+            Assert.Equal((byte)0x33, GearValue(t.Sent.First(IsValueUpdate)));
+        }
+
+        [Fact]
         public void Values_Resent_WhenSubscriptionChanges()
         {
             var driver = MakeDriver(out var t, out var clock);

--- a/tests/FanaBridge.Tests/ItmTelemetryTests.cs
+++ b/tests/FanaBridge.Tests/ItmTelemetryTests.cs
@@ -357,6 +357,30 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void ParseSubscriptionReport_CapturesDeclaredDataType()
+        {
+            // Same tyre-page report: each entry's 5th byte is the firmware's declared slot
+            // type (0x34 = i16 speed, 0x12 = u8 gear, 0x32 = u8 temps).
+            var report = HexToBytes("ff05010300010034030104001203822a00320383300032");
+            var subs = ItmTelemetry.ParseSubscriptionReport(report, report.Length);
+
+            Assert.Equal((byte)0x34, subs[0].DataType);
+            Assert.Equal((byte)0x12, subs[1].DataType);
+            Assert.Equal((byte)0x32, subs[2].DataType);
+            Assert.Equal((byte)0x32, subs[3].DataType);
+        }
+
+        [Fact]
+        public void IsTextType_LowNibbleOne_Only()
+        {
+            Assert.True(ItmTelemetry.IsTextType(0x01));
+            Assert.True(ItmTelemetry.IsTextType(0x11));
+            Assert.False(ItmTelemetry.IsTextType(0x12));   // PBME GEAR (u8)
+            Assert.False(ItmTelemetry.IsTextType(0x34));   // SPEED (i16)
+            Assert.False(ItmTelemetry.IsTextType(0x00));   // unknown / seeded
+        }
+
+        [Fact]
         public void ParseSubscriptionReport_DecodesUnsubscribe()
         {
             // FF 05 01, then [03][h][FF FF][unit] entries = unsubscribe
@@ -424,6 +448,41 @@ namespace FanaBridge.Tests
         public void TryEncodeParam_UnknownParam_ReturnsFalse()
         {
             Assert.False(ItmTelemetryMapper.TryEncodeParam(9999, 0, Wrap(NewStatus()), out _));
+        }
+
+        // ── GEAR per-display encoding (declared dataType steers the wire form) ──
+
+        [Theory]
+        [InlineData("N", "n")]
+        [InlineData("", "n")]
+        [InlineData("3", "3")]
+        [InlineData("9", "9")]
+        [InlineData("R", "r")]
+        [InlineData("reverse", "r")]
+        [InlineData("garbage", "n")]
+        public void TryEncodeParam_Gear_TextSlot_SendsAsciiChar(string gear, string expected)
+        {
+            // A display that declares GEAR as text (e.g. Formula V3) takes the ASCII form
+            // the official software sends: lowercase 'n'/'r', digits literal.
+            var s = NewStatus();
+            Set(s, "Gear", gear);
+
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.Gear, 1, Wrap(s), 0x11, out var v));
+            Assert.Equal((byte)1, v.Size);
+            Assert.Equal(expected, AsAscii(v));
+        }
+
+        [Theory]
+        [InlineData(0x12)]   // PBME's declared u8 type
+        [InlineData(0x00)]   // unknown (host-seeded before the push lands)
+        public void TryEncodeParam_Gear_NumericOrUnknownSlot_SendsNumericByte(int dataType)
+        {
+            var s = NewStatus();
+            Set(s, "Gear", "3");
+
+            Assert.True(ItmTelemetryMapper.TryEncodeParam(ItmParam.Gear, 1, Wrap(s), (byte)dataType, out var v));
+            Assert.Equal((byte)1, v.Size);
+            Assert.Equal((byte)3, AsU8(v));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #70.

On some wheels — reported on a GT Extreme and a Formula V3, both on a ClubSport DD — the ITM gear field never renders while every other field works. Captures of the official software on the same hardware show why: those displays declare their GEAR slot as **text** in the firmware subscription push and are sent ASCII characters (`'n'`, `'1'`–`'9'`, `'r'`), whereas displays like the PBME declare it as a 1-byte integer and take numeric values (and ignore ASCII). FanaBridge always sent the numeric form, so text-declared displays rendered nothing. 484 tests, all green.

## The fix

- **The subscription-push parser captures each slot's declared data type** (entry byte 4; low nibble is the wire type) and the driver carries it in the handle map.
- **GEAR encodes per the declared type** — ASCII on text slots, numeric otherwise, including when the type is unknown (host-seeded subscriptions before the firmware's push lands). Behavior on numeric displays is unchanged.
- **Unchanged values are re-asserted every 500 ms.** ValueUpdate is unacked, so with purely change-gated sends a lost frame stays wrong on the display until the value next changes — one extra report per interval buys self-healing.

The protocol reference sections on subscription pushes and GEAR document the underlying behavior; that doc update ships with the ITM lifecycle work.