### PR TITLE
ITM lifecycle state machine: push-confirmed page control, recovery, and clean idle

### DIFF
--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -70,7 +70,6 @@ Fanatec wheelbases communicate with the host PC over USB HID (Human Interface De
   - [RGB565 Color Encoding](#rgb565-color-encoding)
   - [7-Segment Encoding Tables](#7-segment-encoding-tables)
   - [ITM Parameter IDs](#itm-parameter-ids)
-  - [ITM Unit System](#itm-unit-system)
   - [ITM Page Layouts](#itm-page-layouts)
   - [ITM Supported Devices](#itm-supported-devices)
   - [APM-Capable Wheels](#apm-capable-wheels)
@@ -524,7 +523,7 @@ When only one has changed, send that report alone with commit = `0x01`.
 
 ### 0x02 — ITM Enable
 
-Conventionally the ITM session **enable** (command class `0x02`, not `0x05`). It is separate from the persistent [ITM Mode gate](#0x02--itm-mode-enable-gate) (`FF 05 02`); a full bring-up uses both — see [Control Model](#control-model).
+Conventionally the ITM session **enable** (command class `0x02`, not `0x05`). It is separate from the persistent [ITM Mode gate](#0x02--itm-mode-enable-gate) (`FF 05 02`); Fanatec's bring-up sequences include both, though only the gate has been observed to have a measured effect to date — see [Control Model](#control-model).
 
 ```
 FF 02 02 00 [00 x60]
@@ -535,11 +534,11 @@ FF 02 02 00 [00 x60]
 | 0 | `0xFF` | Report ID |
 | 1 | `0x02` | Command class |
 | 2 | `0x02` | Sub-command |
-| 3 | `0x00` | Always `0x00`. Not a page selector — paging is [PageSet](#0x04--pageset). |
+| 3 | `0x00`/`0x01` | Observed as `0x00` (before page changes) and `0x01` (at software startup) in official-software captures. Not a page selector — paging is [PageSet](#0x04--pageset). Semantics unresolved. |
 
 **Important:**
-- Send Enable **once** at session start (as the official app does), then keep sending [value updates](#0x01--valueupdate). (Repeating it appears harmless in testing.)
-- On its own, Enable shows nothing new. What the display shows is governed by the [ITM Mode gate](#0x02--itm-mode-enable-gate) and [PageSet](#0x04--pageset) — see [Control Model](#control-model) for the bring-up.
+- In hardware testing to date, "Enable" produced **no observable effect in any state tried** — mid-session, after gate-off, after a wheel hot-swap, after a base power cycle — and cold bring-up succeeds without it (gate + PageSet alone). Until this command is better understood, it is recommended to retain it in bring-up sequences purely to match official-software behavior.
+- On its own, Enable shows nothing. What the display shows is governed by the [ITM Mode gate](#0x02--itm-mode-enable-gate) and [PageSet](#0x04--pageset) — see [Control Model](#control-model) for the bring-up.
 
 ### 0x03 — Tuning Menu
 
@@ -793,7 +792,7 @@ Each entry:
 | 0 | 1 | Device ID | Which display this entry is for (values as in [PageSet](#0x04--pageset)) |
 | 1 | 1 | Handle | Parameter handle (dictated by the firmware — see [Firmware Subscription Pushes](#firmware-subscription-pushes-device--host)) |
 | 2–3 | 2 | Param ID | Parameter ID (little-endian). See [ITM Parameter IDs](#itm-parameter-ids). |
-| 4 | 1 | Size | Value size in bytes (1, 2, or 4) |
+| 4 | 1 | Size | Value size in bytes — 1, 2, or 4 for numeric types; text-typed parameters use the character count (e.g. ENGINE_MAPPING sends 1–2 bytes) |
 | 5+ | N | Value | Parameter value (little-endian, size from above) |
 
 > **The leading byte is the display-device id** — which display the entry is for, using the same values as [PageSet](#0x04--pageset). Entries addressed to a display that isn't attached are silently ignored.
@@ -802,12 +801,14 @@ Each entry:
 
 #### 0x02 — ITM Mode (Enable Gate)
 
-Turns ITM on or off at the firmware level — the same persistent state the Fanatec software's "ITM" switch sets; the on-screen "ITM" indicator (corner text) reflects it. This is the persistent `FF 05 02` gate, **not** the session [Enable](#0x02--itm-enable) (`FF 02 02`); a full bring-up uses both — see [Control Model](#control-model).
+Turns ITM on or off at the firmware level — the same persistent state the Fanatec software's "ITM" switch sets; the small "ITM" text in the lower-right of the display reflects it. This is the persistent `FF 05 02` gate, **not** the session [Enable](#0x02--itm-enable) (`FF 02 02`); bring-up sequences conventionally include both, though only the gate has a measured effect — see [Control Model](#control-model).
 
 - **`FF 05 02 00` (off):** the display drops to the true [legacy](#col01--legacy-control-8-bytes) 7-segment view and the "ITM" indicator disappears (any cached 7-seg value already on screen persists).
-- **`FF 05 02 01` (on):** ITM turns on and shows the page from the most recent [PageSet](#0x04--pageset) since the gate-off — **or the legacy page (6) if none** — emitting that page's subscription push (an **unsubscribe-all** clearing the old handles, then the new page's handles; a legacy target shows only the unsubscribe-all).
+- **`FF 05 02 01` (on):** ITM turns on and shows the page from the most recent [PageSet](#0x04--pageset) since the gate-off — **or the legacy ITM page if none** (page 6 on BME/GTSWX; the number varies by display — see [ITM Page Layouts](#itm-page-layouts)). If that lands on a *different* page than before, the firmware emits the page's subscription push: an **unsubscribe-all** clearing the old handles, then the new page's handles. Landing on the legacy ITM page — which carries no telemetry parameters — pushes only the unsubscribe-all. A gate-on that lands where the display already was — e.g. a bare gate cycle from legacy — emits nothing.
 
-A [PageSet](#0x04--pageset) works **even while gated off**: it's recorded (no visual, ITM is off) and applied on the next gate-on. So `gate off → PageSet(N) → gate on` lands directly on page N, whereas a bare `gate off → gate on` lands on legacy. There is always a current page — the legacy page (6) is the fallback, never "no page." (Hardware-confirmed.)
+A [PageSet](#0x04--pageset) works **even while gated off**: it's recorded (no visual, ITM is off) and applied on the next gate-on. So `gate off → PageSet(N) → gate on` lands directly on page N, whereas a bare `gate off → gate on` lands on legacy. There is always a current page — the legacy ITM page is the fallback, never "no page." (Hardware-confirmed.)
+
+> **Don't conflate the two legacy-looking states.** The **legacy ITM page** (gate on, session live) and **true legacy** (gate off) are easy to mistake for each other: both render 7-segment-style col01 content, and the visible difference is the small **"ITM" text in the lower-right of the screen** — shown on the legacy ITM page, absent in true legacy. On the wire they are worse than similar: entering either state produces at most an unsubscribe-all, so **an unsubscribe-all with no subscriptions following does not identify which state the display entered**, and this protocol has no state query. To disambiguate actively, send a `PageSet` targeting a telemetry page: a subscription push back means the session was live (and the display is now on that page); silence means gated off (the PageSet was recorded, not applied) — or a lost command. The `gate off → PageSet → gate on` sequence converges from *either* state, which is why recovery procedures prefer it over diagnosis.
 
 ```
 Enable:   FF 05 02 01 [00 x60]
@@ -818,11 +819,11 @@ Disable:  FF 05 02 00 [00 x60]
 |------|-------|-------------|
 | 3 | `0x01` / `0x00` | ITM on / off |
 
-The setting is **persistent** (survives power cycles).
+The **setting** is persistent (survives power cycles — the same state the official software's ITM switch reflects), but the **runtime session is not**: after a base power cycle or a wheel re-seat the device behaves cold regardless of the persisted setting — `PageSet`s are ignored until a fresh `gate off → PageSet → gate on` re-establishes the session. Persistence tells you what the display *will* be set to; it does not save the host from re-running bring-up.
 
 #### 0x03 — ParamDefs
 
-Defines the display slot layout — tells the firmware what parameters will be displayed and in which positions:
+Functionally a **unit/suffix report**: it attaches a short ASCII decoration to a parameter the firmware has already subscribed — a unit like `"C"` on a temperature, or a total like `"/24"` that renders "Position 5 **/24**". That is all it does. "ParamDefs" is the historical name used throughout these docs, dating from an early misreading that this command *defined* which parameters a page displays — it does not: page composition and placement are fixed by the firmware and announced via [subscription pushes](#firmware-subscription-pushes-device--host); this command only decorates those slots.
 
 ```
 FF 05 03 <entries...> [00-padded to 64 bytes]
@@ -833,9 +834,9 @@ Each entry:
 | Offset | Size | Field | Description |
 |--------|------|-------|-------------|
 | 0 | 1 | Device ID | Which display this entry is for (values as in [PageSet](#0x04--pageset)) |
-| 1 | 1 | Slot ID | Display layout identifier (e.g., `0x82`, `0x85`, `0x88`) |
-| 2 | 1 | Position Lo | Low byte of position (typically `0x00`) |
-| 3 | 1 | Position Hi | High byte of position (typically `0x00`) |
+| 1 | 1 | Slot ID | The target parameter's handle with the high bit set (`0x80 \| handle` — e.g., `0x82` decorates handle 2) |
+| 2 | 1 | Position Lo | Low byte of position. Always `0x00` in captures; purpose unknown. |
+| 3 | 1 | Position Hi | High byte of position. Always `0x00` in captures; purpose unknown. |
 | 4 | 1 | Suffix Length | Number of suffix bytes following (0 = no suffix) |
 | 5+ | N | Suffix Bytes | ASCII text appended after values (e.g., `2F 30` = "/0") |
 
@@ -846,6 +847,8 @@ Each entry:
 ```
 
 The suffix system attaches a unit/total to a slot (e.g. `2F 30` = "/0" total denominator → "Lap 5 / 20"; `43` = "C" for °C on temperature params). **The slot ID is `0x80 + handle`** — i.e. ParamDefs decorates the same handles used by [ValueUpdate](#0x01--valueupdate), but with the high bit set. ParamDefs is **cosmetic** (units only): a param's value renders from its ValueUpdate alone; only params that carry a unit/total get a ParamDefs entry.
+
+Suffixes are the *entire* wire-level unit mechanism. Unit conversion happens host-side — the value is converted before sending (°C vs °F, km/h vs mph) and the matching suffix text chosen; the firmware renders whatever number it is given. A total suffix like `"/24"` is literal text, so the entry must be re-sent whenever the total changes. Suffix frames appear at bring-up, on page changes, and on total changes — not per value tick.
 
 Maximum subscribed parameters per device: **16**.
 
@@ -860,18 +863,18 @@ FF 05 04 <deviceId> <page> [00 x59]
 
 | Byte | Field | Description |
 |------|-------|-------------|
-| 3 | Device ID | Target display (1=Base, 2=not present on tested hardware, 3=BME/GTSWX, 4=Bentley) |
+| 3 | Device ID | Target display: 1=Base, 3=BME/GTSWX, 4=Bentley — see [ITM Supported Devices](#itm-supported-devices). Device 2 ("SmallOLED") exists in the protocol's device numbering but no known hardware implements it; frames addressed to it are seemingly accepted, but have no effect. |
 | 4 | Page number | Page to display (1–6, device-dependent). See [ITM Page Layouts](#itm-page-layouts). |
 
-Page change commands should be spaced at least 100ms apart. The firmware needs time to reconfigure its internal display state between pages.
+Space page-change commands at least ~100 ms apart — an established convention that matches official-software pacing; tighter spacing has not been probed.
 
-**We've observed `PageSet` commands being ignored, but the root cause isn't understood.** In testing, some `PageSet` commands produced no page change and no [subscription push](#firmware-subscription-pushes-device--host) — intermittently, and *regardless* of spacing (failures happened seconds apart, far beyond the 100 ms floor). Re-sending the identical command then worked.
+**Dropped `PageSet`s: concurrent traffic is an identified cause.** `PageSet` reliability depends on what else is on the wire. In hardware testing, switches issued on an otherwise-quiet col03 channel were consistently confirmed by a push, while switches issued with [ValueUpdate](#0x01--valueupdate)s streaming alongside failed a substantial fraction of the time (no push, no page change) — and in one instance, streaming that continued through the retries left the display unresponsive until a quiet gate-off → PageSet → gate-on cycle recovered it. The failure *rate* likely varies with wheelbase, firmware, and traffic volume; the *mechanism* — a switch can silently fail to take, and concurrent traffic makes that more likely — should be assumed everywhere. Two rules for reliable host-driven paging follow: **(1) suspend ValueUpdate/ParamDefs traffic from shortly before a `PageSet` until its push confirms; (2) treat the push as the only acknowledgment that a switch happened** — never assume a `PageSet` took, and be prepared to retry.
 
-What makes this genuinely hard to detect is that there is an **expected** case that looks identical to a dropped command: **the firmware only pushes on an actual page *change*. A `PageSet` for the page the display is already on correctly produces no push.** So the absence of a push is ambiguous — the host cannot tell "already on this page, nothing to do" from "the command was ignored." (Observed directly: a first `PageSet(5)` pushes page 5's subscription; three further `PageSet(5)` in a row push nothing, because the display is already there; a following `PageSet(6)` pushes again as it switches.)
+A second, *expected* case looks identical to a dropped command: **the firmware only pushes on an actual page *change*. A `PageSet` for the page the display is already on correctly produces no push** (consistent in testing; a preceding Enable makes no difference). The absence of a push is therefore ambiguous — the host cannot tell "already on this page" from "command lost." To convert silence into signal, force a *genuine* change: switch to a different page and back (each real change must push).
 
-Practical guidance for host-driven paging: track the page you believe is current, and treat a missing push as a *possible* failure only when you targeted a *different* page — then retry. Even so, whether such a miss is a firmware drop or a page switch that wasn't re-announced is still open, and needs a display-vs-push cross-check to resolve.
+Practical guidance for host-driven paging: suspend value traffic around the switch, treat a missing push as a possible failure only when targeting a *different* page, retry with ≥100 ms spacing, and escalate to a flip-away-and-back — then to a gate cycle with the PageSet sent while gated off, the most reliable recovery observed in testing (see the [gate](#0x02--itm-mode-enable-gate)).
 
-**The legacy "keepalive" is just a PageSet.** `FF 05 04 02 0B` decodes as `PageSet(device 2, page 11)` — addressed to a display not present on the tested hardware, so it does nothing visible, and it appears in zero live captures. No periodic frame is needed to keep the display fed by [ValueUpdate](#0x01--valueupdate)s: the display has **no idle timeout** (see [Control Model](#control-model)), and FanaBridge sends no keepalive.
+**The dev-2 `PageSet` stream is not a keepalive.** Current official software emits `PageSet(2, X)` at ~10 Hz from its first ITM activity until it exits (X varies by rig/version — pinned to 11, device 2's legacy page, or mirroring the active device-3 page). Since no current hardware implements device 2, the stream has no effect on anything; it runs even while gated off and stops only when the software exits. It serves no protocol function: the display has **no idle timeout** (see [Control Model](#control-model)) and no periodic frame is needed — our recommendation is to not send it.
 
 #### 0x05 — DisplayReset
 
@@ -885,7 +888,7 @@ What it does and doesn't touch (hardware-verified):
 
 - **Cleared:** every field value previously written by [ValueUpdate](#0x01--valueupdate), on every ITM page.
 - **Untouched:** the ITM Mode gate, the session enable, the active page, and the firmware's current subscriptions — no subscription push is emitted, and value flow resumes at the existing handles. (The reset elicits nothing on the input endpoint; it is a command, not a query.)
-- **Untouched:** the legacy page (6) — its 7-segment-style content is rendered from [col01 display writes](#0x02--7-segment-display-data) and is cleared through that path instead.
+- **Untouched:** the legacy ITM page — its 7-segment-style content is rendered from [col01 display writes](#0x02--7-segment-display-data) and is cleared through that path instead.
 
 This is the **only known way to clear already-written field values**: gating ITM off and back on does *not* clear them — the firmware retains every field's value across the off→on cycle and shows it again on re-enable (hardware-verified). The official software issues a reset during its own ITM initialization. Because subscriptions survive the reset, subsequent [ValueUpdate](#0x01--valueupdate)s repaint the same handles with no re-bring-up.
 
@@ -893,7 +896,7 @@ This is the **only known way to clear already-written field values**: gating ITM
 
 Control of the ITM display is **split** between the host and the firmware — neither drives it alone:
 
-- **The host selects the page.** A host [PageSet](#0x04--pageset) chooses which page is shown; the wheel's display button does the same thing. The two are equivalent triggers, and either can change the page at any time.
+- **The host selects the page.** A host [PageSet](#0x04--pageset) chooses which page is shown; the wheel's display button does the same thing. The two are equivalent triggers within a live session — neither works before a session exists (a cold display ignores both until brought up).
 - **The firmware assigns the handles.** On every page change it *pushes* the new page's parameter subscriptions (see [Firmware Subscription Pushes](#firmware-subscription-pushes-device--host)); the host echoes [ValueUpdate](#0x01--valueupdate)s only at the handles the firmware pushed. Values sent at *guessed* handles — for a page the firmware hasn't announced — are ignored.
 
 So the host chooses *what page*; the firmware chooses *which handles*.
@@ -902,18 +905,20 @@ So the host chooses *what page*; the firmware chooses *which handles*.
 
 ```
 1. FF 05 02 01 ...        ← ITM Mode gate ON (persistent — 0x02 above)
-2. FF 02 02 00 ...        ← session Enable (once — never in a loop; see 0x02 — ITM Enable)
+2. FF 02 02 00 ...        ← session Enable (optional, kept for official parity; see 0x02 — ITM Enable)
 3. FF 05 04 <dev> <page>  ← PageSet to establish a page
 4. FF 05 01 <entries>     ← ValueUpdates at the handles the PageSet pushes back
 ```
 
-Step 3 is what actually brings a page up: in testing, a bare [`FF 02 02`](#0x02--itm-enable) enable with no PageSet produced no push and no page. Once the gate is on (it is persistent) and enable has run, a [PageSet](#0x04--pageset) — or a wheel-button press — is all that's needed to make the firmware push a page's subscription.
+Step 3 is what actually brings a page up: in testing, a bare [`FF 02 02`](#0x02--itm-enable) enable with no PageSet produced no push and no page. Within a live session, a [PageSet](#0x04--pageset) — or a wheel-button press — is all that's needed to make the firmware push a page's subscription. But note the gate's **setting-vs-session** distinction (see [ITM Mode](#0x02--itm-mode-enable-gate)): after a power cycle or wheel re-seat the device is cold no matter what setting persisted, and the full sequence — with the gate command actually re-sent — is required again.
 
-**No keepalive.** The display has no idle timeout: it holds its content indefinitely, and the value stream isn't even required to keep it lit. FanaBridge sends no keepalive, and the official software sends none either. (Hardware-confirmed.)
+**No keepalive.** The display has no idle timeout: it holds its content indefinitely, and the value stream isn't even required to keep it lit. (Hardware-confirmed.) There is no liveness ping in this protocol — the periodic frame current official software emits is a page-set to an absent display device, not a keepalive (see [PageSet](#0x04--pageset)) — and none is needed.
 
 #### Firmware Subscription Pushes (Device → Host)
 
-This is the mechanism behind the [Control Model](#control-model) above. When the page changes — from a host [PageSet](#0x04--pageset) or the wheel button — the firmware *pushes* one or more `FF 05 01` reports on the col03 **input** endpoint, telling the host exactly which parameters to display at which handles. A host `PageSet` makes the firmware push the new page's subscription ~10–40 ms later; the host then echoes [ValueUpdate](#0x01--valueupdate)s for those subscriptions.
+This is the mechanism behind the [Control Model](#control-model) above. When the page changes — from a host [PageSet](#0x04--pageset) or the wheel button — the firmware *pushes* one or more `FF 05 01` reports on the col03 **input** endpoint, telling the host exactly which parameters to display at which handles. A host `PageSet` makes the firmware push the new page's subscription within tens of milliseconds (20–70 ms observed in testing; hosts should budget a comfortably larger deadline before treating a push as missed); the host then echoes [ValueUpdate](#0x01--valueupdate)s for those subscriptions.
+
+> **Fragmentation varies by setup.** One tested setup (Podium DD+ with a PBME) consolidates a push into 1–2 multi-entry reports; another (ClubSport DD with a GTSWX) sends **one entry per report** — 6–7 reports arriving ~2 ms apart for a single page change. Both wheelbase and wheel differ between those observations, so whether the framing is determined by the base or by the wheel/module is unknown. Accumulate across reports in all cases.
 
 Each pushed report uses the same `FF 05 01` framing, with 5-byte entries:
 
@@ -922,9 +927,9 @@ Each pushed report uses the same `FF 05 01` framing, with 5-byte entries:
 | 0 | 1 | Device ID | Which display this entry is for (values as in [PageSet](#0x04--pageset)) |
 | 1 | 1 | Handle | Firmware handle. The `0x80` bit marks a "slot" param (one with a ParamDefs unit). **Host ValueUpdate handle = handle `& 0x7F`.** |
 | 2–3 | 2 | Param ID | Subscribed parameter (little-endian), or `0xFFFF` = **unsubscribe** that handle. |
-| 4 | 1 | Type | Value data-type/size selector (1/2/4-byte int, float, or text) — not the display unit. |
+| 4 | 1 | Type | Value data-type/size selector — **low nibble** is the wire type (`1`=text, `2/3`=1-byte, `4/5`=2-byte, `6/7/9`=int32, `8/10`=float32); high-nibble meaning unknown (varies per display for the same parameter). Not the display unit. **The same parameter can declare different types on different displays** — GEAR is a 1-byte int on a PBME (`0x12`) but text on a GTSWX (`0x11`) — and the host's value encoding **must follow the declared type**, or the field renders nothing (capture- and hardware-confirmed). |
 
-A page change arrives across **several** reports — an unsubscribe of the old handles (`0xFFFF`), plus one or more (often overlapping / partial) reports listing the new page's handles. **The host must accumulate them** — apply each entry as it arrives (subscribe, or `0xFFFF` = unsubscribe) — never treating a single report as the complete set. (E.g. page 3's 7 handles arrive as two reports sharing `h1–h5`, one adding `h6=BRAKE_BIAS`, the other `h0=SPEED`.) Example — switching to the Tyre Temps page:
+A page change arrives across **several** reports — an unsubscribe of the old handles (`0xFFFF`), plus one or more (often overlapping / partial) reports listing the new page's handles. **The host must accumulate them** — apply each entry as it arrives (subscribe, or `0xFFFF` = unsubscribe) — never treating a single report as the complete set. (One observed instance: page 3's 7 handles arrived as two overlapping reports sharing `h1–h5`, one adding `h6=BRAKE_BIAS`, the other `h0=SPEED` — the specific handles are illustrative only, per the allocation rules below.) Example — switching to the Tyre Temps page:
 
 ```
 FF 05 01  03 00 0001 34  03 01 0004 12  03 82 002A 32  03 83 0030 32 ...
@@ -933,7 +938,13 @@ FF 05 01  03 00 0001 34  03 01 0004 12  03 82 002A 32  03 83 0030 32 ...
 
 (`0x82 & 0x7F = 2`, so the host sends TYRE_FL at handle 2.)
 
-**Handles are double-buffered — never assume a fixed page→handle map.** The firmware alternates the handle *base* between two regions (≈`h0–h5` and `h6–h11`) on every page change: it subscribes the new page's params on the currently-free region, then unsubscribes the old region. So the *same* page appears at different handles on successive visits — Lap Info is `h0=SPEED …` one time and `h6=SPEED …` the next. This is why every page change carries an unsubscribe of the old region alongside the new subscriptions, and why **the host must follow the pushed handles each time** rather than caching a map. (Confirmed by strict base alternation across a full page cycle: `6, 0, 6, 0, 6 …`.)
+**Never assume a fixed page→handle map — handle allocation varies by setup, and handles are not page-owned.** The universal rules, consistent across every observation:
+
+- The firmware announces every assignment via push; assignments are **not** a property of the page. Whichever page is established *first* takes the base handles (a session brought up on page 2 lands it at the handles page 1 would otherwise get).
+- **A handle number can be re-bound to a different parameter on any page change** — observed within a single session: `h9` = ERS_LEVEL while Fuel/ERS/DRS was up, then BEST_LAP_TIME after switching to Lap Times. This is the deeper reason to stop sending values the moment a page change begins: entries at the *old* page's handles may land on re-bound parameters, not just be ignored.
+- Handle numbers live in a small bounded space (≈`h0–h13`; no growth observed over 60 consecutive switches), every change unsubscribes what it replaces, and a [gate](#0x02--itm-mode-enable-gate) cycle resets the table.
+
+On top of those invariants, two different **allocation strategies** have been observed: one setup (Podium DD+ with a PBME) double-buffers between two regions (≈`h0–h5` / `h6–h13`), subscribing each new page into the currently-free region — the same page lands at different handles on successive visits (`6, 0, 6, 0 …` across a full cycle), and a 7th parameter spills into the far region. Another setup (ClubSport DD with a GTSWX) **reuses one region in place** for every page, rebinding the same handle numbers each change. Neither strategy should be assumed: follow the pushed handles after every change and never cache a page→handle map across visits.
 
 **Getting the first page.** The firmware pushes a subscription only when a page is *established or changed*. So after enabling, send a [PageSet](#0x04--pageset) (or wait for a wheel-button press) and populate the handles it pushes back; values sent before that push, at guessed handles, are ignored. See [Control Model](#control-model) for the full bring-up.
 
@@ -1164,7 +1175,7 @@ The firmware recognizes a vocabulary of parameter IDs. Only a subset is confirme
 | 1 | SPEED | 2 | Int16 LE | Present on all pages as header |
 | 2 | RPM | 4 | Int32 | |
 | 3 | RPM_MAX | 4 | Int32 | |
-| 4 | GEAR | 1 | Uint8 | Present on all pages as header |
+| 4 | GEAR | 1 | **Per-display** | Present on all pages as header. **The wire form differs by display and is dictated by the Type byte in the [subscription push](#firmware-subscription-pushes-device--host)**: displays declaring a Uint8 type (e.g. PBME) take numeric — `0x00` renders "n", `1–9` literal digits, **`0xFF` renders "r"** (reverse) — and **ignore ASCII bytes**; displays declaring a text type (e.g. GTSWX, Formula V3) take a single ASCII char — `'n'`, `'1'`–`'9'`, `'r'` (lowercase) — as the official software sends. Both capture-confirmed. Sending the wrong form renders nothing. |
 | 5 | FUEL | 4 | Float32 LE | Supports total (FUEL_MAX) |
 | 6 | FUEL_MAX | 4 | Float32 LE | |
 | 7 | FUEL_PER_LAP | 4 | Float32 LE | |
@@ -1202,27 +1213,6 @@ The full parameter vocabulary includes 120+ IDs covering tyre pressures, brake t
 - 501–536: Race/timing data and flags
 - 1001–1008: System metrics (CPU load, GPU temp, FPS, etc.)
 - 65535 (`0xFFFF`): UNSUBSCRIBE sentinel
-
-### ITM Unit System
-
-Parameters can have associated display units:
-
-| Value | Unit | Category |
-|-------|------|----------|
-| 0 | DEFAULT | No suffix |
-| 1 | SPEED_KPH | Speed |
-| 2 | SPEED_MPH | Speed |
-| 4 | VOLUME_LITER | Volume |
-| 5 | VOLUME_GALLON | Volume |
-| 7 | TIME_SEC | Time |
-| 8 | TEMP_C | Temperature |
-| 9 | TEMP_F | Temperature |
-| 17 | TOTAL_POSITION | Total companion |
-| 18 | TOTAL_LAP | Total companion |
-| 19 | TOTAL_CLASS | Total companion |
-| 22 | OTHERS_PERCENT | Percentage |
-
-"Total" units enable `value / total` display (e.g., "Lap 5 / 20"). The official software submits units on every tick; the raw HID equivalent maps to the suffix mechanism in ParamDefs.
 
 ### ITM Page Layouts
 

--- a/src/FanaBridge.Core/Diagnostics/FanatecSoftwareMonitor.cs
+++ b/src/FanaBridge.Core/Diagnostics/FanatecSoftwareMonitor.cs
@@ -1,0 +1,110 @@
+using System;
+
+namespace FanaBridge.Diagnostics
+{
+    /// <summary>
+    /// Detects whether the Fanatec app/service is running alongside FanaBridge. Both drive
+    /// the same ITM display over the same HID channel with no arbitration in the protocol
+    /// (last writer wins), and there is no wire-level way to detect a co-driver — no state
+    /// query exists — so an OS-level process check is the only detection there is. The
+    /// vendor service is known to gate, reset, and re-page the display on its own at
+    /// startup and around wheel changes; a user running both should see a warning rather
+    /// than chase phantom flicker/lost-page-change bugs.
+    ///
+    /// Checks are TTL-cached (process enumeration is not free, callers poll per frame or
+    /// per UI tick), and detection edges are logged once each way.
+    /// </summary>
+    public class FanatecSoftwareMonitor
+    {
+        // The processes that drive ITM: the vendor's device service and its UI app.
+        // Deliberately NOT the driver-package PnP service (FWPnpService) — it is
+        // auto-started on every boot, never emits ITM traffic, and coexists fine.
+        private static readonly string[] CoDriverProcesses = { "FanatecService", "Fanatec" };
+
+        /// <summary>How long a check result is reused before re-probing the process list.</summary>
+        public int CacheTtlMs { get; set; } = 10_000;
+
+        private readonly Func<string, bool> _processExists;
+        private readonly Func<long> _now;
+        private readonly Action<string> _log;
+
+        // Far enough in the past that the first check always probes, without the
+        // now - long.MinValue subtraction overflow.
+        private long _lastCheckMs = -1_000_000_000;
+        private string _running;   // null = none detected
+
+        public FanatecSoftwareMonitor(Func<string, bool> processExists = null,
+            Func<long> nowMs = null, Action<string> log = null)
+        {
+            _processExists = processExists ?? DefaultProbe;
+            _now = nowMs ?? DefaultClock();
+            _log = log ?? (_ => { });
+        }
+
+        private static bool DefaultProbe(string name)
+        {
+            try
+            {
+                var procs = System.Diagnostics.Process.GetProcessesByName(name);
+                foreach (var p in procs)
+                    p.Dispose();
+                return procs.Length > 0;
+            }
+            catch
+            {
+                return false;   // enumeration can fail under restricted accounts — stay quiet
+            }
+        }
+
+        private static Func<long> DefaultClock()
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            return () => sw.ElapsedMilliseconds;
+        }
+
+        /// <summary>
+        /// The co-driving vendor process detected on the last check (e.g. "FanatecService"),
+        /// or null when none is running. Refreshes at most every <see cref="CacheTtlMs"/>.
+        /// </summary>
+        public string DetectedProcess
+        {
+            get
+            {
+                long now = _now();
+                if (now - _lastCheckMs >= CacheTtlMs)
+                {
+                    _lastCheckMs = now;
+                    string found = null;
+                    foreach (var name in CoDriverProcesses)
+                    {
+                        if (_processExists(name))
+                        {
+                            found = name;
+                            break;
+                        }
+                    }
+                    if (found != null && _running == null)
+                        _log("ITM: Fanatec software detected running (" + found + ") — it may drive the display" +
+                             " concurrently; page changes and values can conflict");
+                    else if (found == null && _running != null)
+                        _log("ITM: Fanatec software no longer running — display is single-driver again");
+                    _running = found;
+                }
+                return _running;
+            }
+        }
+
+        /// <summary>A user-facing warning line, or null when no co-driver is detected.</summary>
+        public string Warning
+        {
+            get
+            {
+                var p = DetectedProcess;
+                return p == null
+                    ? null
+                    : "Fanatec software is running (" + p + "). Both programs drive the same display — " +
+                      "if its ITM/dashboard features are active, expect flicker or lost page changes.";
+            }
+        }
+    }
+}

--- a/src/FanaBridge.Core/Diagnostics/FanatecSoftwareMonitor.cs
+++ b/src/FanaBridge.Core/Diagnostics/FanatecSoftwareMonitor.cs
@@ -24,7 +24,10 @@ namespace FanaBridge.Diagnostics
         /// <summary>How long a check result is reused before re-probing the process list.</summary>
         public int CacheTtlMs { get; set; } = 10_000;
 
-        private readonly Func<string, bool> _processExists;
+        // Probe seam: given the candidate process names, returns the first one running or
+        // null. The default takes ONE process-table snapshot and matches all names against
+        // it — per-name Process.GetProcessesByName calls each snapshot the whole table.
+        private readonly Func<string[], string> _probe;
         private readonly Func<long> _now;
         private readonly Action<string> _log;
 
@@ -33,27 +36,45 @@ namespace FanaBridge.Diagnostics
         private long _lastCheckMs = -1_000_000_000;
         private string _running;   // null = none detected
 
-        public FanatecSoftwareMonitor(Func<string, bool> processExists = null,
+        public FanatecSoftwareMonitor(Func<string[], string> probe = null,
             Func<long> nowMs = null, Action<string> log = null)
         {
-            _processExists = processExists ?? DefaultProbe;
+            _probe = probe ?? DefaultProbe;
             _now = nowMs ?? DefaultClock();
             _log = log ?? (_ => { });
         }
 
-        private static bool DefaultProbe(string name)
+        private static string DefaultProbe(string[] names)
         {
+            System.Diagnostics.Process[] procs;
             try
             {
-                var procs = System.Diagnostics.Process.GetProcessesByName(name);
-                foreach (var p in procs)
-                    p.Dispose();
-                return procs.Length > 0;
+                procs = System.Diagnostics.Process.GetProcesses();
             }
             catch
             {
-                return false;   // enumeration can fail under restricted accounts — stay quiet
+                return null;   // enumeration can fail under restricted accounts — stay quiet
             }
+
+            string found = null;
+            foreach (var p in procs)
+            {
+                if (found == null)
+                {
+                    string pn;
+                    try { pn = p.ProcessName; } catch { pn = null; }
+                    foreach (var n in names)
+                    {
+                        if (string.Equals(pn, n, StringComparison.OrdinalIgnoreCase))
+                        {
+                            found = n;
+                            break;
+                        }
+                    }
+                }
+                p.Dispose();
+            }
+            return found;
         }
 
         private static Func<long> DefaultClock()
@@ -74,15 +95,7 @@ namespace FanaBridge.Diagnostics
                 if (now - _lastCheckMs >= CacheTtlMs)
                 {
                     _lastCheckMs = now;
-                    string found = null;
-                    foreach (var name in CoDriverProcesses)
-                    {
-                        if (_processExists(name))
-                        {
-                            found = name;
-                            break;
-                        }
-                    }
+                    string found = _probe(CoDriverProcesses);
                     if (found != null && _running == null)
                         _log("ITM: Fanatec software detected running (" + found + ") — it may drive the display" +
                              " concurrently; page changes and values can conflict");

--- a/src/FanaBridge.Core/Protocol/ItmLifecycleController.cs
+++ b/src/FanaBridge.Core/Protocol/ItmLifecycleController.cs
@@ -112,13 +112,33 @@ namespace FanaBridge.Protocol
         /// the first fresh send.</summary>
         public int SyncGeneration { get; private set; }
 
-        /// <summary>Values (and ParamDefs) may only be sent while this is true: Synced, and no
-        /// push currently accumulating (an in-flight push means the page is changing under us).</summary>
-        public bool ValuesAllowed => State == ItmLifecycleState.Synced && _accumCloseAt == 0;
+        /// <summary>Values (and ParamDefs) may only be sent while this is true: Synced, with no
+        /// push currently accumulating and no grace window open — either means the page may be
+        /// changing under us, and mid-change values can land on re-bound handles.</summary>
+        public bool ValuesAllowed => State == ItmLifecycleState.Synced
+            && _accumCloseAt == 0 && _graceUntil == 0;
+
+        // Lazily-rebuilt snapshot of the handle map, so per-frame consumers don't pay a
+        // SortedDictionary enumerator allocation ~85 times a second for a map that only
+        // changes when a push arrives.
+        private KeyValuePair<byte, ItmSubscription>[] _subsSnapshot;
 
         /// <summary>The adopted handle map: host handle → subscription (param + declared type),
-        /// sorted by handle. Built exclusively from firmware pushes.</summary>
-        public IEnumerable<KeyValuePair<byte, ItmSubscription>> Subscriptions => _subs;
+        /// ordered by handle. Built exclusively from firmware pushes.</summary>
+        public IReadOnlyList<KeyValuePair<byte, ItmSubscription>> Subscriptions
+        {
+            get
+            {
+                if (_subsSnapshot == null)
+                {
+                    _subsSnapshot = new KeyValuePair<byte, ItmSubscription>[_subs.Count];
+                    int i = 0;
+                    foreach (var kv in _subs)
+                        _subsSnapshot[i++] = kv;
+                }
+                return _subsSnapshot;
+            }
+        }
 
         /// <summary>Number of parameters the firmware currently has subscribed.</summary>
         public int SubscriptionCount => _subs.Count;
@@ -139,7 +159,8 @@ namespace FanaBridge.Protocol
         private int _stepIdx;
         private bool _armOnDrain;    // arm the push expectation when the queue drains
         private byte _armPage;       // the page whose push the armed expectation matches
-        private bool _pushDuringProcedure;   // a push arrived while steps were still being sent
+        private bool _judgeAtDrain;  // an accumulation closed mid-procedure — judge it once the queue drains
+        private bool _startPending;  // Start() was called; the cold entry runs on the next Tick
 
         private long _lastPageSetMs = -1_000_000_000;   // last accepted PageSet (spacing floor)
 
@@ -175,7 +196,12 @@ namespace FanaBridge.Protocol
         private bool _wasLive;
         private byte _resumePage;
 
+        // The user's on/off setting, and whether it has been enforced since the last
+        // Stop(). Un-applied after every Stop so a reconnect re-asserts "off" — the
+        // re-appearing device (power cycle, re-seat) comes up with whatever gate setting
+        // persisted, not necessarily the user's.
         private bool _userEnabled = true;
+        private bool _enabledApplied;
 
         public ItmLifecycleController(ItmEncoder encoder, byte deviceId = ItmEncoder.DefaultDeviceId,
             Func<long> nowMs = null, Action<string> log = null)
@@ -244,60 +270,69 @@ namespace FanaBridge.Protocol
         // ── Inputs ───────────────────────────────────────────────────────
 
         /// <summary>
-        /// Begins the lifecycle with a full cold bring-up. Idempotent — a no-op unless Idle,
-        /// so it is safe to call every frame while the device is connected.
+        /// Begins the lifecycle with a full cold bring-up on the next <see cref="Tick"/> —
+        /// deferred one tick so the caller's per-frame settings sync (notably
+        /// <see cref="DefaultPage"/>) lands before the bring-up target is chosen. Idempotent —
+        /// a no-op unless Idle, so it is safe to call every frame while connected.
         /// </summary>
         public void Start()
         {
-            if (State != ItmLifecycleState.Idle || !_userEnabled)
+            if (State != ItmLifecycleState.Idle || _startPending || !_userEnabled)
                 return;
-            ColdEntry("start");
+            _startPending = true;
         }
 
         /// <summary>
         /// Stops the lifecycle (connection lost): back to Idle, all session state dropped,
-        /// nothing sent. A later <see cref="Start"/> re-runs the cold bring-up.
+        /// nothing sent. A later <see cref="Start"/> re-runs the cold bring-up, and the
+        /// user's on/off setting is re-enforced on the next <see cref="SetUserEnabled"/>.
         /// </summary>
         public void Stop()
         {
             State = ItmLifecycleState.Idle;
-            ClearProcedure();
-            ClearExpectation();
+            AbandonInFlight();
             _subs.Clear();
+            _subsSnapshot = null;
             CurrentPage = 0;
             _pendingRequest = 0;
-            _rung = Rung.None;
             _backoffIdx = 0;
             _wasLive = false;
+            _startPending = false;
+            _enabledApplied = false;
         }
 
         /// <summary>
         /// Applies the user's ITM on/off setting (safe to call every frame; edges are detected
-        /// internally). Off sends a single gate-off — the same persistent state the vendor
-        /// software's ITM switch sets — and goes dormant. On re-arms the cold bring-up.
+        /// internally, and the setting is re-enforced once after every <see cref="Stop"/>).
+        /// Off sends a single gate-off — the same persistent state the vendor software's ITM
+        /// switch sets — and goes dormant. On re-arms the cold bring-up.
         /// </summary>
         public void SetUserEnabled(bool enabled)
         {
-            if (enabled == _userEnabled)
+            if (_enabledApplied && enabled == _userEnabled)
                 return;
             _userEnabled = enabled;
+            _enabledApplied = true;
 
             if (!enabled)
             {
                 // Enforce "off" from any state, including Idle (user may have ITM disabled
-                // from the start — the display must still be gated off once).
-                ClearProcedure();
-                ClearExpectation();
-                _rung = Rung.None;
+                // from the start, or the device may have just reconnected with the gate
+                // setting persisted on — the display must be gated off either way).
+                AbandonInFlight();
+                _startPending = false;
                 State = ItmLifecycleState.Disabled;
                 QueueGateOff();
                 _log("ITM: disabled by user — gating off (setting persists until re-enabled here or in vendor software)");
             }
             else if (State == ItmLifecycleState.Disabled)
             {
-                // Back to Idle; the next Start() runs the cold entry.
+                // Re-enable: arm a cold bring-up (runs on this same Tick). The driver's
+                // Update applies the setting just before Tick, so re-enabling in settings
+                // brings the display up in the same frame, as the old driver did.
                 State = ItmLifecycleState.Idle;
-                ClearProcedure();
+                AbandonInFlight();
+                _startPending = true;
             }
         }
 
@@ -346,6 +381,20 @@ namespace FanaBridge.Protocol
                     // The new wheel comes up with whatever gate setting persisted — re-assert off.
                     QueueGateOff();
                     return;
+                case ItmLifecycleState.TelemetryIdle:
+                    // The display is deliberately dark (game exited). Stay parked: drop the
+                    // old wheel's handles, re-assert the gate-off on the new wheel (its
+                    // persisted setting may be on), and let the resume's PageSet-while-off →
+                    // gate-on shape — valid from any cold state — bring it up when telemetry
+                    // returns. A cold bring-up here would light the display with no game.
+                    AbandonInFlight();
+                    _subs.Clear();
+                    _subsSnapshot = null;
+                    CurrentPage = 0;
+                    State = ItmLifecycleState.TelemetryIdle;
+                    QueueGateOff();
+                    _log("ITM: wheel changed while parked — staying dark; resume will bring the new wheel up");
+                    return;
                 default:
                     ColdEntry("wheel changed");
                     return;
@@ -371,9 +420,7 @@ namespace FanaBridge.Protocol
                 else
                     _subs[s.Handle] = s;
             }
-
-            if (_stepIdx < _steps.Count || _armOnDrain)
-                _pushDuringProcedure = true;
+            _subsSnapshot = null;
 
             if (_accumCloseAt == 0)
                 _accumCloseAt = _now() + AccumulateWindowMs;
@@ -387,6 +434,15 @@ namespace FanaBridge.Protocol
         {
             long now = _now();
 
+            // A requested start runs here rather than in Start() itself, so the caller's
+            // per-frame settings sync (DefaultPage in particular) has landed before the
+            // bring-up target is chosen.
+            if (_startPending)
+            {
+                _startPending = false;
+                ColdEntry("start");
+            }
+
             // Telemetry live→dead edge: park in TelemetryIdle (gate-off, screen dark) from any
             // active state — a switch or recovery interrupted by a game exit is abandoned; the
             // resume shape re-establishes everything and is the strongest recovery there is.
@@ -394,22 +450,43 @@ namespace FanaBridge.Protocol
                 EnterTelemetryIdle("game exited");
             _wasLive = telemetryLive;
 
-            // Judge a completed push accumulation.
+            // Judge a completed push accumulation — unless a procedure's commands are still
+            // being sent, in which case the judgment is deferred to the queue drain so that
+            // every push goes through the one judgment path with the expectation armed.
             if (_accumCloseAt != 0 && now >= _accumCloseAt)
             {
                 _accumCloseAt = 0;
-                JudgeAccumulation(now);
+                if (_stepIdx < _steps.Count || _armOnDrain)
+                    _judgeAtDrain = true;
+                else
+                    JudgeAccumulation(now);
             }
 
-            // Unsub-grace expiry: subscriptions were dropped and nothing followed.
+            // Grace expiry. Grace opens in Synced when a push left the map in a state that
+            // doesn't form a page: empty (unsubscribe-all — the front half of a page change,
+            // or our subscriptions being dropped) or a partial set (a change fragmented
+            // slower than the accumulation window). Anything arriving meanwhile re-judges;
+            // expiry means nothing followed.
             if (_graceUntil != 0 && now >= _graceUntil && _accumCloseAt == 0)
             {
                 _graceUntil = 0;
                 if (State == ItmLifecycleState.Synced)
                 {
-                    byte target = KnownTelemetryPageOrDefault(CurrentPage);
-                    _log("ITM: subscriptions dropped (unsubscribe with nothing following) — recovering page " + target);
-                    EnterRecovery(target, Rung.PageSet1);
+                    var set = SubscribedParamSet();
+                    if (set.Count == 0)
+                    {
+                        byte target = KnownTelemetryPageOrDefault(CurrentPage);
+                        _log("ITM: subscriptions dropped (unsubscribe with nothing following) — recovering page " + target);
+                        EnterRecovery(target, Rung.PageSet1);
+                    }
+                    else
+                    {
+                        // A stable set that matches no catalog page — the firmware knows
+                        // pages we don't. Adopt it; values flow for the encodable params.
+                        CurrentPage = PageForParamSet(set);
+                        SyncGeneration++;
+                        _log("ITM: adopted uncataloged page set: " + DescribeMap());
+                    }
                 }
             }
 
@@ -462,12 +539,11 @@ namespace FanaBridge.Protocol
         // used to infer firmware state.
         private void ColdEntry(string why)
         {
-            ClearProcedure();
-            ClearExpectation();
+            AbandonInFlight();
             _subs.Clear();
+            _subsSnapshot = null;
             CurrentPage = 0;
-            _rung = Rung.None;
-            _graceUntil = 0;
+            _pendingRequest = 0;
 
             _targetPage = DefaultPage;
             State = ItmLifecycleState.BringUp;
@@ -483,15 +559,13 @@ namespace FanaBridge.Protocol
             _targetPage = page;
             State = ItmLifecycleState.Switching;
             ClearExpectation();
+            _graceUntil = 0;
             _quietUntil = _now() + SwitchQuietMs;   // values are suspended from this instant
         }
 
         private void EnterTelemetryIdle(string why)
         {
-            ClearProcedure();
-            ClearExpectation();
-            _graceUntil = 0;
-            _rung = Rung.None;
+            AbandonInFlight();
             _resumePage = KnownTelemetryPageOrDefault(CurrentPage);
             State = ItmLifecycleState.TelemetryIdle;
             QueueGateOff();
@@ -579,9 +653,7 @@ namespace FanaBridge.Protocol
         private void EnterUnavailable()
         {
             State = ItmLifecycleState.Unavailable;
-            _rung = Rung.None;
-            ClearProcedure();
-            ClearExpectation();
+            AbandonInFlight();
             int backoff = UnavailableBackoffMs[Math.Min(_backoffIdx, UnavailableBackoffMs.Count - 1)];
             if (_backoffIdx < UnavailableBackoffMs.Count - 1)
                 _backoffIdx++;
@@ -594,7 +666,9 @@ namespace FanaBridge.Protocol
 
         // Judges the state of the handle map after an accumulation window closes. Matching is
         // on the parameter SET (handles are setup-specific and can re-bind); the map itself was
-        // already adopted entry-by-entry as reports arrived.
+        // already adopted entry-by-entry as reports arrived. Runs only with the command queue
+        // drained (mid-procedure closes are deferred to the drain), so the armed expectation
+        // is always in place when its push is judged.
         private void JudgeAccumulation(long now)
         {
             var set = SubscribedParamSet();
@@ -608,25 +682,15 @@ namespace FanaBridge.Protocol
                     _graceUntil = now + UnsubGraceMs;
                 return;
             }
-            _graceUntil = 0;
 
             byte matchedPage = PageForParamSet(set);
 
-            // A procedure's commands are still being sent (e.g. resume's gate-on not yet
-            // accepted): adopt the data but defer transitions until the procedure completes —
-            // going Synced with a gate-on unsent would strand a dark display.
-            if (_stepIdx < _steps.Count)
-            {
-                CurrentPage = matchedPage;
-                return;
-            }
-
-            // The armed expectation (or the in-flight target, for a push that lands before the
-            // deadline is even armed) confirms the procedure.
+            // The armed expectation confirms the procedure.
             if (_armedPage != 0 && SetEqualsPage(set, _armedPage))
             {
                 byte page = _armedPage;
                 ClearExpectation();
+                _graceUntil = 0;
                 if (State == ItmLifecycleState.Recovery && _rung == Rung.FlipAway && page == _flipPage)
                 {
                     // Flip page confirmed — now flip back to the target.
@@ -637,9 +701,17 @@ namespace FanaBridge.Protocol
                 ConfirmSync(page, "push confirmed");
                 return;
             }
-            if (ExpectsTargetPush() && SetEqualsPage(set, _targetPage))
+
+            // A push for the in-flight target that lands before the expectation is armed
+            // (early) or after a rung re-targeted it (late). NOT during the flip-away rung:
+            // there the flip PageSet is already accepted, so the display is about to move
+            // again — confirming the target now would resume values mid-transition and
+            // abandon the flip; wait for the flip page's push instead.
+            if (ExpectsTargetPush() && SetEqualsPage(set, _targetPage)
+                && !(State == ItmLifecycleState.Recovery && _rung == Rung.FlipAway))
             {
                 ClearExpectation();
+                _graceUntil = 0;
                 ConfirmSync(_targetPage, "push confirmed (early)");
                 return;
             }
@@ -648,10 +720,19 @@ namespace FanaBridge.Protocol
             switch (State)
             {
                 case ItmLifecycleState.Synced:
+                    if (matchedPage == 0)
+                    {
+                        // A set that forms no page is most likely a fragment of a change
+                        // still in flight (fragmented slower than the accumulation window).
+                        // Suspend values (grace) and wait for the rest; grace expiry adopts
+                        // whatever proved stable.
+                        _graceUntil = now + UnsubGraceMs;
+                        return;
+                    }
+                    _graceUntil = 0;
                     CurrentPage = matchedPage;
                     SyncGeneration++;
-                    _log("ITM: page changed at the wheel — now page " +
-                         (matchedPage == 0 ? "?" : matchedPage.ToString()) + ": " + DescribeMap());
+                    _log("ITM: page changed at the wheel — now page " + matchedPage + ": " + DescribeMap());
                     break;
                 case ItmLifecycleState.AwaitPush:
                 case ItmLifecycleState.Switching:
@@ -659,21 +740,28 @@ namespace FanaBridge.Protocol
                 case ItmLifecycleState.Unavailable:
                     // A COMPLETE different page than asked for (wheel button, late push from a
                     // boot-cold base): the display is demonstrably alive — sync to reality. Any
-                    // queued host request is dropped rather than fought. A set matching no page
-                    // is most likely a fragment of a change still in flight (the rest lands in
-                    // a later accumulation) — resuming values on it would reopen the re-bound-
-                    // handle hazard, so keep waiting and let the deadline/ladder decide.
-                    if (matchedPage == 0)
+                    // queued host request is dropped rather than fought. Two look-alikes are
+                    // NOT that and must not resolve the procedure:
+                    // - a set matching no page is a fragment mid-flight; the rest lands in a
+                    //   later accumulation — resuming values on it would reopen the re-bound-
+                    //   handle hazard, so let the deadline/ladder decide;
+                    // - a set matching the page we're LEAVING is a straggler re-announcement,
+                    //   not a user action — confirming it would silently cancel the switch;
+                    // - during flip-away the accepted flip PageSet means the display is about
+                    //   to move again — wait for the flip push (or the deadline).
+                    if (matchedPage == 0 || matchedPage == CurrentPage
+                        || (State == ItmLifecycleState.Recovery && _rung == Rung.FlipAway))
                         break;
                     _pendingRequest = 0;
                     ClearExpectation();
                     _rung = Rung.None;
+                    _graceUntil = 0;
                     ConfirmSync(matchedPage, "adopted unexpected push");
                     break;
                 default:
-                    // Idle / Disabled / TelemetryIdle / BringUp: keep the adopted map, no
-                    // transition. In gated-off states a push means someone else gated on —
-                    // note it, don't fight it.
+                    // Idle / Disabled / TelemetryIdle: keep the adopted map, no transition.
+                    // In gated-off states a push means someone else gated on — note it,
+                    // don't fight it.
                     CurrentPage = matchedPage;
                     if (State == ItmLifecycleState.TelemetryIdle || State == ItmLifecycleState.Disabled)
                         _log("ITM: subscription push received while gated off — another program may be driving the display");
@@ -766,33 +854,22 @@ namespace FanaBridge.Protocol
             if (_armOnDrain)
             {
                 _armOnDrain = false;
-                bool pushArrived = _pushDuringProcedure;
-                _pushDuringProcedure = false;
                 _armedPage = _armPage;
                 _deadlineAt = now + PushDeadlineMs;
                 if (State == ItmLifecycleState.BringUp)
                     State = ItmLifecycleState.AwaitPush;
+            }
 
-                // A push may have landed while the commands were still being accepted
-                // (adopted with the transition deferred) — judge it now. Guarded on a push
-                // actually having arrived during the procedure: the map alone can look
-                // "already right" from stale pre-procedure state (e.g. a resume to the same
-                // page the display was on before the exit), and that must never self-confirm.
-                if (pushArrived && _accumCloseAt == 0 && _subs.Count > 0
-                    && SetEqualsPage(SubscribedParamSet(), _armedPage))
-                {
-                    byte page = _armedPage;
-                    ClearExpectation();
-                    if (State == ItmLifecycleState.Recovery && _rung == Rung.FlipAway && page == _flipPage)
-                    {
-                        _rung = Rung.FlipBack;
-                        StartRung();
-                    }
-                    else
-                    {
-                        ConfirmSync(page, "push confirmed (arrived during send)");
-                    }
-                }
+            // A push accumulation that closed while the commands were still being accepted
+            // is judged now, with the expectation armed — the one JudgeAccumulation path
+            // handles it exactly as if it had arrived after the drain. Judging is strictly
+            // push-driven: with no push, the map alone can look "already right" from stale
+            // pre-procedure state (e.g. a resume to the page shown before the exit), and
+            // that must never self-confirm.
+            if (_judgeAtDrain)
+            {
+                _judgeAtDrain = false;
+                JudgeAccumulation(now);
             }
         }
 
@@ -801,7 +878,7 @@ namespace FanaBridge.Protocol
             _steps.Clear();
             _stepIdx = 0;
             _armOnDrain = false;
-            _pushDuringProcedure = false;
+            _judgeAtDrain = false;
             _quietUntil = 0;
         }
 
@@ -809,6 +886,20 @@ namespace FanaBridge.Protocol
         {
             _armedPage = 0;
             _deadlineAt = 0;
+        }
+
+        // Drops everything in flight: the command procedure, the push expectation, an open
+        // accumulation, the grace window, and the recovery rung. Used by every transition
+        // that abandons the current activity (stop, cold entry, user off, telemetry exit) —
+        // hand-picked subsets at each site drift, and a survivor (e.g. an open accumulation
+        // crossing a cold entry) can mis-attribute a stale push to the new session.
+        private void AbandonInFlight()
+        {
+            ClearProcedure();
+            ClearExpectation();
+            _accumCloseAt = 0;
+            _graceUntil = 0;
+            _rung = Rung.None;
         }
 
         // ── Page catalog helpers ─────────────────────────────────────────
@@ -847,22 +938,25 @@ namespace FanaBridge.Protocol
             return 0;
         }
 
+        // The catalog entry for a wire page number on this device, or null if unknown.
+        private ItmPageInfo PageInfoFor(byte page)
+        {
+            if (page != 0)
+                foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
+                    if (p.Number == page)
+                        return p;
+            return null;
+        }
+
         private bool SetEqualsPage(HashSet<ushort> set, byte page)
         {
-            IReadOnlyList<ushort> expected = null;
-            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
-            {
-                if (p.Number == page)
-                {
-                    expected = p.Params;
-                    break;
-                }
-            }
+            var info = PageInfoFor(page);
             // A page we have no catalog entry for (or the legacy page) can't be matched
             // exactly; accept any non-empty adopted set as that procedure's outcome.
-            if (expected == null || expected.Count == 0)
+            if (info == null || info.Params.Count == 0)
                 return set.Count > 0;
 
+            var expected = info.Params;
             if (expected.Count != set.Count)
                 return false;
             for (int i = 0; i < expected.Count; i++)
@@ -885,14 +979,13 @@ namespace FanaBridge.Protocol
             return 1;
         }
 
+        // "Telemetry page" = carries parameters, so a PageSet to it can be confirmed by a
+        // push. Deliberately keyed on Params.Count rather than IsLegacy: the wire behavior
+        // (a paramless page pushes nothing) is what the lifecycle depends on.
         private bool IsTelemetryPage(byte page)
         {
-            if (page == 0)
-                return false;
-            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
-                if (p.Number == page)
-                    return p.Params.Count > 0;
-            return false;
+            var info = PageInfoFor(page);
+            return info != null && info.Params.Count > 0;
         }
 
         // A different telemetry page to flip to — a genuine page change must push, so the flip

--- a/src/FanaBridge.Core/Protocol/ItmLifecycleController.cs
+++ b/src/FanaBridge.Core/Protocol/ItmLifecycleController.cs
@@ -1,0 +1,918 @@
+using System;
+using System.Collections.Generic;
+
+namespace FanaBridge.Protocol
+{
+    /// <summary>The ITM lifecycle states. See <see cref="ItmLifecycleController"/>.</summary>
+    public enum ItmLifecycleState
+    {
+        /// <summary>Not started (no connection, or never started). Nothing on the wire.</summary>
+        Idle,
+        /// <summary>User turned ITM off. Gate-off sent once; dormant until re-enabled.</summary>
+        Disabled,
+        /// <summary>Cold entry: gate-on → enable → PageSet, each latched on transport accept.</summary>
+        BringUp,
+        /// <summary>Commands sent (bring-up or resume); waiting for the confirming subscription push.</summary>
+        AwaitPush,
+        /// <summary>Host page change in flight: values suspended, quiet window, PageSet, await push.</summary>
+        Switching,
+        /// <summary>Push confirmed; handles adopted from the firmware. Values may flow.</summary>
+        Synced,
+        /// <summary>Expected push missing — running the recovery ladder (values stay suspended).</summary>
+        Recovery,
+        /// <summary>Game exited: gate-off (screen dark). Resumes via PageSet-while-off → gate-on.</summary>
+        TelemetryIdle,
+        /// <summary>Recovery ladder exhausted. Exponential backoff, then retry the gate-cycle rung.</summary>
+        Unavailable,
+    }
+
+    /// <summary>
+    /// The ITM display lifecycle state machine. Hardware truth this encodes (all verified on
+    /// hardware or in official-software captures — see docs/reference/protocol.md, "ITM Display"):
+    ///
+    /// - The firmware's subscription push is the protocol's <b>only acknowledgment</b>. Every
+    ///   state that has asked for a page change knows what push it expects and by when; a missing
+    ///   push is a first-class failure with a recovery ladder, not silence.
+    /// - Value traffic concurrent with a page switch is the identified cause of dropped switches,
+    ///   and a handle can be re-bound to a different parameter on any change — so values and
+    ///   ParamDefs are <b>fully suspended</b> from the moment a switch begins until its push
+    ///   confirms, and for the whole recovery ladder.
+    /// - Push confirmation matches on the <b>parameter set</b>, never on handles; handles and
+    ///   declared data types are adopted from the push. No page→handle map is ever cached.
+    /// - A PageSet to the already-displayed page yields no push, so "no push" after one PageSet
+    ///   is ambiguous; the ladder's flip-away-and-back forces a genuine change to convert
+    ///   silence into signal.
+    /// - The <c>FF 05 02</c> gate is the real screen control. Exit = gate-off (screen dark —
+    ///   no stale values, no burn-in). Resume = PageSet-while-off then gate-on, which elicits
+    ///   the page's push deterministically; a bare gate-on lands on the legacy page with no
+    ///   subscriptions and must never be sent.
+    /// - The runtime session does not survive a power cycle or wheel re-seat even though the
+    ///   gate <i>setting</i> persists — every cold entry re-runs the full bring-up, and a
+    ///   wheel-change event (from the identity layer) is treated as a cold start.
+    /// - Unexpected pushes are adopted in every state (wheel-button page changes, late pushes
+    ///   from a boot-cold base): the firmware is the source of truth and is never fought.
+    ///
+    /// This class is a pure state machine: injected clock, no HID reads, no threads. It consumes
+    /// parsed pushes (<see cref="OnPush"/>), telemetry-liveness edges (<see cref="Tick"/>), user
+    /// page requests and enable state, and wheel-change events; it emits commands through
+    /// <see cref="ItmEncoder"/>, each latched on transport accept and retried until accepted.
+    /// The value/ParamDefs pipeline lives in the driver above, gated by <see cref="ValuesAllowed"/>
+    /// and repainted on <see cref="SyncGeneration"/> changes.
+    /// </summary>
+    public class ItmLifecycleController
+    {
+        private readonly ItmEncoder _encoder;
+        private readonly byte _deviceId;
+        private readonly Func<long> _now;
+        private readonly Action<string> _log;
+
+        // ── Tunables (ms). Defaults are conservative multiples of the measured
+        //    behavior; single-rig timing constants, compensated by the ladder and
+        //    loud escalation logging until field data arrives. ─────────────────
+        /// <summary>Deadline for the expected push after a page-changing command completes.
+        /// Pushes follow a genuine change in 20–70 ms; 250 ms is a comfortable budget.</summary>
+        public int PushDeadlineMs { get; set; } = 250;
+
+        /// <summary>How long a push accumulates across reports before it is judged. One tested
+        /// setup consolidates a push into 1–2 reports; another sends one entry per report over
+        /// ~15 ms — the matcher must never treat a single report as the complete set.</summary>
+        public int AccumulateWindowMs { get; set; } = 50;
+
+        /// <summary>Grace window after an unsubscribe-only push in Synced: subscriptions arriving
+        /// within it are a page change (host- or button-driven); nothing arriving means the
+        /// firmware dropped our subscriptions → Recovery.</summary>
+        public int UnsubGraceMs { get; set; } = 100;
+
+        /// <summary>Quiet time between suspending values and sending a host PageSet. Suspension
+        /// is load-bearing: switches with values streaming alongside fail a substantial fraction
+        /// of the time, and mid-switch values can land on re-bound handles.</summary>
+        public int SwitchQuietMs { get; set; } = 50;
+
+        /// <summary>Minimum spacing between PageSet commands (firmware reconfiguration time).</summary>
+        public int PageSetSpacingMs { get; set; } = 100;
+
+        /// <summary>Backoff steps for <see cref="ItmLifecycleState.Unavailable"/> retries.</summary>
+        public IReadOnlyList<int> UnavailableBackoffMs { get; set; } =
+            new int[] { 5_000, 30_000, 300_000 };
+
+        /// <summary>The page targeted by cold entries (and resume, when no better page is known).</summary>
+        public byte DefaultPage { get; set; } = 1;
+
+        // ── Observable state ─────────────────────────────────────────────
+        public ItmLifecycleState State { get; private set; } = ItmLifecycleState.Idle;
+
+        /// <summary>The wire page number the display is known to be on (0 = unknown). Adopted
+        /// from pushes by matching the subscribed parameter set against the device's page
+        /// catalog — never assumed from a sent PageSet.</summary>
+        public byte CurrentPage { get; private set; }
+
+        /// <summary>Increments every time a push is adopted (sync, re-sync, wheel-button page
+        /// change). The driver repaints — immediate values, double-tap, then ParamDefs — on
+        /// every change: after any resync the display shows stale firmware-cached values until
+        /// the first fresh send.</summary>
+        public int SyncGeneration { get; private set; }
+
+        /// <summary>Values (and ParamDefs) may only be sent while this is true: Synced, and no
+        /// push currently accumulating (an in-flight push means the page is changing under us).</summary>
+        public bool ValuesAllowed => State == ItmLifecycleState.Synced && _accumCloseAt == 0;
+
+        /// <summary>The adopted handle map: host handle → subscription (param + declared type),
+        /// sorted by handle. Built exclusively from firmware pushes.</summary>
+        public IEnumerable<KeyValuePair<byte, ItmSubscription>> Subscriptions => _subs;
+
+        /// <summary>Number of parameters the firmware currently has subscribed.</summary>
+        public int SubscriptionCount => _subs.Count;
+
+        // ── Internal state ───────────────────────────────────────────────
+        private enum Cmd { GateOn, GateOff, Enable, PageSet }
+
+        private struct Step
+        {
+            public Cmd Cmd;
+            public byte Page;   // PageSet only
+        }
+
+        // The in-flight command procedure: each step is sent in order and latched only when
+        // the transport accepts it (a declined write is retried next tick). PageSet steps
+        // additionally respect PageSetSpacingMs.
+        private readonly List<Step> _steps = new List<Step>();
+        private int _stepIdx;
+        private bool _armOnDrain;    // arm the push expectation when the queue drains
+        private byte _armPage;       // the page whose push the armed expectation matches
+        private bool _pushDuringProcedure;   // a push arrived while steps were still being sent
+
+        private long _lastPageSetMs = -1_000_000_000;   // last accepted PageSet (spacing floor)
+
+        // Push expectation (armed once the triggering command sequence is fully accepted).
+        private byte _armedPage;     // page whose param set is expected (0 = not armed)
+        private long _deadlineAt;    // 0 = no deadline
+
+        // Push accumulation across fragmented reports.
+        private long _accumCloseAt;  // 0 = no accumulation open
+
+        // Unsubscribe-grace (Synced only).
+        private long _graceUntil;    // 0 = none
+
+        // Adopted handle map (from pushes only — cold entries clear it; there is no seeding).
+        private readonly SortedDictionary<byte, ItmSubscription> _subs =
+            new SortedDictionary<byte, ItmSubscription>();
+
+        // Switching.
+        private byte _targetPage;      // the page a procedure is driving toward
+        private long _quietUntil;      // Switching: when the quiet window ends (0 = sent already)
+        private byte _pendingRequest;  // host request queued behind an in-flight procedure
+
+        // Recovery ladder.
+        private enum Rung { None, PageSet1, PageSet2, FlipAway, FlipBack, GateCycle }
+        private Rung _rung = Rung.None;
+        private byte _flipPage;
+
+        // Unavailable backoff.
+        private int _backoffIdx;
+        private long _retryAt;
+
+        // Telemetry-liveness edge tracking + resume page.
+        private bool _wasLive;
+        private byte _resumePage;
+
+        private bool _userEnabled = true;
+
+        public ItmLifecycleController(ItmEncoder encoder, byte deviceId = ItmEncoder.DefaultDeviceId,
+            Func<long> nowMs = null, Action<string> log = null)
+        {
+            _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+            _deviceId = deviceId;
+            _now = nowMs ?? DefaultClock();
+            _log = log ?? (_ => { });
+        }
+
+        private static Func<long> DefaultClock()
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            return () => sw.ElapsedMilliseconds;
+        }
+
+        /// <summary>A short human-readable state line for logs and the Device Status panel.</summary>
+        public string Describe()
+        {
+            switch (State)
+            {
+                case ItmLifecycleState.Synced:
+                    return "Synced — page " + (CurrentPage == 0 ? "?" : CurrentPage.ToString())
+                        + ", " + _subs.Count + " params";
+                case ItmLifecycleState.Recovery:
+                    return "Recovering (" + RungName(_rung) + ", target page " + _targetPage + ")";
+                case ItmLifecycleState.Unavailable:
+                    long wait = _retryAt - _now();
+                    return "Unavailable — retry in " + Math.Max(0, (wait + 999) / 1000) + " s";
+                case ItmLifecycleState.AwaitPush:
+                    return "Waiting for page " + _targetPage + " confirmation";
+                case ItmLifecycleState.Switching:
+                    return "Switching to page " + _targetPage;
+                default:
+                    return State.ToString();
+            }
+        }
+
+        /// <summary>The adopted handle map as a log-friendly line, e.g. <c>h0=p1:t34 h1=p4:t12</c>.</summary>
+        public string DescribeMap()
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (var kv in _subs)
+            {
+                if (sb.Length > 0) sb.Append(' ');
+                sb.Append('h').Append(kv.Key).Append("=p").Append(kv.Value.ParamId);
+                if (kv.Value.DataType != 0)
+                    sb.Append(":t").Append(kv.Value.DataType.ToString("X2"));
+            }
+            return sb.Length == 0 ? "(no subscriptions)" : sb.ToString();
+        }
+
+        private static string RungName(Rung r)
+        {
+            switch (r)
+            {
+                case Rung.PageSet1: return "re-PageSet 1/2";
+                case Rung.PageSet2: return "re-PageSet 2/2";
+                case Rung.FlipAway: return "flip-away";
+                case Rung.FlipBack: return "flip-back";
+                case Rung.GateCycle: return "gate cycle";
+                default: return r.ToString();
+            }
+        }
+
+        // ── Inputs ───────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Begins the lifecycle with a full cold bring-up. Idempotent — a no-op unless Idle,
+        /// so it is safe to call every frame while the device is connected.
+        /// </summary>
+        public void Start()
+        {
+            if (State != ItmLifecycleState.Idle || !_userEnabled)
+                return;
+            ColdEntry("start");
+        }
+
+        /// <summary>
+        /// Stops the lifecycle (connection lost): back to Idle, all session state dropped,
+        /// nothing sent. A later <see cref="Start"/> re-runs the cold bring-up.
+        /// </summary>
+        public void Stop()
+        {
+            State = ItmLifecycleState.Idle;
+            ClearProcedure();
+            ClearExpectation();
+            _subs.Clear();
+            CurrentPage = 0;
+            _pendingRequest = 0;
+            _rung = Rung.None;
+            _backoffIdx = 0;
+            _wasLive = false;
+        }
+
+        /// <summary>
+        /// Applies the user's ITM on/off setting (safe to call every frame; edges are detected
+        /// internally). Off sends a single gate-off — the same persistent state the vendor
+        /// software's ITM switch sets — and goes dormant. On re-arms the cold bring-up.
+        /// </summary>
+        public void SetUserEnabled(bool enabled)
+        {
+            if (enabled == _userEnabled)
+                return;
+            _userEnabled = enabled;
+
+            if (!enabled)
+            {
+                // Enforce "off" from any state, including Idle (user may have ITM disabled
+                // from the start — the display must still be gated off once).
+                ClearProcedure();
+                ClearExpectation();
+                _rung = Rung.None;
+                State = ItmLifecycleState.Disabled;
+                QueueGateOff();
+                _log("ITM: disabled by user — gating off (setting persists until re-enabled here or in vendor software)");
+            }
+            else if (State == ItmLifecycleState.Disabled)
+            {
+                // Back to Idle; the next Start() runs the cold entry.
+                State = ItmLifecycleState.Idle;
+                ClearProcedure();
+            }
+        }
+
+        /// <summary>
+        /// Host page request (e.g. the default-page setting changed). In Synced this starts the
+        /// switch procedure; while another procedure is in flight it is queued and applied after
+        /// the next sync — unless a wheel-button change supersedes it (adopt, never fight).
+        /// </summary>
+        public void RequestPage(byte page)
+        {
+            if (page == 0)
+                return;
+            switch (State)
+            {
+                case ItmLifecycleState.Synced:
+                    if (page == CurrentPage)
+                        return;   // same-page PageSet pushes nothing — never ask for one
+                    BeginSwitch(page);
+                    break;
+                case ItmLifecycleState.TelemetryIdle:
+                    _resumePage = page;   // used by the resume PageSet-while-off
+                    break;
+                case ItmLifecycleState.BringUp:
+                case ItmLifecycleState.AwaitPush:
+                case ItmLifecycleState.Switching:
+                case ItmLifecycleState.Recovery:
+                case ItmLifecycleState.Unavailable:
+                    _pendingRequest = page;
+                    break;
+                    // Idle/Disabled: cold entries read DefaultPage directly.
+            }
+        }
+
+        /// <summary>
+        /// A wheel/hub/module change reported by the identity layer (FF 08). A hot-swap resets
+        /// the display to a cold state that is invisible on the ITM channel itself, so this is
+        /// treated as a full cold start: the handle map is dropped and bring-up re-runs.
+        /// </summary>
+        public void OnWheelChanged()
+        {
+            switch (State)
+            {
+                case ItmLifecycleState.Idle:
+                    return;
+                case ItmLifecycleState.Disabled:
+                    // The new wheel comes up with whatever gate setting persisted — re-assert off.
+                    QueueGateOff();
+                    return;
+                default:
+                    ColdEntry("wheel changed");
+                    return;
+            }
+        }
+
+        /// <summary>
+        /// Applies one parsed firmware push report (col03-IN <c>FF 05 01</c> entries for this
+        /// display). Entries are adopted into the handle map immediately, in every state; the
+        /// report opens (or joins) an accumulation window that is judged as a whole, because a
+        /// single page change can arrive fragmented across several reports.
+        /// </summary>
+        public void OnPush(IReadOnlyList<ItmSubscription> entries)
+        {
+            if (entries == null || entries.Count == 0)
+                return;
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                var s = entries[i];
+                if (s.IsUnsubscribe)
+                    _subs.Remove(s.Handle);
+                else
+                    _subs[s.Handle] = s;
+            }
+
+            if (_stepIdx < _steps.Count || _armOnDrain)
+                _pushDuringProcedure = true;
+
+            if (_accumCloseAt == 0)
+                _accumCloseAt = _now() + AccumulateWindowMs;
+        }
+
+        /// <summary>
+        /// Drives the machine one tick. Call once per frame while the device is connected,
+        /// with whether game telemetry is currently live.
+        /// </summary>
+        public void Tick(bool telemetryLive)
+        {
+            long now = _now();
+
+            // Telemetry live→dead edge: park in TelemetryIdle (gate-off, screen dark) from any
+            // active state — a switch or recovery interrupted by a game exit is abandoned; the
+            // resume shape re-establishes everything and is the strongest recovery there is.
+            if (_wasLive && !telemetryLive && IsActiveState(State))
+                EnterTelemetryIdle("game exited");
+            _wasLive = telemetryLive;
+
+            // Judge a completed push accumulation.
+            if (_accumCloseAt != 0 && now >= _accumCloseAt)
+            {
+                _accumCloseAt = 0;
+                JudgeAccumulation(now);
+            }
+
+            // Unsub-grace expiry: subscriptions were dropped and nothing followed.
+            if (_graceUntil != 0 && now >= _graceUntil && _accumCloseAt == 0)
+            {
+                _graceUntil = 0;
+                if (State == ItmLifecycleState.Synced)
+                {
+                    byte target = KnownTelemetryPageOrDefault(CurrentPage);
+                    _log("ITM: subscriptions dropped (unsubscribe with nothing following) — recovering page " + target);
+                    EnterRecovery(target, Rung.PageSet1);
+                }
+            }
+
+            // TelemetryIdle → resume on telemetry arrival: PageSet-while-off, then gate-on.
+            // (Never a bare gate-on — that lands on the legacy page with no subscriptions.)
+            if (State == ItmLifecycleState.TelemetryIdle && telemetryLive)
+            {
+                byte page = KnownTelemetryPageOrDefault(_resumePage);
+                _targetPage = page;
+                State = ItmLifecycleState.AwaitPush;
+                QueueStep(Cmd.PageSet, page);
+                QueueStep(Cmd.GateOn);
+                ArmOnDrain(page);
+                _log("ITM: telemetry resumed — PageSet(" + page + ") while off, then gate-on");
+            }
+
+            // Switching: after the quiet window, send the PageSet.
+            if (State == ItmLifecycleState.Switching && _quietUntil != 0 && now >= _quietUntil)
+            {
+                _quietUntil = 0;
+                QueueStep(Cmd.PageSet, _targetPage);
+                ArmOnDrain(_targetPage);
+            }
+
+            // Unavailable: backoff expiry retries the strongest rung (gate cycle with
+            // PageSet-while-off — the most reliable recovery observed).
+            if (State == ItmLifecycleState.Unavailable && now >= _retryAt)
+            {
+                _log("ITM: retrying after backoff — gate cycle for page " + _targetPage);
+                EnterRecovery(_targetPage, Rung.GateCycle);
+            }
+
+            PumpSteps(now);
+
+            // Expected-push deadline. Deferred while an accumulation is open — a push is
+            // mid-flight and the judgment will resolve it.
+            if (_deadlineAt != 0 && now >= _deadlineAt && _accumCloseAt == 0 && _stepIdx >= _steps.Count)
+            {
+                ClearExpectation();
+                OnPushMissed();
+            }
+        }
+
+        // ── Procedures ───────────────────────────────────────────────────
+
+        // Cold entry (start, restart, wheel change, power cycle): gate + enable + PageSet, each
+        // latched on transport accept; confirmation only ever comes from the push. The enable is
+        // kept for official-software parity — it has never been observed to do anything, and no
+        // state transition depends on it. The handle map is dropped: host state must never be
+        // used to infer firmware state.
+        private void ColdEntry(string why)
+        {
+            ClearProcedure();
+            ClearExpectation();
+            _subs.Clear();
+            CurrentPage = 0;
+            _rung = Rung.None;
+            _graceUntil = 0;
+
+            _targetPage = DefaultPage;
+            State = ItmLifecycleState.BringUp;
+            QueueStep(Cmd.GateOn);
+            QueueStep(Cmd.Enable);
+            QueueStep(Cmd.PageSet, DefaultPage);
+            ArmOnDrain(DefaultPage);
+            _log("ITM: bring-up (" + why + ") — gate + enable + PageSet(" + DefaultPage + ")");
+        }
+
+        private void BeginSwitch(byte page)
+        {
+            _targetPage = page;
+            State = ItmLifecycleState.Switching;
+            ClearExpectation();
+            _quietUntil = _now() + SwitchQuietMs;   // values are suspended from this instant
+        }
+
+        private void EnterTelemetryIdle(string why)
+        {
+            ClearProcedure();
+            ClearExpectation();
+            _graceUntil = 0;
+            _rung = Rung.None;
+            _resumePage = KnownTelemetryPageOrDefault(CurrentPage);
+            State = ItmLifecycleState.TelemetryIdle;
+            QueueGateOff();
+            _log("ITM: " + why + " — gating display off (dark; resume restores page " + _resumePage + ")");
+        }
+
+        private void EnterRecovery(byte target, Rung rung)
+        {
+            _targetPage = target;
+            State = ItmLifecycleState.Recovery;
+            _rung = rung;
+            StartRung();
+        }
+
+        // The ladder, quiet throughout (the driver sends nothing outside Synced): re-PageSet ×2 →
+        // flip-away-and-back (a genuine change MUST push, converting silence into a hard signal) →
+        // gate cycle with PageSet-while-off (the most reliable recovery observed; also the only
+        // move that un-wedges a display that stopped responding to PageSets) → Unavailable.
+        // Every rung logs what it tried — the ladder doubles as field diagnostics.
+        private void StartRung()
+        {
+            ClearProcedure();
+            ClearExpectation();
+            switch (_rung)
+            {
+                case Rung.PageSet1:
+                case Rung.PageSet2:
+                    _log("ITM recovery: " + RungName(_rung) + " — PageSet(" + _targetPage + ")");
+                    QueueStep(Cmd.PageSet, _targetPage);
+                    ArmOnDrain(_targetPage);
+                    break;
+                case Rung.FlipAway:
+                    _flipPage = PickFlipPage(_targetPage);
+                    _log("ITM recovery: flip-away-and-back — PageSet(" + _flipPage + ") then back to " + _targetPage);
+                    QueueStep(Cmd.PageSet, _flipPage);
+                    ArmOnDrain(_flipPage);
+                    break;
+                case Rung.FlipBack:
+                    QueueStep(Cmd.PageSet, _targetPage);
+                    ArmOnDrain(_targetPage);
+                    break;
+                case Rung.GateCycle:
+                    _log("ITM recovery: gate cycle — gate-off, PageSet(" + _targetPage + ") while off, gate-on (display blanks briefly)");
+                    QueueStep(Cmd.GateOff);
+                    QueueStep(Cmd.PageSet, _targetPage);
+                    QueueStep(Cmd.GateOn);
+                    ArmOnDrain(_targetPage);
+                    break;
+            }
+        }
+
+        private void OnPushMissed()
+        {
+            switch (State)
+            {
+                case ItmLifecycleState.AwaitPush:
+                case ItmLifecycleState.Switching:
+                    _log("ITM: no push within " + PushDeadlineMs + " ms for page " + _targetPage +
+                         " — entering recovery (a PageSet to the already-shown page correctly pushes nothing;" +
+                         " the ladder disambiguates)");
+                    EnterRecovery(_targetPage, Rung.PageSet1);
+                    break;
+                case ItmLifecycleState.Recovery:
+                    AdvanceRung();
+                    break;
+            }
+        }
+
+        private void AdvanceRung()
+        {
+            switch (_rung)
+            {
+                case Rung.PageSet1:
+                    _rung = Rung.PageSet2; StartRung(); break;
+                case Rung.PageSet2:
+                    _rung = Rung.FlipAway; StartRung(); break;
+                case Rung.FlipAway:   // the flip page didn't push — a hard failure signal
+                case Rung.FlipBack:
+                    _rung = Rung.GateCycle; StartRung(); break;
+                case Rung.GateCycle:
+                    EnterUnavailable(); break;
+            }
+        }
+
+        private void EnterUnavailable()
+        {
+            State = ItmLifecycleState.Unavailable;
+            _rung = Rung.None;
+            ClearProcedure();
+            ClearExpectation();
+            int backoff = UnavailableBackoffMs[Math.Min(_backoffIdx, UnavailableBackoffMs.Count - 1)];
+            if (_backoffIdx < UnavailableBackoffMs.Count - 1)
+                _backoffIdx++;
+            _retryAt = _now() + backoff;
+            _log("ITM: recovery ladder exhausted for page " + _targetPage + " — display unavailable, retrying in "
+                 + (backoff / 1000) + " s. If this persists, another program may be driving the display.");
+        }
+
+        // ── Push judgment ────────────────────────────────────────────────
+
+        // Judges the state of the handle map after an accumulation window closes. Matching is
+        // on the parameter SET (handles are setup-specific and can re-bind); the map itself was
+        // already adopted entry-by-entry as reports arrived.
+        private void JudgeAccumulation(long now)
+        {
+            var set = SubscribedParamSet();
+
+            if (set.Count == 0)
+            {
+                // Unsubscribe-only. In Synced this may be the front half of a page change
+                // (host- or button-driven) or our subscriptions being dropped — grace decides.
+                // After our own gate-off (TelemetryIdle/Disabled) it is the expected echo.
+                if (State == ItmLifecycleState.Synced)
+                    _graceUntil = now + UnsubGraceMs;
+                return;
+            }
+            _graceUntil = 0;
+
+            byte matchedPage = PageForParamSet(set);
+
+            // A procedure's commands are still being sent (e.g. resume's gate-on not yet
+            // accepted): adopt the data but defer transitions until the procedure completes —
+            // going Synced with a gate-on unsent would strand a dark display.
+            if (_stepIdx < _steps.Count)
+            {
+                CurrentPage = matchedPage;
+                return;
+            }
+
+            // The armed expectation (or the in-flight target, for a push that lands before the
+            // deadline is even armed) confirms the procedure.
+            if (_armedPage != 0 && SetEqualsPage(set, _armedPage))
+            {
+                byte page = _armedPage;
+                ClearExpectation();
+                if (State == ItmLifecycleState.Recovery && _rung == Rung.FlipAway && page == _flipPage)
+                {
+                    // Flip page confirmed — now flip back to the target.
+                    _rung = Rung.FlipBack;
+                    StartRung();
+                    return;
+                }
+                ConfirmSync(page, "push confirmed");
+                return;
+            }
+            if (ExpectsTargetPush() && SetEqualsPage(set, _targetPage))
+            {
+                ClearExpectation();
+                ConfirmSync(_targetPage, "push confirmed (early)");
+                return;
+            }
+
+            // Unexpected push: adopt, never fight.
+            switch (State)
+            {
+                case ItmLifecycleState.Synced:
+                    CurrentPage = matchedPage;
+                    SyncGeneration++;
+                    _log("ITM: page changed at the wheel — now page " +
+                         (matchedPage == 0 ? "?" : matchedPage.ToString()) + ": " + DescribeMap());
+                    break;
+                case ItmLifecycleState.AwaitPush:
+                case ItmLifecycleState.Switching:
+                case ItmLifecycleState.Recovery:
+                case ItmLifecycleState.Unavailable:
+                    // A COMPLETE different page than asked for (wheel button, late push from a
+                    // boot-cold base): the display is demonstrably alive — sync to reality. Any
+                    // queued host request is dropped rather than fought. A set matching no page
+                    // is most likely a fragment of a change still in flight (the rest lands in
+                    // a later accumulation) — resuming values on it would reopen the re-bound-
+                    // handle hazard, so keep waiting and let the deadline/ladder decide.
+                    if (matchedPage == 0)
+                        break;
+                    _pendingRequest = 0;
+                    ClearExpectation();
+                    _rung = Rung.None;
+                    ConfirmSync(matchedPage, "adopted unexpected push");
+                    break;
+                default:
+                    // Idle / Disabled / TelemetryIdle / BringUp: keep the adopted map, no
+                    // transition. In gated-off states a push means someone else gated on —
+                    // note it, don't fight it.
+                    CurrentPage = matchedPage;
+                    if (State == ItmLifecycleState.TelemetryIdle || State == ItmLifecycleState.Disabled)
+                        _log("ITM: subscription push received while gated off — another program may be driving the display");
+                    break;
+            }
+        }
+
+        private bool ExpectsTargetPush()
+        {
+            return State == ItmLifecycleState.AwaitPush
+                || State == ItmLifecycleState.Switching
+                || State == ItmLifecycleState.Recovery;
+        }
+
+        private void ConfirmSync(byte page, string why)
+        {
+            bool recovered = State == ItmLifecycleState.Recovery || State == ItmLifecycleState.Unavailable;
+            State = ItmLifecycleState.Synced;
+            CurrentPage = page;
+            _rung = Rung.None;
+            _backoffIdx = 0;
+            SyncGeneration++;
+            _log("ITM: " + why + " — page " + (page == 0 ? "?" : page.ToString())
+                 + (recovered ? " (recovered)" : "") + ": " + DescribeMap());
+
+            if (_pendingRequest != 0)
+            {
+                byte p = _pendingRequest;
+                _pendingRequest = 0;
+                if (p != page)
+                    BeginSwitch(p);
+            }
+        }
+
+        // ── Command pump ─────────────────────────────────────────────────
+
+        private void QueueStep(Cmd cmd, byte page = 0)
+        {
+            _steps.Add(new Step { Cmd = cmd, Page = page });
+        }
+
+        private void QueueGateOff()
+        {
+            ClearProcedure();
+            QueueStep(Cmd.GateOff);
+        }
+
+        private void ArmOnDrain(byte page)
+        {
+            _armOnDrain = true;
+            _armPage = page;
+        }
+
+        private void PumpSteps(long now)
+        {
+            while (_stepIdx < _steps.Count)
+            {
+                var step = _steps[_stepIdx];
+                bool ok;
+                switch (step.Cmd)
+                {
+                    case Cmd.GateOn:
+                        ok = _encoder.SetItmMode(true);
+                        break;
+                    case Cmd.GateOff:
+                        ok = _encoder.SetItmMode(false);
+                        break;
+                    case Cmd.Enable:
+                        ok = _encoder.EnableItm();
+                        break;
+                    default:   // PageSet
+                        if (now - _lastPageSetMs < PageSetSpacingMs)
+                            return;   // spacing floor — resume next tick
+                        ok = _encoder.SetPage(_deviceId, step.Page);
+                        if (ok)
+                            _lastPageSetMs = now;
+                        break;
+                }
+                if (!ok)
+                    return;   // declined — retry this step next tick
+                _stepIdx++;
+            }
+
+            if (_steps.Count > 0)
+            {
+                _steps.Clear();
+                _stepIdx = 0;
+            }
+
+            if (_armOnDrain)
+            {
+                _armOnDrain = false;
+                bool pushArrived = _pushDuringProcedure;
+                _pushDuringProcedure = false;
+                _armedPage = _armPage;
+                _deadlineAt = now + PushDeadlineMs;
+                if (State == ItmLifecycleState.BringUp)
+                    State = ItmLifecycleState.AwaitPush;
+
+                // A push may have landed while the commands were still being accepted
+                // (adopted with the transition deferred) — judge it now. Guarded on a push
+                // actually having arrived during the procedure: the map alone can look
+                // "already right" from stale pre-procedure state (e.g. a resume to the same
+                // page the display was on before the exit), and that must never self-confirm.
+                if (pushArrived && _accumCloseAt == 0 && _subs.Count > 0
+                    && SetEqualsPage(SubscribedParamSet(), _armedPage))
+                {
+                    byte page = _armedPage;
+                    ClearExpectation();
+                    if (State == ItmLifecycleState.Recovery && _rung == Rung.FlipAway && page == _flipPage)
+                    {
+                        _rung = Rung.FlipBack;
+                        StartRung();
+                    }
+                    else
+                    {
+                        ConfirmSync(page, "push confirmed (arrived during send)");
+                    }
+                }
+            }
+        }
+
+        private void ClearProcedure()
+        {
+            _steps.Clear();
+            _stepIdx = 0;
+            _armOnDrain = false;
+            _pushDuringProcedure = false;
+            _quietUntil = 0;
+        }
+
+        private void ClearExpectation()
+        {
+            _armedPage = 0;
+            _deadlineAt = 0;
+        }
+
+        // ── Page catalog helpers ─────────────────────────────────────────
+
+        private readonly HashSet<ushort> _setScratch = new HashSet<ushort>();
+
+        private HashSet<ushort> SubscribedParamSet()
+        {
+            _setScratch.Clear();
+            foreach (var kv in _subs)
+                _setScratch.Add(kv.Value.ParamId);
+            return _setScratch;
+        }
+
+        // The wire page whose parameter set exactly matches, or 0 if none does. Set matching is
+        // the only reliable identification: handles are allocation-strategy-specific, and the
+        // page number itself is never echoed anywhere in a push.
+        private byte PageForParamSet(HashSet<ushort> set)
+        {
+            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
+            {
+                if (p.Params.Count != set.Count || p.Params.Count == 0)
+                    continue;
+                bool all = true;
+                for (int i = 0; i < p.Params.Count; i++)
+                {
+                    if (!set.Contains(p.Params[i]))
+                    {
+                        all = false;
+                        break;
+                    }
+                }
+                if (all)
+                    return p.Number;
+            }
+            return 0;
+        }
+
+        private bool SetEqualsPage(HashSet<ushort> set, byte page)
+        {
+            IReadOnlyList<ushort> expected = null;
+            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
+            {
+                if (p.Number == page)
+                {
+                    expected = p.Params;
+                    break;
+                }
+            }
+            // A page we have no catalog entry for (or the legacy page) can't be matched
+            // exactly; accept any non-empty adopted set as that procedure's outcome.
+            if (expected == null || expected.Count == 0)
+                return set.Count > 0;
+
+            if (expected.Count != set.Count)
+                return false;
+            for (int i = 0; i < expected.Count; i++)
+                if (!set.Contains(expected[i]))
+                    return false;
+            return true;
+        }
+
+        // A telemetry (non-legacy) page suitable as a target: the candidate itself if it is
+        // one, else the default page, else the device's first telemetry page.
+        private byte KnownTelemetryPageOrDefault(byte candidate)
+        {
+            if (IsTelemetryPage(candidate))
+                return candidate;
+            if (IsTelemetryPage(DefaultPage))
+                return DefaultPage;
+            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
+                if (p.Params.Count > 0)
+                    return p.Number;
+            return 1;
+        }
+
+        private bool IsTelemetryPage(byte page)
+        {
+            if (page == 0)
+                return false;
+            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
+                if (p.Number == page)
+                    return p.Params.Count > 0;
+            return false;
+        }
+
+        // A different telemetry page to flip to — a genuine page change must push, so the flip
+        // converts "no push" from ambiguous into a hard failure signal.
+        private byte PickFlipPage(byte target)
+        {
+            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
+                if (p.Params.Count > 0 && p.Number != target)
+                    return p.Number;
+            return target == 1 ? (byte)2 : (byte)1;
+        }
+
+        private static bool IsActiveState(ItmLifecycleState s)
+        {
+            return s == ItmLifecycleState.BringUp
+                || s == ItmLifecycleState.AwaitPush
+                || s == ItmLifecycleState.Switching
+                || s == ItmLifecycleState.Synced
+                || s == ItmLifecycleState.Recovery
+                || s == ItmLifecycleState.Unavailable;
+        }
+    }
+}

--- a/src/FanaBridge.Core/Protocol/ItmLifecycleController.cs
+++ b/src/FanaBridge.Core/Protocol/ItmLifecycleController.cs
@@ -493,8 +493,14 @@ namespace FanaBridge.Protocol
                 }
             }
 
-            // Switching: after the quiet window, send the PageSet.
-            if (State == ItmLifecycleState.Switching && _quietUntil != 0 && now >= _quietUntil)
+            // Switching: after the quiet window, send the PageSet — but only once no push is
+            // accumulating. A push arriving during the quiet window is evidence the display is
+            // already changing pages (a wheel-button change or late firmware activity); sending
+            // a PageSet over it would reintroduce the concurrent-traffic hazard. Wait for the
+            // accumulation to be judged first — it may adopt that page and drop the host request
+            // (the judgment above cleared _accumCloseAt, so this fires the same tick it resolves).
+            if (State == ItmLifecycleState.Switching && _quietUntil != 0 && now >= _quietUntil
+                && _accumCloseAt == 0)
             {
                 _quietUntil = 0;
                 QueueStep(Cmd.PageSet, _targetPage);
@@ -649,9 +655,18 @@ namespace FanaBridge.Protocol
         {
             State = ItmLifecycleState.Unavailable;
             AbandonInFlight();
-            int backoff = UnavailableBackoffMs[Math.Min(_backoffIdx, UnavailableBackoffMs.Count - 1)];
-            if (_backoffIdx < UnavailableBackoffMs.Count - 1)
-                _backoffIdx++;
+            // UnavailableBackoffMs is publicly settable — tolerate a null/empty list rather
+            // than crashing the lifecycle on a bad tunable.
+            var steps = UnavailableBackoffMs;
+            int backoff;
+            if (steps == null || steps.Count == 0)
+                backoff = 5_000;
+            else
+            {
+                backoff = steps[Math.Min(_backoffIdx, steps.Count - 1)];
+                if (_backoffIdx < steps.Count - 1)
+                    _backoffIdx++;
+            }
             _retryAt = _now() + backoff;
             _log("ITM: recovery ladder exhausted for page " + _targetPage + " — display unavailable, retrying in "
                  + (backoff / 1000) + " s. If this persists, another program may be driving the display.");

--- a/src/FanaBridge.Core/Protocol/ItmLifecycleController.cs
+++ b/src/FanaBridge.Core/Protocol/ItmLifecycleController.cs
@@ -20,8 +20,6 @@ namespace FanaBridge.Protocol
         Synced,
         /// <summary>Expected push missing — running the recovery ladder (values stay suspended).</summary>
         Recovery,
-        /// <summary>Game exited: gate-off (screen dark). Resumes via PageSet-while-off → gate-on.</summary>
-        TelemetryIdle,
         /// <summary>Recovery ladder exhausted. Exponential backoff, then retry the gate-cycle rung.</summary>
         Unavailable,
     }
@@ -42,10 +40,13 @@ namespace FanaBridge.Protocol
     /// - A PageSet to the already-displayed page yields no push, so "no push" after one PageSet
     ///   is ambiguous; the ladder's flip-away-and-back forces a genuine change to convert
     ///   silence into signal.
-    /// - The <c>FF 05 02</c> gate is the real screen control. Exit = gate-off (screen dark —
-    ///   no stale values, no burn-in). Resume = PageSet-while-off then gate-on, which elicits
-    ///   the page's push deterministically; a bare gate-on lands on the legacy page with no
-    ///   subscriptions and must never be sent.
+    /// - The <c>FF 05 02</c> gate is the real screen control, but it is <b>never used at idle</b>
+    ///   — a game exit clears the fields to placeholders (DisplayReset) and keeps the ITM page
+    ///   visible, so the display never drops to the legacy 7-segment view on its own. Cold
+    ///   entries also DisplayReset so the page comes up showing placeholders, never a previous
+    ///   session's cached values. Gate-off is reserved for the user's explicit ITM-off and for
+    ///   the recovery ladder's last-resort gate-cycle rung (its brief drop to legacy is the
+    ///   escape hatch that re-establishes a wedged display).
     /// - The runtime session does not survive a power cycle or wheel re-seat even though the
     ///   gate <i>setting</i> persists — every cold entry re-runs the full bring-up, and a
     ///   wheel-change event (from the identity layer) is treated as a cold start.
@@ -95,7 +96,9 @@ namespace FanaBridge.Protocol
         public IReadOnlyList<int> UnavailableBackoffMs { get; set; } =
             new int[] { 5_000, 30_000, 300_000 };
 
-        /// <summary>The page targeted by cold entries (and resume, when no better page is known).</summary>
+        /// <summary>The page the display starts on: targeted by cold entries (connect / wheel
+        /// change / power cycle) and re-established at each game start. The wheel button
+        /// navigates from there within a session. Read live.</summary>
         public byte DefaultPage { get; set; } = 1;
 
         // ── Observable state ─────────────────────────────────────────────
@@ -144,7 +147,7 @@ namespace FanaBridge.Protocol
         public int SubscriptionCount => _subs.Count;
 
         // ── Internal state ───────────────────────────────────────────────
-        private enum Cmd { GateOn, GateOff, Enable, PageSet }
+        private enum Cmd { GateOn, GateOff, Enable, PageSet, Reset }
 
         private struct Step
         {
@@ -192,9 +195,8 @@ namespace FanaBridge.Protocol
         private int _backoffIdx;
         private long _retryAt;
 
-        // Telemetry-liveness edge tracking + resume page.
+        // Telemetry-liveness edge tracking (game exit clears fields; game return repaints).
         private bool _wasLive;
-        private byte _resumePage;
 
         // The user's on/off setting, and whether it has been enforced since the last
         // Stop(). Un-applied after every Stop so a reconnect re-asserts "off" — the
@@ -338,8 +340,9 @@ namespace FanaBridge.Protocol
 
         /// <summary>
         /// Host page request (e.g. the default-page setting changed). In Synced this starts the
-        /// switch procedure; while another procedure is in flight it is queued and applied after
-        /// the next sync — unless a wheel-button change supersedes it (adopt, never fight).
+        /// switch procedure — which works whether or not a game is running (the page previews on
+        /// the wheel either way). While another procedure is in flight it is queued and applied
+        /// after the next sync, unless a wheel-button change supersedes it (adopt, never fight).
         /// </summary>
         public void RequestPage(byte page)
         {
@@ -351,9 +354,6 @@ namespace FanaBridge.Protocol
                     if (page == CurrentPage)
                         return;   // same-page PageSet pushes nothing — never ask for one
                     BeginSwitch(page);
-                    break;
-                case ItmLifecycleState.TelemetryIdle:
-                    _resumePage = page;   // used by the resume PageSet-while-off
                     break;
                 case ItmLifecycleState.BringUp:
                 case ItmLifecycleState.AwaitPush:
@@ -380,20 +380,6 @@ namespace FanaBridge.Protocol
                 case ItmLifecycleState.Disabled:
                     // The new wheel comes up with whatever gate setting persisted — re-assert off.
                     QueueGateOff();
-                    return;
-                case ItmLifecycleState.TelemetryIdle:
-                    // The display is deliberately dark (game exited). Stay parked: drop the
-                    // old wheel's handles, re-assert the gate-off on the new wheel (its
-                    // persisted setting may be on), and let the resume's PageSet-while-off →
-                    // gate-on shape — valid from any cold state — bring it up when telemetry
-                    // returns. A cold bring-up here would light the display with no game.
-                    AbandonInFlight();
-                    _subs.Clear();
-                    _subsSnapshot = null;
-                    CurrentPage = 0;
-                    State = ItmLifecycleState.TelemetryIdle;
-                    QueueGateOff();
-                    _log("ITM: wheel changed while parked — staying dark; resume will bring the new wheel up");
                     return;
                 default:
                     ColdEntry("wheel changed");
@@ -443,11 +429,25 @@ namespace FanaBridge.Protocol
                 ColdEntry("start");
             }
 
-            // Telemetry live→dead edge: park in TelemetryIdle (gate-off, screen dark) from any
-            // active state — a switch or recovery interrupted by a game exit is abandoned; the
-            // resume shape re-establishes everything and is the strongest recovery there is.
-            if (_wasLive && !telemetryLive && IsActiveState(State))
-                EnterTelemetryIdle("game exited");
+            // Telemetry live→dead edge (game exit): clear the fields to placeholders so no
+            // stale numbers linger. The ITM page stays visible — no gate-off; dropping to
+            // legacy is reserved for the recovery escape hatch, never idle. Only from Synced
+            // (there's a page to clear); a mid-transition exit just lets its procedure resolve.
+            bool becameLive = telemetryLive && !_wasLive;
+            if (_wasLive && !telemetryLive && State == ItmLifecycleState.Synced)
+                QueueStep(Cmd.Reset);
+            // Game start (telemetry returns) from a settled Synced display: re-establish the
+            // default page. The DefaultPage setting is a real default — each game launch starts
+            // on it — while the wheel button owns navigation within a session. If the display is
+            // already on the default (the common case), just repaint over the placeholders.
+            if (becameLive && State == ItmLifecycleState.Synced)
+            {
+                byte def = EffectiveDefaultPage();
+                if (CurrentPage != def)
+                    BeginSwitch(def);
+                else
+                    SyncGeneration++;
+            }
             _wasLive = telemetryLive;
 
             // Judge a completed push accumulation — unless a procedure's commands are still
@@ -463,10 +463,9 @@ namespace FanaBridge.Protocol
             }
 
             // Grace expiry. Grace opens in Synced when a push left the map in a state that
-            // doesn't form a page: empty (unsubscribe-all — the front half of a page change,
-            // or our subscriptions being dropped) or a partial set (a change fragmented
-            // slower than the accumulation window). Anything arriving meanwhile re-judges;
-            // expiry means nothing followed.
+            // doesn't form a page: empty (unsubscribe-all with nothing following) or a partial
+            // set (a change fragmented slower than the accumulation window). Anything arriving
+            // meanwhile re-judges; expiry means nothing followed.
             if (_graceUntil != 0 && now >= _graceUntil && _accumCloseAt == 0)
             {
                 _graceUntil = 0;
@@ -475,9 +474,13 @@ namespace FanaBridge.Protocol
                     var set = SubscribedParamSet();
                     if (set.Count == 0)
                     {
-                        byte target = KnownTelemetryPageOrDefault(CurrentPage);
-                        _log("ITM: subscriptions dropped (unsubscribe with nothing following) — recovering page " + target);
-                        EnterRecovery(target, Rung.PageSet1);
+                        // An unsubscribe-all with nothing following means the display moved to
+                        // the legacy ITM page (no telemetry parameters) — the wheel button
+                        // reaches it, and it's a valid destination. Adopt it; never fight it
+                        // back to a telemetry page (that was the "can't select legacy" bug).
+                        CurrentPage = LegacyPageNumber();
+                        SyncGeneration++;
+                        _log("ITM: on the legacy ITM page (no telemetry parameters)");
                     }
                     else
                     {
@@ -488,19 +491,6 @@ namespace FanaBridge.Protocol
                         _log("ITM: adopted uncataloged page set: " + DescribeMap());
                     }
                 }
-            }
-
-            // TelemetryIdle → resume on telemetry arrival: PageSet-while-off, then gate-on.
-            // (Never a bare gate-on — that lands on the legacy page with no subscriptions.)
-            if (State == ItmLifecycleState.TelemetryIdle && telemetryLive)
-            {
-                byte page = KnownTelemetryPageOrDefault(_resumePage);
-                _targetPage = page;
-                State = ItmLifecycleState.AwaitPush;
-                QueueStep(Cmd.PageSet, page);
-                QueueStep(Cmd.GateOn);
-                ArmOnDrain(page);
-                _log("ITM: telemetry resumed — PageSet(" + page + ") while off, then gate-on");
             }
 
             // Switching: after the quiet window, send the PageSet.
@@ -545,13 +535,17 @@ namespace FanaBridge.Protocol
             CurrentPage = 0;
             _pendingRequest = 0;
 
-            _targetPage = DefaultPage;
+            byte page = EffectiveDefaultPage();
+            _targetPage = page;
             State = ItmLifecycleState.BringUp;
+            QueueStep(Cmd.Reset);       // clear the firmware's stale field cache first, so the
+                                        // page comes up showing placeholders, not a previous
+                                        // session's values (gate-independent — safe before gate-on)
             QueueStep(Cmd.GateOn);
             QueueStep(Cmd.Enable);
-            QueueStep(Cmd.PageSet, DefaultPage);
-            ArmOnDrain(DefaultPage);
-            _log("ITM: bring-up (" + why + ") — gate + enable + PageSet(" + DefaultPage + ")");
+            QueueStep(Cmd.PageSet, page);
+            ArmOnDrain(page);
+            _log("ITM: bring-up (" + why + ") — reset + gate + enable + PageSet(" + page + ")");
         }
 
         private void BeginSwitch(byte page)
@@ -561,15 +555,6 @@ namespace FanaBridge.Protocol
             ClearExpectation();
             _graceUntil = 0;
             _quietUntil = _now() + SwitchQuietMs;   // values are suspended from this instant
-        }
-
-        private void EnterTelemetryIdle(string why)
-        {
-            AbandonInFlight();
-            _resumePage = KnownTelemetryPageOrDefault(CurrentPage);
-            State = ItmLifecycleState.TelemetryIdle;
-            QueueGateOff();
-            _log("ITM: " + why + " — gating display off (dark; resume restores page " + _resumePage + ")");
         }
 
         private void EnterRecovery(byte target, Rung rung)
@@ -619,6 +604,16 @@ namespace FanaBridge.Protocol
 
         private void OnPushMissed()
         {
+            // A PageSet to the legacy page can correctly push nothing (it carries no telemetry
+            // parameters, and it may already be shown). A missed push there means we're on the
+            // legacy page — confirm it, don't recover away from it.
+            if ((State == ItmLifecycleState.AwaitPush || State == ItmLifecycleState.Switching)
+                && IsLegacyPage(_targetPage))
+            {
+                ConfirmSync(_targetPage, "on the legacy ITM page (no push expected)");
+                return;
+            }
+
             switch (State)
             {
                 case ItmLifecycleState.AwaitPush:
@@ -675,9 +670,19 @@ namespace FanaBridge.Protocol
 
             if (set.Count == 0)
             {
-                // Unsubscribe-only. In Synced this may be the front half of a page change
-                // (host- or button-driven) or our subscriptions being dropped — grace decides.
-                // After our own gate-off (TelemetryIdle/Disabled) it is the expected echo.
+                // Unsubscribe-only push (no telemetry parameters).
+                // - If we asked for the legacy page, this IS its confirming push — the legacy
+                //   ITM page carries no parameters, so an unsubscribe-all is all it emits.
+                if (ExpectsTargetPush() && IsLegacyPage(_targetPage))
+                {
+                    ClearExpectation();
+                    _graceUntil = 0;
+                    ConfirmSync(_targetPage, "on the legacy ITM page");
+                    return;
+                }
+                // - In Synced it may be the front half of a page change (subs arrive within
+                //   grace) or the display moving to the legacy page (wheel button) — grace
+                //   decides (see the grace-expiry handling in Tick).
                 if (State == ItmLifecycleState.Synced)
                     _graceUntil = now + UnsubGraceMs;
                 return;
@@ -759,11 +764,10 @@ namespace FanaBridge.Protocol
                     ConfirmSync(matchedPage, "adopted unexpected push");
                     break;
                 default:
-                    // Idle / Disabled / TelemetryIdle: keep the adopted map, no transition.
-                    // In gated-off states a push means someone else gated on — note it,
-                    // don't fight it.
+                    // Idle / Disabled: keep the adopted map, no transition. While the user has
+                    // ITM gated off, a push means someone else gated it on — note it, don't fight.
                     CurrentPage = matchedPage;
-                    if (State == ItmLifecycleState.TelemetryIdle || State == ItmLifecycleState.Disabled)
+                    if (State == ItmLifecycleState.Disabled)
                         _log("ITM: subscription push received while gated off — another program may be driving the display");
                     break;
             }
@@ -786,6 +790,13 @@ namespace FanaBridge.Protocol
             SyncGeneration++;
             _log("ITM: " + why + " — page " + (page == 0 ? "?" : page.ToString())
                  + (recovered ? " (recovered)" : "") + ": " + DescribeMap());
+
+            // Reached a synced display with no game feeding it — a bring-up at connect or a
+            // page change while idle. Clear the fields to placeholders so the page shows --- ,
+            // not a previous session's cached values; a game arriving repaints over them. (Not
+            // for the legacy page, which has no fields.)
+            if (!_wasLive && !IsLegacyPage(page))
+                QueueStep(Cmd.Reset);
 
             if (_pendingRequest != 0)
             {
@@ -831,6 +842,9 @@ namespace FanaBridge.Protocol
                         break;
                     case Cmd.Enable:
                         ok = _encoder.EnableItm();
+                        break;
+                    case Cmd.Reset:
+                        ok = _encoder.ResetDisplay();   // FF 05 05 01 — clear cached field values
                         break;
                     default:   // PageSet
                         if (now - _lastPageSetMs < PageSetSpacingMs)
@@ -890,9 +904,9 @@ namespace FanaBridge.Protocol
 
         // Drops everything in flight: the command procedure, the push expectation, an open
         // accumulation, the grace window, and the recovery rung. Used by every transition
-        // that abandons the current activity (stop, cold entry, user off, telemetry exit) —
-        // hand-picked subsets at each site drift, and a survivor (e.g. an open accumulation
-        // crossing a cold entry) can mis-attribute a stale push to the new session.
+        // that abandons the current activity (stop, cold entry, user off) — hand-picked subsets
+        // at each site drift, and a survivor (e.g. an open accumulation crossing a cold entry)
+        // can mis-attribute a stale push to the new session.
         private void AbandonInFlight()
         {
             ClearProcedure();
@@ -951,10 +965,17 @@ namespace FanaBridge.Protocol
         private bool SetEqualsPage(HashSet<ushort> set, byte page)
         {
             var info = PageInfoFor(page);
-            // A page we have no catalog entry for (or the legacy page) can't be matched
-            // exactly; accept any non-empty adopted set as that procedure's outcome.
-            if (info == null || info.Params.Count == 0)
+            // An unknown page (no catalog entry) can't be matched exactly — accept any non-empty
+            // set as that procedure's outcome. Armed pages are always catalog pages, so this is
+            // only a safety net.
+            if (info == null)
                 return set.Count > 0;
+            // The legacy page carries no parameters, so its confirming push is the empty
+            // unsubscribe-all (handled earlier in JudgeAccumulation). A NON-empty set reaching
+            // here is a telemetry page and must never match legacy — otherwise we'd confirm
+            // "on legacy" while holding telemetry subscriptions.
+            if (info.Params.Count == 0)
+                return set.Count == 0;
 
             var expected = info.Params;
             if (expected.Count != set.Count)
@@ -965,27 +986,34 @@ namespace FanaBridge.Protocol
             return true;
         }
 
-        // A telemetry (non-legacy) page suitable as a target: the candidate itself if it is
-        // one, else the default page, else the device's first telemetry page.
-        private byte KnownTelemetryPageOrDefault(byte candidate)
-        {
-            if (IsTelemetryPage(candidate))
-                return candidate;
-            if (IsTelemetryPage(DefaultPage))
-                return DefaultPage;
-            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
-                if (p.Params.Count > 0)
-                    return p.Number;
-            return 1;
-        }
-
-        // "Telemetry page" = carries parameters, so a PageSet to it can be confirmed by a
-        // push. Deliberately keyed on Params.Count rather than IsLegacy: the wire behavior
-        // (a paramless page pushes nothing) is what the lifecycle depends on.
-        private bool IsTelemetryPage(byte page)
+        // The legacy ITM page has no telemetry parameters — its PageSet pushes only an
+        // unsubscribe-all (or nothing, if already there), which the matcher must treat as a
+        // valid destination rather than a dropped-subscriptions failure.
+        private bool IsLegacyPage(byte page)
         {
             var info = PageInfoFor(page);
-            return info != null && info.Params.Count > 0;
+            return info != null && info.IsLegacy;
+        }
+
+        // The device's legacy page number, or 0 if it has none.
+        private byte LegacyPageNumber()
+        {
+            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
+                if (p.IsLegacy)
+                    return p.Number;
+            return 0;
+        }
+
+        // The configured starting page resolved to a real page on this device. Guards against a
+        // 0 (unset) or an out-of-range value (e.g. a page number saved for a different display)
+        // becoming a PageSet(0) or a target no push can ever confirm — falls back to the
+        // device's first page.
+        private byte EffectiveDefaultPage()
+        {
+            if (PageInfoFor(DefaultPage) != null)
+                return DefaultPage;
+            var pages = ItmDeviceCatalog.PagesFor(_deviceId);
+            return pages.Count > 0 ? pages[0].Number : (byte)1;
         }
 
         // A different telemetry page to flip to — a genuine page change must push, so the flip
@@ -996,16 +1024,6 @@ namespace FanaBridge.Protocol
                 if (p.Params.Count > 0 && p.Number != target)
                     return p.Number;
             return target == 1 ? (byte)2 : (byte)1;
-        }
-
-        private static bool IsActiveState(ItmLifecycleState s)
-        {
-            return s == ItmLifecycleState.BringUp
-                || s == ItmLifecycleState.AwaitPush
-                || s == ItmLifecycleState.Switching
-                || s == ItmLifecycleState.Synced
-                || s == ItmLifecycleState.Recovery
-                || s == ItmLifecycleState.Unavailable;
         }
     }
 }

--- a/src/FanaBridge.Core/Transport/FanatecWheelbase.cs
+++ b/src/FanaBridge.Core/Transport/FanatecWheelbase.cs
@@ -268,6 +268,20 @@ namespace FanaBridge.Transport
         /// </summary>
         public event Action<FanatecWheelbase> WheelChanged;
 
+        /// <summary>
+        /// Monotonic count of <see cref="WheelChanged"/> firings — a poll-friendly change
+        /// signal for per-frame consumers (e.g. the ITM lifecycle treats every wheel change
+        /// as a cold start) that must not hold event subscriptions across plugin
+        /// generations (see issue #37).
+        /// </summary>
+        public int WheelChangeCount { get; private set; }
+
+        private void RaiseWheelChanged()
+        {
+            WheelChangeCount++;
+            WheelChanged?.Invoke(this);
+        }
+
         // ── Configuration ────────────────────────────────────────────────
 
         /// <summary>
@@ -597,7 +611,7 @@ namespace FanaBridge.Transport
             BaseCode = FanatecIdentity.DecodeBaseCode(_lastReading.BaseType);
 
             ResolveCapabilities("Wheel changed");
-            WheelChanged?.Invoke(this);
+            RaiseWheelChanged();
         }
 
         // Commit a fixed SRM converter identity from the DE FA channel (a one-shot — no settler). Rim +
@@ -621,7 +635,7 @@ namespace FanaBridge.Transport
             _identityStable = true;                          // fixed identity — always settled
 
             ResolveCapabilities("SRM converter identified");
-            WheelChanged?.Invoke(this);
+            RaiseWheelChanged();
             Log.Info(string.Format(
                 "FanatecWheelbase: SRM Conversion Kit — Wheel={0} (id 0x{1:X2}), Module={2}, KitFw={3}",
                 WheelCode ?? "unknown", wire, ModuleCode ?? "(none)", SrmKitFirmware ?? "?"));
@@ -638,7 +652,7 @@ namespace FanaBridge.Transport
                 return;
 
             ResolveCapabilities("RefreshCapabilities");
-            WheelChanged?.Invoke(this);
+            RaiseWheelChanged();
         }
 
         /// <summary>

--- a/src/FanaBridge.Core/Transport/FanatecWheelbase.cs
+++ b/src/FanaBridge.Core/Transport/FanatecWheelbase.cs
@@ -269,16 +269,30 @@ namespace FanaBridge.Transport
         public event Action<FanatecWheelbase> WheelChanged;
 
         /// <summary>
-        /// Monotonic count of <see cref="WheelChanged"/> firings — a poll-friendly change
-        /// signal for per-frame consumers (e.g. the ITM lifecycle treats every wheel change
-        /// as a cold start) that must not hold event subscriptions across plugin
-        /// generations (see issue #37).
+        /// Monotonic count of committed identity changes (FF 08 settles and SRM converter
+        /// identification) — a poll-friendly change signal for per-frame consumers (e.g. the
+        /// ITM lifecycle treats every wheel change as a cold start) that must not hold event
+        /// subscriptions across plugin generations (see issue #37). Deliberately NOT bumped
+        /// by <see cref="RefreshCapabilities"/>: a profile-store re-resolution fires
+        /// <see cref="WheelChanged"/> too, but the physical attachment (and thus the display
+        /// state) is unchanged — treating it as a hot-swap would cold-restart the ITM display
+        /// because the user saved an unrelated settings override. Written only from the
+        /// identity commit path (the drain/tick thread).
         /// </summary>
         public int WheelChangeCount { get; private set; }
 
-        private void RaiseWheelChanged()
+        private void RaiseWheelChanged(bool identityChanged)
         {
-            WheelChangeCount++;
+            if (identityChanged)
+            {
+                WheelChangeCount++;
+                // An identity change invalidates any buffered ITM subscription reports: they
+                // were pushed by the PREVIOUS attachment, and feeding them to the restarted
+                // ITM lifecycle could falsely confirm the new wheel's bring-up against the
+                // old wheel's page.
+                lock (_itmLock)
+                    _itmReports.Clear();
+            }
             WheelChanged?.Invoke(this);
         }
 
@@ -611,7 +625,7 @@ namespace FanaBridge.Transport
             BaseCode = FanatecIdentity.DecodeBaseCode(_lastReading.BaseType);
 
             ResolveCapabilities("Wheel changed");
-            RaiseWheelChanged();
+            RaiseWheelChanged(identityChanged: true);
         }
 
         // Commit a fixed SRM converter identity from the DE FA channel (a one-shot — no settler). Rim +
@@ -635,7 +649,7 @@ namespace FanaBridge.Transport
             _identityStable = true;                          // fixed identity — always settled
 
             ResolveCapabilities("SRM converter identified");
-            RaiseWheelChanged();
+            RaiseWheelChanged(identityChanged: true);
             Log.Info(string.Format(
                 "FanatecWheelbase: SRM Conversion Kit — Wheel={0} (id 0x{1:X2}), Module={2}, KitFw={3}",
                 WheelCode ?? "unknown", wire, ModuleCode ?? "(none)", SrmKitFirmware ?? "?"));
@@ -652,7 +666,7 @@ namespace FanaBridge.Transport
                 return;
 
             ResolveCapabilities("RefreshCapabilities");
-            RaiseWheelChanged();
+            RaiseWheelChanged(identityChanged: false);   // same attachment — profiles re-resolved only
         }
 
         /// <summary>

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -94,11 +94,34 @@ namespace FanaBridge.Adapters
         /// <summary>Test hook: the generation the cached drivers were built against.</summary>
         internal FanatecPlugin BoundPluginForTest => _boundPlugin;
 
+        // ITM status snapshot for the Device Status panel / diagnostics. Composed on the
+        // DataUpdate thread (the only thread that mutates the lifecycle) and read from the
+        // UI's DispatcherTimer — a volatile string hand-off instead of cross-thread reads
+        // of live state-machine fields. Refreshed on state/sync changes plus a coarse
+        // 1 s tick (the Unavailable line carries a retry countdown).
+        private volatile string _itmStatusSnapshot;
+        private ItmLifecycleState _itmSnapState;
+        private int _itmSnapGen;
+        private int _itmSnapTick;
+
+        private void PublishItmStatusSnapshot(ItmLifecycleState state)
+        {
+            int gen = _itmDisplay.Lifecycle.SyncGeneration;
+            int tick = Environment.TickCount;
+            if (_itmStatusSnapshot != null && state == _itmSnapState && gen == _itmSnapGen
+                && tick - _itmSnapTick < 1000)
+                return;
+            _itmSnapState = state;
+            _itmSnapGen = gen;
+            _itmSnapTick = tick;
+            _itmStatusSnapshot = _itmDisplay.Lifecycle.Describe();
+        }
+
         /// <summary>
         /// The ITM lifecycle status line for the Device Status panel, or null when this
-        /// instance isn't driving an ITM display.
+        /// instance isn't driving an ITM display. Safe to read from any thread.
         /// </summary>
-        internal string ItmStatusDescription => _itmDisplay?.Lifecycle.Describe();
+        internal string ItmStatusDescription => _itmDisplay == null ? null : _itmStatusSnapshot;
 
         public FanatecWheelDeviceInstance(DeviceConfig config)
         {
@@ -405,6 +428,7 @@ namespace FanaBridge.Adapters
                 _displayManager?.Clear();
                 _itmDisplay?.Stop();
                 _itmWasRunning = false;
+                _itmStatusSnapshot = null;   // don't show a stale ITM row while disconnected
                 // Reset one-shot latches so a reconnect starts clean: errors can log again
                 // and the legacy page can re-blank when the mode is "None".
                 _itmErrorLogged = false;
@@ -512,13 +536,28 @@ namespace FanaBridge.Adapters
 
                     _itmDisplay.Update(data);
 
-                    // Log the bring-up completing once, so hardware verification can
-                    // confirm from the SimHub log that ITM went live.
+                    // Log the FIRST bring-up completing per connection, so hardware
+                    // verification can confirm from the SimHub log that ITM went live.
+                    // Sticky until disconnect: IsRunning legitimately flaps through page
+                    // switches, game exits, and recoveries (the controller logs those
+                    // itself), and re-firing here would read as a reconnect loop.
                     if (_itmDisplay.IsRunning && !_itmWasRunning)
+                    {
+                        _itmWasRunning = true;
                         SimHub.Logging.Current.Info(
                             "FanatecWheelDeviceInstance[" + _config.Capabilities.Name +
                             "]: ITM enabled — following firmware subscriptions");
-                    _itmWasRunning = _itmDisplay.IsRunning;
+                    }
+
+                    // While the display is failing (recovery ladder / unavailable), run the
+                    // TTL-cached co-driver probe so its detection edge lands in the session
+                    // log next to the failure it may explain — not only while the settings
+                    // tab happens to be open.
+                    var itmState = _itmDisplay.Lifecycle.State;
+                    if (itmState == ItmLifecycleState.Recovery || itmState == ItmLifecycleState.Unavailable)
+                        plugin.ProbeItmCoDriver();
+
+                    PublishItmStatusSnapshot(itmState);
 
                     // Optionally also drive the legacy 7-segment gear/speed over col01. On an
                     // ITM OLED (e.g. PBME) the firmware renders this on its legacy page. This

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -57,6 +57,11 @@ namespace FanaBridge.Adapters
         private byte _itmDeviceId;
         private bool _itmWasRunning;
         private bool _itmErrorLogged;
+        // Wheel-change edge detection (polled — no event subscription that could
+        // outlive a plugin generation, see issue #37). A wheel/hub/module change
+        // resets the display cold with no trace on the ITM channel, so the ITM
+        // lifecycle must restart from bring-up.
+        private int _itmWheelChangeCount;
         // True once the legacy page has been blanked after switching to mode "None",
         // so it is cleared once on the transition rather than every frame.
         private bool _legacyBlanked;
@@ -88,6 +93,12 @@ namespace FanaBridge.Adapters
 
         /// <summary>Test hook: the generation the cached drivers were built against.</summary>
         internal FanatecPlugin BoundPluginForTest => _boundPlugin;
+
+        /// <summary>
+        /// The ITM lifecycle status line for the Device Status panel, or null when this
+        /// instance isn't driving an ITM display.
+        /// </summary>
+        internal string ItmStatusDescription => _itmDisplay?.Lifecycle.Describe();
 
         public FanatecWheelDeviceInstance(DeviceConfig config)
         {
@@ -466,6 +477,9 @@ namespace FanaBridge.Adapters
                     _itmDisplay = new ItmDisplayDriver(plugin.Itm,
                         log: msg => SimHub.Logging.Current.Info("FanaBridge: " + msg),
                         deviceId: _itmDeviceId);
+                    // Baseline the wheel-change counter at creation — the driver is starting
+                    // cold anyway, so changes before this point are already accounted for.
+                    _itmWheelChangeCount = plugin.Wheelbase?.WheelChangeCount ?? 0;
                     SimHub.Logging.Current.Info(
                         "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: Created ITM display driver");
                 }
@@ -481,6 +495,16 @@ namespace FanaBridge.Adapters
                     _itmDisplay.ShowLapTotal = _displaySettings.ItmShowLapTotal;
                     _itmDisplay.ShowPositionTotal = _displaySettings.ItmShowPositionTotal;
                     _itmDisplay.DefaultPage = _displaySettings.ItmDefaultPage;
+
+                    // A wheel/hub/module change (identity layer, FF 08) resets the display to
+                    // a cold state that is invisible on the ITM channel — restart the ITM
+                    // lifecycle from bring-up. Polled via the monotonic counter.
+                    int wheelChanges = plugin.Wheelbase?.WheelChangeCount ?? 0;
+                    if (wheelChanges != _itmWheelChangeCount)
+                    {
+                        _itmWheelChangeCount = wheelChanges;
+                        _itmDisplay.OnWheelChanged();
+                    }
 
                     // Feed the firmware's pushed ITM subscription reports (col03-IN) to the
                     // driver so it follows the page the wheel button selects.

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -242,6 +242,10 @@ namespace FanaBridge.Adapters
             // lazily (DataUpdate builds them on demand from the live plugin).
             _displayManager = null;
             _itmDisplay = null;
+            // Clear the status cache the instant the driver is invalidated (not just at the
+            // rebuild site) so the Device Status row can never read a disposed generation's
+            // description in the window before the new driver publishes (issue #37 path).
+            _itmStatusSnapshot = null;
             _itmWasRunning = false;
             _itmErrorLogged = false;
             _legacyBlanked = false;
@@ -504,6 +508,10 @@ namespace FanaBridge.Adapters
                     // Baseline the wheel-change counter at creation — the driver is starting
                     // cold anyway, so changes before this point are already accounted for.
                     _itmWheelChangeCount = plugin.Wheelbase?.WheelChangeCount ?? 0;
+                    // Drop any status snapshot cached from a disposed generation's controller,
+                    // so the Device Status row never shows the old controller's description
+                    // (a plugin-generation rebind or a display-id change rebuilds the driver here).
+                    _itmStatusSnapshot = null;
                     SimHub.Logging.Current.Info(
                         "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: Created ITM display driver");
                 }
@@ -528,6 +536,10 @@ namespace FanaBridge.Adapters
                     {
                         _itmWheelChangeCount = wheelChanges;
                         _itmDisplay.OnWheelChanged();
+                        // A hot-swap fully cold-restarts the lifecycle — re-arm the one-shot
+                        // "ITM enabled" log so the re-sync on the new wheel gets a fresh
+                        // confirmation line (swaps are infrequent, so no reconnect-loop noise).
+                        _itmWasRunning = false;
                     }
 
                     // Feed the firmware's pushed ITM subscription reports (col03-IN) to the

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -108,8 +108,11 @@ namespace FanaBridge.Adapters
         {
             int gen = _itmDisplay.Lifecycle.SyncGeneration;
             int tick = Environment.TickCount;
+            // Wrap-safe elapsed check: Environment.TickCount rolls to int.MinValue every ~24.9
+            // days (and net48 has no TickCount64), so measure the delta as an unsigned difference
+            // — correct across the wrap, and it never throws even under a checked-arithmetic build.
             if (_itmStatusSnapshot != null && state == _itmSnapState && gen == _itmSnapGen
-                && tick - _itmSnapTick < 1000)
+                && unchecked((uint)(tick - _itmSnapTick)) < 1000)
                 return;
             _itmSnapState = state;
             _itmSnapGen = gen;

--- a/src/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/src/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -70,28 +70,21 @@ namespace FanaBridge.Adapters
         /// </summary>
         public byte DefaultPage { get; set; } = 1;
 
-        private bool _enabled = true;
-
         /// <summary>
         /// Whether the ITM display is enabled. Set false to turn ITM off (the display is gated
         /// off — the same persistent state the vendor software's ITM switch sets — and the
-        /// driver goes dormant); set true to re-enable. Read live each frame.
+        /// driver goes dormant); set true to re-enable. Read live each frame; applied to the
+        /// lifecycle inside <see cref="Update"/> so all controller mutation stays on the
+        /// update thread.
         /// </summary>
-        public bool Enabled
-        {
-            get { return _enabled; }
-            set
-            {
-                _enabled = value;
-                _lifecycle.SetUserEnabled(value);
-            }
-        }
+        public bool Enabled { get; set; } = true;
 
         // ── State ────────────────────────────────────────────────────────
         private long _lastValuesMs;
         private long _lastSendOkMs;    // last accepted value send — drives the periodic re-assert
-        private byte _lastRequestedPage;   // edge-detects a default-page settings change
-        private bool _pageEdgeArmed;
+        // Edge-detects a default-page settings change; null = re-baseline on the next Update
+        // (fresh driver or post-Stop), so the first frame never reads as a change.
+        private byte? _lastRequestedPage;
 
         // Post-sync repaint: first values immediately, a tight second tap, then ParamDefs.
         private enum Paint { None, First, SecondTap }
@@ -161,6 +154,8 @@ namespace FanaBridge.Adapters
         /// </summary>
         public void OnWheelChanged()
         {
+            // The cold entry runs immediately — make sure it targets the current setting.
+            _lifecycle.DefaultPage = DefaultPage;
             _lifecycle.OnWheelChanged();
         }
 
@@ -173,7 +168,7 @@ namespace FanaBridge.Adapters
             _defTap2DueMs = 0;
             _defTap2Defs = null;
             _paint = Paint.None;
-            _pageEdgeArmed = false;
+            _lastRequestedPage = null;
         }
 
         /// <summary>
@@ -199,12 +194,9 @@ namespace FanaBridge.Adapters
             // and requested live, so the wheel button isn't fought between changes.
             _lifecycle.DefaultPage = DefaultPage;
             _lifecycle.SetUserEnabled(Enabled);
-            if (!_pageEdgeArmed)
-            {
-                _pageEdgeArmed = true;
+            if (_lastRequestedPage == null)
                 _lastRequestedPage = DefaultPage;
-            }
-            if (DefaultPage != _lastRequestedPage)
+            else if (DefaultPage != _lastRequestedPage.Value)
             {
                 _lastRequestedPage = DefaultPage;
                 _lifecycle.RequestPage(DefaultPage);
@@ -294,8 +286,10 @@ namespace FanaBridge.Adapters
             List<ItmParamDef> defs = null;
             var sig = new System.Text.StringBuilder();
 
-            foreach (var kv in _lifecycle.Subscriptions)
+            var subs = _lifecycle.Subscriptions;
+            for (int i = 0; i < subs.Count; i++)
             {
+                var kv = subs[i];
                 ushort paramId = kv.Value.ParamId;
                 string suffix;
                 if (ItmTelemetryMapper.TryGetUnitSuffix(paramId, data, out suffix))
@@ -360,8 +354,10 @@ namespace FanaBridge.Adapters
         private SendOutcome TrySendValues(GameData data, long now, bool force)
         {
             _valueBuf.Clear();
-            foreach (var kv in _lifecycle.Subscriptions)
+            var subs = _lifecycle.Subscriptions;
+            for (int i = 0; i < subs.Count; i++)
             {
+                var kv = subs[i];
                 if (ItmTelemetryMapper.TryEncodeParam(kv.Value.ParamId, kv.Key, data, kv.Value.DataType, out var v))
                     _valueBuf.Add(v);
                 else if (_unencodableWarned.Add(kv.Value.ParamId))

--- a/src/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/src/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -189,9 +189,9 @@ namespace FanaBridge.Adapters
             long now = _now();
             bool telemetryLive = data != null && data.GameRunning && data.NewData != null;
 
-            // Settings flow into the lifecycle: the default page (cold-entry/resume target) and
-            // the user's on/off switch. A settings change of the default page is edge-detected
-            // and requested live, so the wheel button isn't fought between changes.
+            // Settings flow into the lifecycle: the default page (cold-entry target) and the
+            // user's on/off switch. A settings change of the default page is edge-detected and
+            // requested live, so the wheel button isn't fought between changes.
             _lifecycle.DefaultPage = DefaultPage;
             _lifecycle.SetUserEnabled(Enabled);
             if (_lastRequestedPage == null)
@@ -225,7 +225,7 @@ namespace FanaBridge.Adapters
 
             // ...and only while a game is feeding telemetry: SimHub keeps the last telemetry
             // values around after a game exits, and painting from stale data would resurrect
-            // exactly the frozen frame the exit gate-off just hid.
+            // exactly the frozen frame the exit DisplayReset just cleared to placeholders.
             if (!telemetryLive)
                 return;
 

--- a/src/FanaBridge/Adapters/ItmDisplayDriver.cs
+++ b/src/FanaBridge/Adapters/ItmDisplayDriver.cs
@@ -1,22 +1,21 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FanaBridge.Protocol;
 using GameReaderCommon;
 
 namespace FanaBridge.Adapters
 {
     /// <summary>
-    /// Drives a Fanatec ITM telemetry display, firmware-driven: it enables ITM once and
-    /// sends rate-limited value updates for exactly the parameters the firmware has
-    /// subscribed. No keepalive is needed — the display has no idle timeout (hardware-
-    /// confirmed); the value stream, or simply the last frame it holds, keeps it lit.
+    /// Drives a Fanatec ITM telemetry display: maps SimHub telemetry to the parameters the
+    /// firmware has subscribed, paces the sends, and maintains the ParamDefs unit/total
+    /// suffixes. The <b>lifecycle</b> — bring-up, page switches, push confirmation, game-exit
+    /// gating, recovery — lives in <see cref="ItmLifecycleController"/>; this driver only
+    /// sends while the controller says the display is synced (<see cref="ItmLifecycleController.ValuesAllowed"/>)
+    /// and repaints whenever a push is adopted (<see cref="ItmLifecycleController.SyncGeneration"/>):
+    /// after any resync the display shows stale firmware-cached values until the first fresh send.
     ///
-    /// This driver follows the wheel's subscription reports: when the ITM page changes, the
-    /// firmware pushes subscription reports on col03-IN telling the host which parameter
-    /// sits at which handle for the new page (see
-    /// <see cref="ItmTelemetry.ParseSubscriptionReport"/>); the host echoes values back at
-    /// those handles.
+    /// First values after a sync are double-tapped (~20 ms apart, matching official-software
+    /// post-switch behavior), and ParamDefs go out <i>after</i> the value double-tap.
     ///
     /// Sits above <see cref="ItmEncoder"/> (framing) and <see cref="ItmTelemetry"/>
     /// (value encoding + subscription parsing). The clock is injectable so the timing is
@@ -28,10 +27,18 @@ namespace FanaBridge.Adapters
         private readonly byte _deviceId;   // which display this driver targets (PageSet + per-entry id)
         private readonly Func<long> _now;
         private readonly Action<string> _log;
+        private readonly ItmLifecycleController _lifecycle;
 
         // ── Tunables (ms) ────────────────────────────────────────────────
         /// <summary>Minimum spacing between value-update sends (caps the rate).</summary>
         public int ValueIntervalMs { get; set; } = 40;
+
+        /// <summary>
+        /// Gap before the tight second value send after a sync (double-tap). The first values
+        /// after a page change are double-tapped ~20 ms apart, matching the official software's
+        /// post-switch behavior — free insurance against a single lost first paint.
+        /// </summary>
+        public int ValueDoubleTapMs { get; set; } = 20;
 
         /// <summary>
         /// Maximum age of the on-display values before they are re-sent even when unchanged.
@@ -58,37 +65,41 @@ namespace FanaBridge.Adapters
         public bool ShowPositionTotal { get; set; } = true;
 
         /// <summary>
-        /// The ITM page (wire page number) forced on bring-up; the wheel's display button
-        /// navigates from there. Read once per bring-up. Defaults to page 1 (Lap Info).
+        /// The ITM page (wire page number) targeted by bring-up; the wheel's display button
+        /// navigates from there. Changing it live requests a confirmed page switch.
         /// </summary>
         public byte DefaultPage { get; set; } = 1;
 
+        private bool _enabled = true;
+
         /// <summary>
-        /// Whether the ITM display is enabled. Set false to turn ITM off (the driver sends
-        /// the firmware "ITM off" command and goes dormant); set true to re-enable (the
-        /// next <see cref="Update"/> re-runs bring-up). Read live each frame.
+        /// Whether the ITM display is enabled. Set false to turn ITM off (the display is gated
+        /// off — the same persistent state the vendor software's ITM switch sets — and the
+        /// driver goes dormant); set true to re-enable. Read live each frame.
         /// </summary>
-        public bool Enabled { get; set; } = true;
+        public bool Enabled
+        {
+            get { return _enabled; }
+            set
+            {
+                _enabled = value;
+                _lifecycle.SetUserEnabled(value);
+            }
+        }
 
         // ── State ────────────────────────────────────────────────────────
-        private enum Phase { Idle, Enabling, Running, Disabled }
-        private Phase _phase = Phase.Idle;
-
         private long _lastValuesMs;
-        private byte _lastPageApplied;   // last page we forced via SetPage — edge-detects a settings change
+        private long _lastSendOkMs;    // last accepted value send — drives the periodic re-assert
+        private byte _lastRequestedPage;   // edge-detects a default-page settings change
+        private bool _pageEdgeArmed;
 
-        // Bring-up progress: each command is latched only once the transport accepts it,
-        // so a declined write is retried next tick instead of leaving the driver in
-        // Running against a display that never got its enable/page-set.
-        private bool _bringUpModeSent, _bringUpEnableSent, _bringUpPageSent;
+        // Post-sync repaint: first values immediately, a tight second tap, then ParamDefs.
+        private enum Paint { None, First, SecondTap }
+        private Paint _paint = Paint.None;
+        private long _paintTap2At;
+        private int _lastSyncGen;
 
-        // Firmware-driven subscription map: host handle -> subscription (parameter ID plus
-        // the firmware's declared slot dataType, which steers per-display value encoding —
-        // GEAR is numeric on a PBME but ASCII text on a Formula V3). Kept sorted by handle
-        // so the dirty-tracking comparison sees a stable order.
-        private readonly SortedDictionary<byte, ItmSubscription> _subs = new SortedDictionary<byte, ItmSubscription>();
         private ItmValue[] _lastValues;
-        private long _lastSendOkMs;   // last accepted value send — drives the periodic re-assert
         private bool _loggedFirstValues;
         private string _lastSlotDefsSig = "";   // last ParamDefs suffix set, to skip redundant writes
         private long _defTap2DueMs;               // when to fire the tight second def tap (0 = none)
@@ -105,6 +116,7 @@ namespace FanaBridge.Adapters
             _now = nowMs ?? DefaultClock();
             _log = log ?? (_ => { });
             _deviceId = deviceId;
+            _lifecycle = new ItmLifecycleController(encoder, deviceId, _now, _log);
         }
 
         private static Func<long> DefaultClock()
@@ -113,82 +125,153 @@ namespace FanaBridge.Adapters
             return () => sw.ElapsedMilliseconds;
         }
 
-        /// <summary>True once ITM is enabled and values are flowing.</summary>
-        public bool IsRunning => _phase == Phase.Running;
+        /// <summary>The lifecycle state machine — exposed for status surfacing and tuning.</summary>
+        public ItmLifecycleController Lifecycle => _lifecycle;
+
+        /// <summary>True while the display is push-confirmed in sync (values may flow).</summary>
+        public bool IsRunning => _lifecycle.State == ItmLifecycleState.Synced;
 
         /// <summary>The number of parameters the firmware currently has subscribed.</summary>
-        public int SubscriptionCount => _subs.Count;
+        public int SubscriptionCount => _lifecycle.SubscriptionCount;
 
         /// <summary>
-        /// Begins ITM bring-up (a single Enable) on the next <see cref="Update"/>.
+        /// Begins the ITM lifecycle (cold bring-up) on the next <see cref="Update"/>.
         /// Idempotent — a no-op unless idle, so it is safe to call every frame.
         /// </summary>
         public void Start()
         {
-            if (_phase == Phase.Idle)
-                _phase = Phase.Enabling;
+            _lifecycle.DefaultPage = DefaultPage;
+            _lifecycle.Start();
         }
 
         /// <summary>
-        /// Stops driving and returns to idle, dropping all subscriptions. A later
-        /// <see cref="Start"/> re-enables.
+        /// Stops driving and returns to idle (connection lost), dropping all subscriptions.
+        /// A later <see cref="Start"/> re-runs the cold bring-up.
         /// </summary>
         public void Stop()
         {
-            _phase = Phase.Idle;
-            ResetSession();
+            _lifecycle.Stop();
+            ResetSendState();
         }
 
-        /// <summary>Drops all per-session state (subscriptions, dirty tracking, one-shot logs).</summary>
-        private void ResetSession()
+        /// <summary>
+        /// A wheel/hub/module change from the identity layer. A hot-swap resets the display
+        /// cold without any trace on the ITM channel itself — the lifecycle restarts from
+        /// bring-up and nothing is sent until the fresh push confirms.
+        /// </summary>
+        public void OnWheelChanged()
         {
-            _subs.Clear();
+            _lifecycle.OnWheelChanged();
+        }
+
+        /// <summary>Drops the driver-side send latches (dirty tracking, def signatures, taps).</summary>
+        private void ResetSendState()
+        {
             _lastValues = null;
             _loggedFirstValues = false;
             _lastSlotDefsSig = "";
             _defTap2DueMs = 0;
             _defTap2Defs = null;
-            _wasTelemetryLive = false;
-            _pendingExitReset = false;
-            _bringUpModeSent = false;
-            _bringUpEnableSent = false;
-            _bringUpPageSent = false;
+            _paint = Paint.None;
+            _pageEdgeArmed = false;
         }
 
-        // Game-exit tracking: values must never be painted from SimHub's stale
-        // post-exit telemetry, and the fields already on the display would hold
-        // their last values forever (no idle timeout). On the live→not-live
-        // transition a DisplayReset reverts every field to its placeholder
-        // (e.g. "--- / -", "--:--.-") — session, page, and subscriptions stay
-        // put. The reset is retried across ticks until the transport accepts
-        // it. (The Legacy ITM page is unaffected by the reset; its content is
-        // cleared separately by the col01 display driver's exit blank.)
-        private bool _wasTelemetryLive;
-        private bool _pendingExitReset;
-
         /// <summary>
-        /// Applies a firmware ITM subscription report (col03-IN, pushed on a wheel-button
-        /// page change): subscribes/updates each handle's parameter, removes unsubscribed
-        /// handles. Safe to call before <see cref="Start"/> — the map is simply pre-seeded.
+        /// Applies a firmware ITM subscription report (col03-IN push): parsed and handed to the
+        /// lifecycle, which adopts the entries in every state and judges the accumulated set.
         /// </summary>
         public void OnSubscriptionReport(byte[] report)
         {
             var subs = ItmTelemetry.ParseSubscriptionReport(report, report?.Length ?? 0, _deviceId);
             if (subs.Count == 0)
                 return;
+            _lifecycle.OnPush(subs);
+        }
 
-            foreach (var s in subs)
+        /// <summary>Drives the lifecycle and the value/defs pipeline one tick. Call once per frame while connected.</summary>
+        public void Update(GameData data)
+        {
+            long now = _now();
+            bool telemetryLive = data != null && data.GameRunning && data.NewData != null;
+
+            // Settings flow into the lifecycle: the default page (cold-entry/resume target) and
+            // the user's on/off switch. A settings change of the default page is edge-detected
+            // and requested live, so the wheel button isn't fought between changes.
+            _lifecycle.DefaultPage = DefaultPage;
+            _lifecycle.SetUserEnabled(Enabled);
+            if (!_pageEdgeArmed)
             {
-                if (s.IsUnsubscribe)
-                    _subs.Remove(s.Handle);
-                else
-                    _subs[s.Handle] = s;
+                _pageEdgeArmed = true;
+                _lastRequestedPage = DefaultPage;
+            }
+            if (DefaultPage != _lastRequestedPage)
+            {
+                _lastRequestedPage = DefaultPage;
+                _lifecycle.RequestPage(DefaultPage);
             }
 
-            _lastValues = null;   // subscription set changed — force a fresh value send
-            _log("ITM: subscriptions now — " + Describe());
-            // ParamDefs (suffixes) are refreshed from Update(), where telemetry is
-            // available for the dynamic "/total" suffixes.
+            _lifecycle.Tick(telemetryLive);
+
+            // A new sync generation = a push was adopted (bring-up, page change, resume,
+            // recovery). The firmware may be showing stale cached values and its suffix
+            // decorations may be gone — repaint everything: values immediately, a tight
+            // second tap, then ParamDefs.
+            if (_lifecycle.SyncGeneration != _lastSyncGen)
+            {
+                _lastSyncGen = _lifecycle.SyncGeneration;
+                _lastValues = null;
+                _lastSlotDefsSig = "";
+                _defTap2DueMs = 0;
+                _defTap2Defs = null;
+                _paint = Paint.First;
+            }
+
+            // Values (and defs) flow only while push-confirmed in sync — mid-switch traffic
+            // is the identified cause of dropped switches, and handles can re-bind.
+            if (!_lifecycle.ValuesAllowed)
+                return;
+
+            // ...and only while a game is feeding telemetry: SimHub keeps the last telemetry
+            // values around after a game exits, and painting from stale data would resurrect
+            // exactly the frozen frame the exit gate-off just hid.
+            if (!telemetryLive)
+                return;
+
+            switch (_paint)
+            {
+                case Paint.First:
+                    // Immediate post-sync paint, bypassing the interval and the change gate.
+                    switch (TrySendValues(data, now, force: true))
+                    {
+                        case SendOutcome.Sent:
+                            _paint = Paint.SecondTap;
+                            _paintTap2At = now + ValueDoubleTapMs;
+                            break;
+                        case SendOutcome.NothingToSend:
+                            _paint = Paint.None;   // nothing encodable — no tap needed
+                            break;
+                            // Declined: retry next tick.
+                    }
+                    break;
+
+                case Paint.SecondTap:
+                    if (now >= _paintTap2At && TrySendValues(data, now, force: true) != SendOutcome.Declined)
+                        _paint = Paint.None;
+                    break;
+
+                default:
+                    if (now - _lastValuesMs >= ValueIntervalMs)
+                    {
+                        TrySendValues(data, now, force: false);
+                        _lastValuesMs = now;
+                    }
+                    break;
+            }
+
+            // ParamDefs go out after the post-sync value double-tap completes (values-then-defs,
+            // matching the official software's post-switch ordering), then on every suffix change.
+            if (_paint == Paint.None)
+                UpdateSlotDefs(data, now);
         }
 
         // Sends ParamDefs declaring each subscribed param's display suffix — a static
@@ -211,7 +294,7 @@ namespace FanaBridge.Adapters
             List<ItmParamDef> defs = null;
             var sig = new System.Text.StringBuilder();
 
-            foreach (var kv in _subs)
+            foreach (var kv in _lifecycle.Subscriptions)
             {
                 ushort paramId = kv.Value.ParamId;
                 string suffix;
@@ -270,165 +353,14 @@ namespace FanaBridge.Adapters
             return false;
         }
 
-        /// <summary>Drives the state machine one tick. Call once per frame while connected.</summary>
-        public void Update(GameData data)
+        private enum SendOutcome { Sent, NothingToSend, Declined }
+
+        // Encodes the subscribed values and sends them. force bypasses the change gate (used
+        // by the post-sync paint and its double-tap); the periodic re-assert bypasses it too.
+        private SendOutcome TrySendValues(GameData data, long now, bool force)
         {
-            // User turned ITM off: send the firmware "ITM off" command, then stay
-            // dormant (no values) so the display stays off, as the Fanatec software does.
-            // Only latch Disabled once the off command was actually accepted — a
-            // declined write is retried next tick. Re-enabling drops back into
-            // bring-up below.
-            if (!Enabled)
-            {
-                if (_phase != Phase.Disabled)
-                {
-                    if (!_encoder.SetItmMode(false))   // FF 05 02 00
-                        return;
-                    ResetSession();
-                    _phase = Phase.Disabled;
-                    _log("ITM: disabled by user — sent ITM off");
-                }
-                return;
-            }
-
-            // Enabled again after being disabled — re-arm bring-up.
-            if (_phase == Phase.Disabled)
-                _phase = Phase.Enabling;
-
-            if (_phase == Phase.Idle)
-                return;
-
-            long now = _now();
-            bool telemetryLive = data != null && data.GameRunning && data.NewData != null;
-
-            if (_phase == Phase.Enabling)
-            {
-                // Bring-up: gate ITM on (FF 05 02 01), start the session (FF 02 02 00), then force
-                // the configured default page (FF 05 04 <dev> <page>) so the display matches our
-                // seed and shows correct values right away. The wheel button navigates from there;
-                // detecting the wheel's current page on cold start instead is deferred — see #43.
-                // Each command advances only once the transport accepts it — bring-up fires right
-                // as the rim settles, exactly when a transient write failure is most likely, and a
-                // dropped Enable/PageSet would otherwise leave the driver streaming values at a
-                // display that never started a session.
-                if (!_bringUpModeSent)
-                {
-                    if (!_encoder.SetItmMode(true))     // FF 05 02 01 — firmware ITM gate on
-                        return;
-                    _bringUpModeSent = true;
-                }
-                if (!_bringUpEnableSent)
-                {
-                    if (!_encoder.EnableItm())          // FF 02 02 00 — start the display session
-                        return;
-                    _bringUpEnableSent = true;
-                }
-                if (!_bringUpPageSent)
-                {
-                    if (!_encoder.SetPage(_deviceId, DefaultPage))  // force the configured default page
-                        return;
-                    _bringUpPageSent = true;
-                }
-                _lastPageApplied = DefaultPage;
-                SeedInitialSubscriptions();             // the default page's params
-                _log("ITM: enabled — seeded " + _subs.Count + " params, following firmware subscriptions");
-                _phase = Phase.Running;
-                // Record liveness on this tick too — a game exiting right after a
-                // single live frame must still trigger the exit reset below.
-                _wasTelemetryLive = telemetryLive;
-                return;
-            }
-
-            // Running
-
-            // Game just exited (or an earlier exit reset is still pending): DisplayReset
-            // reverts every field to its placeholder rendering so the last telemetry
-            // frame doesn't sit on the display forever. The session, page, and firmware
-            // subscriptions stay put — values simply flow again when the next game
-            // starts. An ITM off→on cycle does NOT clear fields (hardware-verified:
-            // the firmware retains their values), so this reset is the one command
-            // that does. Retried until the transport accepts it.
-            if (_pendingExitReset || (_wasTelemetryLive && !telemetryLive))
-            {
-                _pendingExitReset = true;
-                if (!_encoder.ResetDisplay())      // declined — retry next tick
-                    return;
-                _pendingExitReset = false;
-                _wasTelemetryLive = false;
-                _lastValues = null;                // repaint everything when telemetry returns
-                _lastSlotDefsSig = "";             // the reset cleared the firmware suffix — force a
-                                                   // re-decorate on resume (same page/suffix set won't
-                                                   // otherwise trip the sig change, so it'd stay blank)
-                _log("ITM: game exited — display reset (fields back to placeholders)");
-                return;
-            }
-            _wasTelemetryLive = telemetryLive;
-
-            // If the user changed the default page in settings, switch the display to it live
-            // (edge-triggered, so we don't fight the wheel button between changes). Runs in
-            // idle too — this is the settings panel's live preview.
-            if (DefaultPage != _lastPageApplied)
-            {
-                // Latch only on an accepted write — a declined PageSet retries next tick
-                // (the edge condition stays true until it lands).
-                if (_encoder.SetPage(_deviceId, DefaultPage))
-                {
-                    _lastPageApplied = DefaultPage;
-                    // Deliberately DON'T reseed here — keep the current subscriptions until the firmware
-                    // pushes the new page's set. Unlike bring-up (which has no prior state), a live switch
-                    // has valid subs to lose: if the PageSet flakes, or targets the page already shown (no
-                    // push comes back), a speculative reseed would strand the display on wrong-page handles
-                    // with nothing to correct it. The existing subs stay valid for whatever is displayed.
-                    _log("ITM: default page changed — forcing page " + DefaultPage);
-                }
-            }
-
-            // Values only flow while a game is feeding telemetry: SimHub keeps the last
-            // telemetry values around after a game exits, so painting from stale data
-            // would resurrect exactly the frozen frame the exit reset just cleared.
-            if (!telemetryLive)
-                return;
-
-            UpdateSlotDefs(data, now);   // refresh unit/total suffixes; tight double-tap so they stick
-            if (now - _lastValuesMs >= ValueIntervalMs)
-            {
-                SendSubscribedValues(data, now);
-                _lastValuesMs = now;
-            }
-        }
-
-        // Bring-up forces the default page via SetPage(device, DefaultPage), which makes the
-        // firmware push that page's subscription — but that push takes ~tens of ms to arrive, and
-        // a bare Enable announces nothing. Pre-seed the default page's handle→param map so values
-        // flow in that gap; the firmware's push then confirms/replaces it. Seeds only when empty.
-        private void SeedInitialSubscriptions()
-        {
-            if (_subs.Count > 0)
-                return;
-            var ids = SeedParamsForPage(DefaultPage);
-            for (int h = 0; h < ids.Count; h++)
-                // dataType 0 = unknown: values encode with the default (numeric) forms until
-                // the firmware's push supplies each slot's declared type.
-                _subs[(byte)h] = new ItmSubscription((byte)h, ids[h]);
-        }
-
-        // The params the given page carries on this driver's device (empty for an unknown page
-        // or the legacy page). Used only to seed handles 0..N-1 before the firmware's push lands.
-        private IReadOnlyList<ushort> SeedParamsForPage(byte page)
-        {
-            foreach (var p in ItmDeviceCatalog.PagesFor(_deviceId))
-                if (p.Number == page)
-                    return p.Params;
-            return Array.Empty<ushort>();
-        }
-
-        private void SendSubscribedValues(GameData data, long now)
-        {
-            if (_subs.Count == 0)
-                return;
-
             _valueBuf.Clear();
-            foreach (var kv in _subs)
+            foreach (var kv in _lifecycle.Subscriptions)
             {
                 if (ItmTelemetryMapper.TryEncodeParam(kv.Value.ParamId, kv.Key, data, kv.Value.DataType, out var v))
                     _valueBuf.Add(v);
@@ -439,18 +371,21 @@ namespace FanaBridge.Adapters
                          " (handle " + kv.Key + ") — field will show dashes");
             }
 
+            if (_valueBuf.Count == 0)
+                return SendOutcome.NothingToSend;
+
             // Re-assert even unchanged values every RefreshIntervalMs: ValueUpdate is unacked,
             // and change-gated sending alone would leave a lost frame wrong on the display
             // until the value next changes.
             bool refresh = now - _lastSendOkMs >= RefreshIntervalMs;
-            if (_valueBuf.Count == 0 || (!refresh && !HasChanged(_valueBuf)))
-                return;
+            if (!force && !refresh && !HasChanged(_valueBuf))
+                return SendOutcome.NothingToSend;
 
             // Only record the values as last-sent (and log the first update) when the send
             // actually succeeded — a transport failure must not suppress the retry, or the
             // display would stay stale until a value changes.
             if (!_encoder.SendValues(_valueBuf, _deviceId))
-                return;
+                return SendOutcome.Declined;
 
             _lastSendOkMs = now;
             Remember(_valueBuf);
@@ -458,13 +393,10 @@ namespace FanaBridge.Adapters
             if (!_loggedFirstValues)
             {
                 _loggedFirstValues = true;
-                _log("ITM: first value update — " + _valueBuf.Count + " params: " + Describe());
+                _log("ITM: first value update — " + _valueBuf.Count + " params: " + _lifecycle.DescribeMap());
             }
+            return SendOutcome.Sent;
         }
-
-        private string Describe()
-            => string.Join(" ", _subs.Select(kv => "h" + kv.Key + "=p" + kv.Value.ParamId
-                + (kv.Value.DataType != 0 ? ":t" + kv.Value.DataType.ToString("X2") : "")));
 
         private bool HasChanged(IReadOnlyList<ItmValue> values)
         {

--- a/src/FanaBridge/Diagnostics/DiagnosticsReport.cs
+++ b/src/FanaBridge/Diagnostics/DiagnosticsReport.cs
@@ -29,7 +29,7 @@ namespace FanaBridge.Protocol
     {
         public static string Build(
             FanatecWheelbase wheelbase, bool connected, string statusDetail, string buildInfo,
-            string controlMapperSection = null)
+            string controlMapperSection = null, string itmSection = null)
         {
             var sb = new StringBuilder();
 
@@ -67,6 +67,11 @@ namespace FanaBridge.Protocol
             {
                 sb.AppendLine();
                 sb.AppendLine(controlMapperSection.TrimEnd());
+            }
+            if (!string.IsNullOrEmpty(itmSection))
+            {
+                sb.AppendLine();
+                sb.AppendLine(itmSection.TrimEnd());
             }
 
             sb.AppendLine("```");

--- a/src/FanaBridge/FanatecPlugin.cs
+++ b/src/FanaBridge/FanatecPlugin.cs
@@ -212,6 +212,47 @@ namespace FanaBridge
             return null;
         }
 
+        // Detects the vendor's app/service running alongside FanaBridge — the same
+        // display, no arbitration, so it's a warning the user needs to see instead of
+        // chasing phantom ITM flicker. TTL-cached; edges are logged once.
+        private readonly Diagnostics.FanatecSoftwareMonitor _fanatecSoftware =
+            new Diagnostics.FanatecSoftwareMonitor(
+                log: msg => SimHub.Logging.Current.Warn("FanaBridge: " + msg));
+
+        /// <summary>
+        /// The ITM display's lifecycle status line (e.g. "Synced — page 1, 6 params",
+        /// "Unavailable — retry in 30 s") from the connected instance driving an ITM
+        /// display, or null when none is. Shown in the Device Status panel.
+        /// </summary>
+        public string ItmStatus
+        {
+            get
+            {
+                if (!IsDeviceConnected) return null;
+                lock (_deviceInstancesLock)
+                {
+                    foreach (var inst in _deviceInstances)
+                    {
+                        try
+                        {
+                            var s = inst.ItmStatusDescription;
+                            if (s != null) return s;
+                        }
+                        catch { }
+                    }
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// A warning line when the Fanatec app/service is running alongside FanaBridge
+        /// while an ITM display is being driven (both write the same display; the
+        /// protocol has no arbitration and no way to detect the other writer on the
+        /// wire). Null when there is nothing to warn about.
+        /// </summary>
+        public string ItmCoDriverWarning => ItmStatus == null ? null : _fanatecSoftware.Warning;
+
         /// <summary>
         /// Whether Control Mapper's "Recognize Individual Wheels" is on (the setting the
         /// integration depends on), or null if it can't be determined. Read-only; used by
@@ -562,8 +603,19 @@ namespace FanaBridge
                     + "  diagnostic error: " + ex.Message;
             }
 
+            // ITM display lifecycle state + co-driver detection — the flaky-display
+            // context a report is usually filed about.
+            string itmSection = null;
+            var itmStatus = ItmStatus;
+            if (itmStatus != null)
+            {
+                itmSection = "ITM display" + Environment.NewLine
+                    + "  State:     " + itmStatus + Environment.NewLine
+                    + "  Co-driver: " + (ItmCoDriverWarning ?? "none detected (Fanatec app/service not running)");
+            }
+
             var report = DiagnosticsReport.Build(
-                _wheelbase, IsDeviceConnected, StatusDetail, BuildIdentity.Full, controlMapperSection);
+                _wheelbase, IsDeviceConnected, StatusDetail, BuildIdentity.Full, controlMapperSection, itmSection);
 
             return report;
         }

--- a/src/FanaBridge/FanatecPlugin.cs
+++ b/src/FanaBridge/FanatecPlugin.cs
@@ -222,7 +222,9 @@ namespace FanaBridge
         /// <summary>
         /// The ITM display's lifecycle status line (e.g. "Synced — page 1, 6 params",
         /// "Unavailable — retry in 30 s") from the connected instance driving an ITM
-        /// display, or null when none is. Shown in the Device Status panel.
+        /// display, or null when none is. Shown in the Device Status panel. The value is a
+        /// snapshot string the owning DataUpdate thread published, so this reads it (a
+        /// volatile field) without touching live state-machine fields off-thread.
         /// </summary>
         public string ItmStatus
         {
@@ -233,12 +235,8 @@ namespace FanaBridge
                 {
                     foreach (var inst in _deviceInstances)
                     {
-                        try
-                        {
-                            var s = inst.ItmStatusDescription;
-                            if (s != null) return s;
-                        }
-                        catch { }
+                        var s = inst.ItmStatusDescription;   // a volatile string read — cannot throw
+                        if (s != null) return s;
                     }
                 }
                 return null;
@@ -247,11 +245,22 @@ namespace FanaBridge
 
         /// <summary>
         /// A warning line when the Fanatec app/service is running alongside FanaBridge
-        /// while an ITM display is being driven (both write the same display; the
-        /// protocol has no arbitration and no way to detect the other writer on the
-        /// wire). Null when there is nothing to warn about.
+        /// (both write the same display; the protocol has no arbitration and no way to
+        /// detect the other writer on the wire). Null when there is nothing to warn
+        /// about. Callers gate on <see cref="ItmStatus"/> themselves where relevance
+        /// requires an ITM display to be in play.
         /// </summary>
-        public string ItmCoDriverWarning => ItmStatus == null ? null : _fanatecSoftware.Warning;
+        public string ItmCoDriverWarning => _fanatecSoftware.Warning;
+
+        /// <summary>
+        /// Runs the TTL-cached co-driver check (the monitor logs detection edges itself).
+        /// Called from the ITM path while the display is in a failure state, so the
+        /// detection line lands in the log next to the failure it may explain.
+        /// </summary>
+        internal void ProbeItmCoDriver()
+        {
+            var _ = _fanatecSoftware.DetectedProcess;
+        }
 
         /// <summary>
         /// Whether Control Mapper's "Recognize Individual Wheels" is on (the setting the

--- a/src/FanaBridge/UI/ScreenSettingsPanel.xaml
+++ b/src/FanaBridge/UI/ScreenSettingsPanel.xaml
@@ -10,7 +10,7 @@
                     Background="#1A4488CC" BorderBrush="#4488CC" BorderThickness="1"
                     CornerRadius="4" Padding="10,8" Margin="0,0,0,12">
                 <TextBlock Foreground="#AADDFF" FontSize="12" TextWrapping="Wrap">
-                    &#x2139;  This wheel has an ITM telemetry display — FanaBridge shows live SimHub telemetry on its pages (speed, gear, lap times, tire temps, and more). Pick the page it starts on below, and use the wheel's display button to switch pages while driving. Its legacy page shows the simple gear/speed display picked under Legacy Display Mode; choose "None" to leave that off.
+                    &#x2139;  This wheel has an ITM telemetry display — FanaBridge shows live SimHub telemetry on its pages (speed, gear, lap times, tire temps, and more). Pick the page each game starts on below, and use the wheel's display button to switch pages while driving. Its legacy page shows the simple gear/speed display picked under Legacy Display Mode; choose "None" to leave that off.
                 </TextBlock>
             </Border>
 
@@ -22,17 +22,17 @@
 
                     <!-- Default page (choices populated per display device) -->
                     <StackPanel x:Name="panelDefaultPage" Margin="0,0,0,12">
-                        <TextBlock Text="Default Page" FontWeight="SemiBold" Margin="0,0,0,4" />
+                        <TextBlock Text="Starting Page" FontWeight="SemiBold" Margin="0,0,0,4" />
                         <ComboBox x:Name="cmbDefaultPage"
                                   SelectionChanged="CmbDefaultPage_SelectionChanged"
                                   Width="220" HorizontalAlignment="Left" />
                         <TextBlock Foreground="#999999" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0">
-                            The page shown when the display starts. The wheel's display button navigates from there.
+                            The display returns to this page each time a game starts. Use the wheel's display button to switch pages while driving; the next game starts back here. Pick the legacy gear/speed page here if you'd rather start on that.
                         </TextBlock>
                     </StackPanel>
 
                     <!-- "/total" suffixes -->
-                    <StackPanel x:Name="panelTotals">
+                    <StackPanel x:Name="panelTotals" Margin="0,0,0,12">
                         <TextBlock Text="Totals" FontWeight="SemiBold" Margin="0,0,0,4" />
                         <TextBlock Foreground="#999999" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,6">
                             Show "/total" on the lap and position fields (e.g. "Lap 5 / 34" rather than "Lap 5"). Turn off for games that don't report usable totals.
@@ -42,6 +42,7 @@
                         <CheckBox x:Name="chkShowPositionTotal" Content="Show position total (P3 / 20)"
                                   Checked="ItmOption_Changed" Unchecked="ItmOption_Changed" Margin="0,4,0,2" />
                     </StackPanel>
+
                 </StackPanel>
             </styles:SHSubSection>
 

--- a/src/FanaBridge/UI/ScreenSettingsPanel.xaml.cs
+++ b/src/FanaBridge/UI/ScreenSettingsPanel.xaml.cs
@@ -46,6 +46,7 @@ namespace FanaBridge.UI
             PopulateDefaultPages(itmDeviceId);
             SelectByPageNumber(cmbDefaultPage, _settings.ItmDefaultPage);
 
+
             borderItmInfo.Visibility = isItm ? Visibility.Visible : Visibility.Collapsed;
             sectionItmOptions.Visibility = isItm ? Visibility.Visible : Visibility.Collapsed;
             // The mode selector drives the simple 7-seg gear/speed — the only display on

--- a/src/FanaBridge/UI/SettingsControl.xaml
+++ b/src/FanaBridge/UI/SettingsControl.xaml
@@ -52,6 +52,19 @@
                         <TextBlock Text="Capabilities" Foreground="#888888" FontSize="11" />
                     </StackPanel>
 
+                    <!-- ITM display lifecycle state (only while an ITM display is driven).
+                         Refreshed on a light timer — the state machine moves without
+                         StateChanged firing (page switches, recovery, game exits). -->
+                    <StackPanel x:Name="panelItmStatus" Margin="0,8,0,2" Visibility="Collapsed">
+                        <TextBlock x:Name="txtItmStatus" Text="—" TextWrapping="Wrap" />
+                        <TextBlock Text="ITM Display" Foreground="#888888" FontSize="11" />
+                    </StackPanel>
+
+                    <!-- Co-driver warning: the vendor app/service writes the same display
+                         with no arbitration; there is no wire-level way to detect it. -->
+                    <TextBlock x:Name="txtItmCoDriver" Foreground="#E0A800" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,4,0,4" Visibility="Collapsed" />
+
                     <!-- Shown when the attached wheel resolves to a registered SimHub
                          device the user hasn't added yet — LED/display output never
                          starts without the device. Sits below the status readout

--- a/src/FanaBridge/UI/SettingsControl.xaml.cs
+++ b/src/FanaBridge/UI/SettingsControl.xaml.cs
@@ -281,6 +281,18 @@ namespace FanaBridge.UI
             if (_bootCaps == null)
                 _bootCaps = Plugin.CurrentCapabilities;
 
+            // The ITM lifecycle moves without StateChanged firing (page switches,
+            // recovery rungs, game exits) — poll its status row while visible.
+            if (_itmStatusTimer == null)
+            {
+                _itmStatusTimer = new System.Windows.Threading.DispatcherTimer
+                {
+                    Interval = TimeSpan.FromSeconds(2)
+                };
+                _itmStatusTimer.Tick += (s, a) => UpdateItmStatus();
+            }
+            _itmStatusTimer.Start();
+
             UpdateStatus();
         }
 
@@ -289,7 +301,31 @@ namespace FanaBridge.UI
             StopScroll();
             StopPromptRetry();
             UnwatchSimHubDevices();
+            _itmStatusTimer?.Stop();
             Plugin.StateChanged -= OnPluginStateChanged;
+        }
+
+        private System.Windows.Threading.DispatcherTimer _itmStatusTimer;
+
+        // ITM display row + co-driver warning. Self-contained (hides itself when no ITM
+        // display is being driven), safe on every connection state.
+        private void UpdateItmStatus()
+        {
+            if (Plugin == null || panelItmStatus == null) return;
+
+            string itm = null;
+            string warn = null;
+            try
+            {
+                itm = Plugin.ItmStatus;
+                warn = itm != null ? Plugin.ItmCoDriverWarning : null;
+            }
+            catch { }
+
+            panelItmStatus.Visibility = itm == null ? Visibility.Collapsed : Visibility.Visible;
+            txtItmStatus.Text = itm ?? "—";
+            txtItmCoDriver.Text = "⚠  " + warn;
+            txtItmCoDriver.Visibility = warn == null ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private void OnPluginStateChanged()
@@ -308,6 +344,7 @@ namespace FanaBridge.UI
             // Also self-contained (hides itself while disconnected), so it runs
             // ahead of the early returns below and stays correct on every path.
             UpdateAddDevicePrompt();
+            UpdateItmStatus();
 
             if (!Plugin.IsDeviceConnected)
             {

--- a/src/FanaBridge/UI/SettingsControl.xaml.cs
+++ b/src/FanaBridge/UI/SettingsControl.xaml.cs
@@ -324,7 +324,9 @@ namespace FanaBridge.UI
 
             panelItmStatus.Visibility = itm == null ? Visibility.Collapsed : Visibility.Visible;
             txtItmStatus.Text = itm ?? "—";
-            txtItmCoDriver.Text = "⚠  " + warn;
+            // Only carry the warning glyph when there is a warning — a collapsed element still
+            // exposes its Text to automation/accessibility trees, so don't leave a stray "⚠".
+            txtItmCoDriver.Text = warn == null ? "" : "⚠  " + warn;
             txtItmCoDriver.Visibility = warn == null ? Visibility.Collapsed : Visibility.Visible;
         }
 

--- a/tests/FanaBridge.Tests/FanatecSoftwareMonitorTests.cs
+++ b/tests/FanaBridge.Tests/FanatecSoftwareMonitorTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using FanaBridge.Diagnostics;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    public class FanatecSoftwareMonitorTests
+    {
+        private sealed class Clock { public long T; public long Now() => T; }
+
+        [Fact]
+        public void NoVendorProcesses_NoWarning()
+        {
+            var m = new FanatecSoftwareMonitor(_ => false, () => 0);
+            Assert.Null(m.DetectedProcess);
+            Assert.Null(m.Warning);
+        }
+
+        [Fact]
+        public void VendorService_Detected_WithWarning()
+        {
+            var m = new FanatecSoftwareMonitor(n => n == "FanatecService", () => 0);
+            Assert.Equal("FanatecService", m.DetectedProcess);
+            Assert.Contains("FanatecService", m.Warning);
+        }
+
+        [Fact]
+        public void VendorApp_Detected()
+        {
+            var m = new FanatecSoftwareMonitor(n => n == "Fanatec", () => 0);
+            Assert.Equal("Fanatec", m.DetectedProcess);
+        }
+
+        [Fact]
+        public void PnpDriverService_IsNotACoDriver()
+        {
+            // FWPnpService (the driver-package PnP service) auto-starts on every boot and
+            // never emits ITM traffic — it must not trip the warning.
+            var m = new FanatecSoftwareMonitor(n => n == "FWPnpService", () => 0);
+            Assert.Null(m.DetectedProcess);
+        }
+
+        [Fact]
+        public void Checks_AreTtlCached()
+        {
+            var clock = new Clock();
+            int probes = 0;
+            var m = new FanatecSoftwareMonitor(_ => { probes++; return false; }, clock.Now);
+
+            _ = m.DetectedProcess;
+            int first = probes;
+            _ = m.DetectedProcess;                 // inside the TTL — no new probe
+            Assert.Equal(first, probes);
+
+            clock.T += m.CacheTtlMs;
+            _ = m.DetectedProcess;                 // TTL expired — re-probes
+            Assert.True(probes > first);
+        }
+
+        [Fact]
+        public void DetectionEdges_LoggedOnceEachWay()
+        {
+            var clock = new Clock();
+            bool running = false;
+            var logs = new List<string>();
+            var m = new FanatecSoftwareMonitor(n => running && n == "FanatecService", clock.Now, logs.Add);
+
+            _ = m.DetectedProcess;                 // not running — nothing to log
+            Assert.Empty(logs);
+
+            running = true;
+            clock.T += m.CacheTtlMs;
+            _ = m.DetectedProcess;                 // appeared → logged
+            clock.T += m.CacheTtlMs;
+            _ = m.DetectedProcess;                 // still running → no repeat
+            Assert.Single(logs, l => l.Contains("detected running"));
+
+            running = false;
+            clock.T += m.CacheTtlMs;
+            _ = m.DetectedProcess;                 // disappeared → logged once
+            Assert.Single(logs, l => l.Contains("no longer running"));
+        }
+    }
+}

--- a/tests/FanaBridge.Tests/FanatecSoftwareMonitorTests.cs
+++ b/tests/FanaBridge.Tests/FanatecSoftwareMonitorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FanaBridge.Diagnostics;
@@ -9,10 +10,15 @@ namespace FanaBridge.Tests
     {
         private sealed class Clock { public long T; public long Now() => T; }
 
+        // A probe simulating the given set of running process names: returns the first
+        // candidate name that is "running", like the real single-snapshot probe.
+        private static Func<string[], string> Running(params string[] running)
+            => names => names.FirstOrDefault(n => running.Contains(n, StringComparer.OrdinalIgnoreCase));
+
         [Fact]
         public void NoVendorProcesses_NoWarning()
         {
-            var m = new FanatecSoftwareMonitor(_ => false, () => 0);
+            var m = new FanatecSoftwareMonitor(Running(), () => 0);
             Assert.Null(m.DetectedProcess);
             Assert.Null(m.Warning);
         }
@@ -20,7 +26,7 @@ namespace FanaBridge.Tests
         [Fact]
         public void VendorService_Detected_WithWarning()
         {
-            var m = new FanatecSoftwareMonitor(n => n == "FanatecService", () => 0);
+            var m = new FanatecSoftwareMonitor(Running("FanatecService"), () => 0);
             Assert.Equal("FanatecService", m.DetectedProcess);
             Assert.Contains("FanatecService", m.Warning);
         }
@@ -28,7 +34,7 @@ namespace FanaBridge.Tests
         [Fact]
         public void VendorApp_Detected()
         {
-            var m = new FanatecSoftwareMonitor(n => n == "Fanatec", () => 0);
+            var m = new FanatecSoftwareMonitor(Running("Fanatec"), () => 0);
             Assert.Equal("Fanatec", m.DetectedProcess);
         }
 
@@ -37,7 +43,7 @@ namespace FanaBridge.Tests
         {
             // FWPnpService (the driver-package PnP service) auto-starts on every boot and
             // never emits ITM traffic — it must not trip the warning.
-            var m = new FanatecSoftwareMonitor(n => n == "FWPnpService", () => 0);
+            var m = new FanatecSoftwareMonitor(Running("FWPnpService"), () => 0);
             Assert.Null(m.DetectedProcess);
         }
 
@@ -46,7 +52,7 @@ namespace FanaBridge.Tests
         {
             var clock = new Clock();
             int probes = 0;
-            var m = new FanatecSoftwareMonitor(_ => { probes++; return false; }, clock.Now);
+            var m = new FanatecSoftwareMonitor(_ => { probes++; return null; }, clock.Now);
 
             _ = m.DetectedProcess;
             int first = probes;
@@ -64,7 +70,8 @@ namespace FanaBridge.Tests
             var clock = new Clock();
             bool running = false;
             var logs = new List<string>();
-            var m = new FanatecSoftwareMonitor(n => running && n == "FanatecService", clock.Now, logs.Add);
+            var m = new FanatecSoftwareMonitor(
+                names => running ? Running("FanatecService")(names) : null, clock.Now, logs.Add);
 
             _ = m.DetectedProcess;                 // not running — nothing to log
             Assert.Empty(logs);

--- a/tests/FanaBridge.Tests/FanatecWheelbaseTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelbaseTests.cs
@@ -657,6 +657,50 @@ namespace FanaBridge.Tests
             Assert.Equal(8, drained[0][3]);                    // oldest 8 dropped
         }
 
+        [Fact]
+        public void WheelChange_ClearsBufferedItmReports()
+        {
+            // A wheel/hub change invalidates buffered ITM subscription reports: they were
+            // pushed by the PREVIOUS attachment, and feeding them to the restarted ITM
+            // lifecycle could falsely confirm the new wheel's bring-up against the old page.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("GTSWX")));   // an ITM wheel
+
+            t.Itm.Enqueue(new byte[] { 0xFF, 0x05, 0x01, 0x11 });   // old wheel's push
+            clock.T += 10;
+            wb.UpdateIdentity();                                     // buffered
+
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("CSSWFORMV3")));   // rim swap
+
+            var drained = new List<byte[]>();
+            wb.DrainItmReports(drained.Add);
+            Assert.Empty(drained);   // the stale pre-swap report was cleared
+        }
+
+        [Fact]
+        public void RefreshCapabilities_DoesNotCountAsAWheelChange()
+        {
+            // WheelChangeCount drives the ITM lifecycle's cold-restart. A profile-store
+            // re-resolution (override save, profile delete) fires WheelChanged too, but the
+            // physical attachment is unchanged — bumping the count would needlessly cold-
+            // restart the ITM display because the user saved an unrelated setting.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0020, 64, 64, "Base"));
+            Assert.True(wb.AutoConnect());
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("GTSWX")));
+
+            int afterIdentity = wb.WheelChangeCount;
+            Assert.True(afterIdentity > 0);   // the identity commit counted
+
+            wb.RefreshCapabilities();
+            Assert.Equal(afterIdentity, wb.WheelChangeCount);   // the re-resolution did not
+
+            CommitIdentity(wb, t, clock, Ff08(0x0C, WheelWire("CSSWFORMV3")));   // a real swap
+            Assert.Equal(afterIdentity + 1, wb.WheelChangeCount);
+        }
+
         // ── Guard rails ────────────────────────────────────────────────────
 
         [Fact]

--- a/tests/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/tests/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -10,6 +10,12 @@ using Xunit;
 
 namespace FanaBridge.Tests
 {
+    /// <summary>
+    /// Driver-level tests: telemetry→value mapping, ParamDefs suffixes, send pacing, and the
+    /// post-sync repaint (immediate values + tight double-tap, then defs), all riding on the
+    /// lifecycle controller. The lifecycle itself (states, recovery ladder, deadlines) is
+    /// covered exhaustively in <see cref="ItmLifecycleControllerTests"/>.
+    /// </summary>
     public class ItmDisplayDriverTests
     {
         // ── Test doubles ─────────────────────────────────────────────────
@@ -46,6 +52,11 @@ namespace FanaBridge.Tests
         // Frame classifiers (col03: [0]=0xFF, [1]=class, [2]=subcmd)
         private static bool IsEnable(byte[] r) => r[1] == 0x02 && r[2] == 0x02;
         private static bool IsValueUpdate(byte[] r) => r[1] == 0x05 && r[2] == 0x01;
+        private static bool IsParamDefs(byte[] r) => r[1] == 0x05 && r[2] == 0x03;
+        private static bool IsPageSet(byte[] r) => r[1] == 0x05 && r[2] == 0x04;
+        private static bool IsItmModeOn(byte[] r) => r[1] == 0x05 && r[2] == 0x02 && r[3] == 0x01;
+        private static bool IsItmModeOff(byte[] r) => r[1] == 0x05 && r[2] == 0x02 && r[3] == 0x00;
+        private static bool IsDisplayReset(byte[] r) => r[1] == 0x05 && r[2] == 0x05 && r[3] == 0x01;
 
         private sealed class Clock { public long T; public long Now() => T; }
 
@@ -63,7 +74,7 @@ namespace FanaBridge.Tests
         private static void Set(object s, string p, object v) =>
             s.GetType().GetProperty(p).GetSetMethod(true).Invoke(s, new[] { v });
 
-        // The driver only runs while a game is feeding telemetry, so test frames are
+        // The driver only sends values while a game is feeding telemetry, so test frames are
         // game-running by default (GameRunning has an internal setter — reflection).
         private static GameData Data(object status, bool gameRunning = true)
         {
@@ -75,10 +86,28 @@ namespace FanaBridge.Tests
         private static GameData EmptyData() => Data(NewStatus());
         private static GameData NotRunningData() => Data(NewStatus(), gameRunning: false);
 
-        // A firmware subscription report (col03-IN). Tyre page: SPEED@0, GEAR@1,
-        // FL(42)@0x82, RL(48)@0x83.
-        private static readonly byte[] TyreSubReport =
-            HexToBytes("ff05010300010034030104001203822a00320383300032");
+        // ── Firmware push reports (col03-IN, complete pages) ─────────────
+        // Confirmation matches on the parameter set, so syncing needs a page's COMPLETE push.
+        // Entry: [dev][handle][pidLo][pidHi][dataType]; the 0x80 handle bit marks slot params.
+
+        // Page 1 (Lap Info): SPEED@0, GEAR@1, LAP(505)@0x82, POSITION(501)@0x83,
+        // LAP_TIME(509)@4, LAST_LAP(510)@5.
+        private static readonly byte[] LapInfoPush = HexToBytes(
+            "ff0501" + "0300010034" + "0301040012" + "0382f90132" + "0383f50132" + "0304fd012a" + "0305fe012a");
+
+        // Page 5 (Tyre Temps): SPEED@0, GEAR@1, FL(42)@0x82, RL(48)@0x83, FR(45)@0x84, RR(51)@0x85.
+        private static readonly byte[] TyrePush = HexToBytes(
+            "ff0501" + "0300010034" + "0301040012" + "03822a0032" + "0383300032" + "03842d0032" + "0385330032");
+
+        // Page 2 (Fuel/ERS/DRS): SPEED@0, GEAR@1, FUEL(5)@0x82, ERS(9)@3, DRS_ZONE(14)@4,
+        // DRS_ACTIVE(15)@5, DELTA_OWN_BEST(516)@6.
+        private static readonly byte[] FuelPush = HexToBytes(
+            "ff0501" + "0300010034" + "0301040012" + "0382050018" + "0303090016" + "03040e0012" + "03050f0012" + "0306040214");
+
+        // A partial report: SPEED@0, GEAR@1, FL(42)@0x82, RL(48)@0x83 — not a complete page.
+        private static readonly byte[] PartialTyreReport =
+            HexToBytes("ff0501" + "0300010034" + "0301040012" + "03822a0032" + "0383300032");
+
         private static byte[] HexToBytes(string hex)
         {
             var b = new byte[hex.Length / 2];
@@ -86,13 +115,42 @@ namespace FanaBridge.Tests
             return b;
         }
 
-        private static void Enable(ItmDisplayDriver driver, Clock clock)
+        // A firmware unsubscribe report (FF FF param) for the given handles.
+        private static byte[] UnsubReport(params byte[] handles)
         {
-            driver.Start();
-            driver.Update(EmptyData());   // Enabling -> Running (Enable + seed)
+            var list = new List<byte> { 0xFF, 0x05, 0x01 };
+            foreach (var h in handles) { list.Add(0x03); list.Add(h); list.Add(0xFF); list.Add(0xFF); list.Add(0x00); }
+            return list.ToArray();
         }
 
-        // ── Lifecycle ────────────────────────────────────────────────────
+        // Brings the driver to push-confirmed sync and completes the post-sync repaint
+        // (first values, tight second tap, ParamDefs). Values only flow after this —
+        // there is no pre-push seeding.
+        private static void Sync(ItmDisplayDriver driver, Clock clock, byte[]? push = null, GameData? data = null)
+        {
+            var d = data ?? EmptyData();
+            driver.Start();
+            driver.Update(d);                    // bring-up: gate-on + enable + PageSet
+            driver.OnSubscriptionReport(push ?? LapInfoPush);
+            clock.T += 50;                       // push accumulation window
+            driver.Update(d);                    // judged → Synced; first paint
+            clock.T += 20;                       // value double-tap gap
+            driver.Update(d);                    // second tap + ParamDefs
+            Assert.True(driver.IsRunning);
+        }
+
+        // Delivers a push mid-session and runs the judgment + repaint ticks.
+        private static void Push(ItmDisplayDriver driver, Clock clock, byte[] report, GameData? data = null)
+        {
+            var d = data ?? EmptyData();
+            driver.OnSubscriptionReport(report);
+            clock.T += 50;
+            driver.Update(d);                    // judged; first paint
+            clock.T += 20;
+            driver.Update(d);                    // second tap + defs
+        }
+
+        // ── Lifecycle wiring ─────────────────────────────────────────────
 
         [Fact]
         public void Update_BeforeStart_SendsNothing()
@@ -103,74 +161,103 @@ namespace FanaBridge.Tests
             Assert.False(driver.IsRunning);
         }
 
-        private static bool IsItmModeOn(byte[] r) => r[1] == 0x05 && r[2] == 0x02 && r[3] == 0x01;
-
         [Fact]
-        public void Start_EnablesOnce_ThenRunning()
+        public void Start_SendsBringUp_ButNotRunningUntilPush()
         {
-            var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
+            var driver = MakeDriver(out var t, out _);
+            driver.Start();
+            driver.Update(EmptyData());
 
-            Assert.True(driver.IsRunning);
-            Assert.Single(t.Sent, IsEnable);
+            Assert.Contains(t.Sent, IsItmModeOn);
+            Assert.Contains(t.Sent, IsEnable);
+            Assert.Contains(t.Sent, IsPageSet);
+            Assert.False(driver.IsRunning);   // confirmation only ever comes from the push
         }
 
         [Fact]
         public void BringUp_ForcesDefaultPage()
         {
-            var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
+            var driver = MakeDriver(out var t, out _);
+            driver.Start();
+            driver.Update(EmptyData());
 
-            // Bring-up starts the session (FF 02 02) and forces page 1 (FF 05 04 03 01) so the
-            // display matches the Lap Info seed. Detecting the wheel's actual page is deferred (#43).
-            Assert.Contains(t.Sent, IsEnable);
-            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[3] == 0x03 && r[4] == 0x01);
+            // PageSet(dev 3, page 1) — the configured default.
+            Assert.Contains(t.Sent, r => r.Length > 4 && IsPageSet(r) && r[3] == 0x03 && r[4] == 0x01);
         }
 
         [Fact]
         public void BringUp_ForcesConfiguredDefaultPage()
         {
-            var driver = MakeDriver(out var t, out var clock);
+            var driver = MakeDriver(out var t, out _);
             driver.DefaultPage = 5;   // Tyre Temps
-            Enable(driver, clock);
+            driver.Start();
+            driver.Update(EmptyData());
 
-            // The forced-page PageSet uses the configured default page, not 1.
-            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[4] == 0x05);
-            // And the seed reflects that page (Tyre Temps = SPEED, GEAR + 4 tyre temps = 6 params).
+            Assert.Contains(t.Sent, r => r.Length > 4 && IsPageSet(r) && r[4] == 0x05);
+            // No seeding: nothing is subscribed until the firmware's push announces it.
+            Assert.Equal(0, driver.SubscriptionCount);
+        }
+
+        [Fact]
+        public void PushConfirmation_MakesRunning_AndAdoptsSubscriptions()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Sync(driver, clock);
+
+            Assert.True(driver.IsRunning);
             Assert.Equal(6, driver.SubscriptionCount);
+        }
+
+        [Fact]
+        public void NoValues_BeforePushConfirmation()
+        {
+            // Values sent at guessed handles are ignored at best — and after a page change can
+            // land on re-bound parameters. Nothing goes out until the push confirms.
+            var driver = MakeDriver(out var t, out var clock);
+            driver.Start();
+            driver.Update(EmptyData());
+            t.Sent.Clear();
+
+            var s = NewStatus();
+            Set(s, "SpeedLocal", 100.0);
+            clock.T += 200;
+            driver.Update(Data(s));
+
+            Assert.DoesNotContain(t.Sent, IsValueUpdate);
         }
 
         [Fact]
         public void ChangingDefaultPageWhileRunning_ForcesItLive()
         {
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);   // bring-up on the default page (1)
-            t.Sent.Clear();          // ignore bring-up frames
+            Sync(driver, clock);   // synced on page 1
+            t.Sent.Clear();
 
             driver.DefaultPage = 3;  // user picks a new default page in settings
             clock.T += 1000;
+            driver.Update(EmptyData());   // request registered; quiet window starts
+            clock.T += 60;                // past the switch quiet window
             driver.Update(EmptyData());
 
             // A PageSet to the new page is issued live — no re-enable / reconnect needed.
-            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[4] == 0x03);
+            Assert.Contains(t.Sent, r => r.Length > 4 && IsPageSet(r) && r[4] == 0x03);
         }
 
         [Fact]
         public void ChangingDefaultPageWhileRunning_DoesNotReseedSubscriptions()
         {
-            var driver = MakeDriver(out _, out var clock);
-            driver.DefaultPage = 1;
-            Enable(driver, clock);
-            int before = driver.SubscriptionCount;   // page 1's seeded set
+            var driver = MakeDriver(out var t, out var clock);
+            Sync(driver, clock);
+            int before = driver.SubscriptionCount;
 
-            driver.DefaultPage = 3;   // switch page live
+            driver.DefaultPage = 3;
             clock.T += 1000;
             driver.Update(EmptyData());
+            clock.T += 60;
+            driver.Update(EmptyData());
 
-            // The PageSet is issued (see ChangingDefaultPageWhileRunning_ForcesItLive), but the
-            // subscriptions are NOT speculatively reseeded — we wait for the firmware's push. A flaked
-            // switch, or a switch to the page already shown (no push), must not strand the display on
-            // wrong-page handles, so the existing set is kept until the firmware replaces it.
+            // The subscriptions are NOT speculatively replaced — the existing set stays until
+            // the firmware's push announces the new page's handles.
             Assert.Equal(before, driver.SubscriptionCount);
         }
 
@@ -182,10 +269,10 @@ namespace FanaBridge.Tests
             var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, deviceId: 4);   // Bentley
 
             driver.Start();
-            driver.Update(EmptyData());   // Enabling -> Running
+            driver.Update(EmptyData());
 
             // The forced-page PageSet targets device 4 (Bentley), not the default 3.
-            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[3] == 0x04 && r[4] == 0x01);
+            Assert.Contains(t.Sent, r => r.Length > 4 && IsPageSet(r) && r[3] == 0x04 && r[4] == 0x01);
         }
 
         [Fact]
@@ -195,47 +282,30 @@ namespace FanaBridge.Tests
             var clock = new Clock();
             var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, deviceId: 4);   // Bentley
             driver.Start();
-            driver.Update(EmptyData());   // bring-up + Lap Info seed
+            driver.Update(EmptyData());
+
+            // Bentley page 1 push (device id 4 in every entry): SPEED@0, GEAR@1, LAP@0x82,
+            // POSITION@0x83, LAP_TIME@4, LAST_LAP@5.
+            driver.OnSubscriptionReport(HexToBytes(
+                "ff0501" + "0400010034" + "0401040012" + "0482f90132" + "0483f50132" + "0404fd012a" + "0405fe012a"));
+            clock.T += 50;
 
             var s = NewStatus();
             Set(s, "SpeedLocal", 100.0);
-            clock.T += 1000;             // past the value interval
-            driver.Update(Data(s));
+            driver.Update(Data(s));   // judged → Synced; first paint
 
             var vu = t.Sent.LastOrDefault(IsValueUpdate);
             Assert.NotNull(vu);
-            Assert.Equal(0x04, vu[3]);   // per-entry device id = Bentley
-        }
-
-        [Fact]
-        public void Enable_SeedsLapInfoSubscriptions()
-        {
-            var driver = MakeDriver(out _, out var clock);
-            Enable(driver, clock);
-
-            // Lap Info has 6 params; seeded so the forced page 1 populates immediately,
-            // before the firmware's push (from the SetPage) arrives.
-            Assert.Equal(6, driver.SubscriptionCount);
-        }
-
-        [Fact]
-        public void Enable_DoesNotOverwriteAlreadyReceivedSubscriptions()
-        {
-            var driver = MakeDriver(out _, out var clock);
-            driver.OnSubscriptionReport(TyreSubReport);   // 4 subs arrive before Enable
-            Enable(driver, clock);
-
-            Assert.Equal(4, driver.SubscriptionCount);    // seed skipped
+            Assert.Equal(0x04, vu![3]);   // per-entry device id = Bentley
         }
 
         // ── Enable/disable gate ──────────────────────────────────────────
-        private static bool IsItmModeOff(byte[] r) => r[1] == 0x05 && r[2] == 0x02 && r[3] == 0x00;
 
         [Fact]
         public void Disabled_SendsItmModeOff_AndGoesDormant()
         {
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
+            Sync(driver, clock);
             t.Sent.Clear();
 
             driver.Enabled = false;
@@ -243,7 +313,7 @@ namespace FanaBridge.Tests
 
             Assert.Contains(t.Sent, IsItmModeOff);   // FF 05 02 00 sent
             Assert.False(driver.IsRunning);
-            Assert.Equal(0, driver.SubscriptionCount);
+            Assert.False(driver.Lifecycle.ValuesAllowed);
 
             // Dormant: no values on later ticks.
             t.Sent.Clear();
@@ -256,7 +326,7 @@ namespace FanaBridge.Tests
         public void Disabled_SendsItmModeOff_OnlyOnce()
         {
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
+            Sync(driver, clock);
             driver.Enabled = false;
 
             driver.Update(EmptyData());
@@ -270,17 +340,19 @@ namespace FanaBridge.Tests
         public void ReEnable_AfterDisable_ResumesBringUp()
         {
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
+            Sync(driver, clock);
             driver.Enabled = false;
             driver.Update(EmptyData());
             t.Sent.Clear();
 
             driver.Enabled = true;
-            driver.Update(EmptyData());   // Disabled -> Enabling -> Running in one tick
+            driver.Start();               // as the device instance does every frame while enabled
+            clock.T += 200;               // past the PageSet spacing floor
+            driver.Update(EmptyData());
 
-            Assert.True(driver.IsRunning);
             Assert.Contains(t.Sent, IsItmModeOn);   // gate turned back on
-            Assert.Contains(t.Sent, IsEnable);      // session re-enabled
+            Assert.Contains(t.Sent, IsEnable);      // session enable (official parity)
+            Assert.Contains(t.Sent, IsPageSet);     // and the page — confirmation via push
         }
 
         [Fact]
@@ -297,23 +369,24 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void SendValues_UnknownSubscribedParam_LogsOnce()
+        public void UserDisable_ItmOff_RetriedUntilAccepted()
         {
-            var t = new RecordingTransport();
-            var clock = new Clock();
-            var logs = new List<string>();
-            var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, logs.Add);
+            var driver = MakeDriver(out var t, out var clock);
+            Sync(driver, clock);
+            driver.Enabled = false;
 
-            // Subscribe param 9999 (outside every page layout) at handle 2 (fw 0x82).
-            driver.OnSubscriptionReport(HexToBytes("ff050103820f2700"));
-            driver.Start();
-            driver.Update(EmptyData());   // Enabling -> Running
-            clock.T += 40;
-            driver.Update(EmptyData());   // SendSubscribedValues encounters the unknown param
-            clock.T += 40;
-            driver.Update(EmptyData());   // ticks again — must not re-log
+            t.SendReturns = false;             // off command declined — must be retried
+            driver.Update(EmptyData());
+            t.Sent.Clear();
 
-            Assert.Single(logs, m => m.Contains("no encoder for subscribed param 9999"));
+            t.SendReturns = true;
+            driver.Update(EmptyData());        // retried and accepted
+            Assert.Contains(t.Sent, IsItmModeOff);
+
+            t.Sent.Clear();
+            clock.T += 500;
+            driver.Update(EmptyData());        // dormant after success
+            Assert.Empty(t.Sent);
         }
 
         // ── Subscription handling ────────────────────────────────────────
@@ -321,8 +394,10 @@ namespace FanaBridge.Tests
         [Fact]
         public void OnSubscriptionReport_AddsSubscriptions()
         {
+            // Pushes are adopted in every state — even before Start (host state must never
+            // be used to infer firmware state).
             var driver = MakeDriver(out _, out _);
-            driver.OnSubscriptionReport(TyreSubReport);
+            driver.OnSubscriptionReport(PartialTyreReport);
             Assert.Equal(4, driver.SubscriptionCount);   // SPEED, GEAR, FL, RL
         }
 
@@ -330,27 +405,21 @@ namespace FanaBridge.Tests
         public void OnSubscriptionReport_UnsubscribeRemovesHandles()
         {
             var driver = MakeDriver(out _, out _);
-            driver.OnSubscriptionReport(TyreSubReport);
+            driver.OnSubscriptionReport(PartialTyreReport);
 
             // Unsubscribe handles 0 and 1 (FF FF param).
             driver.OnSubscriptionReport(HexToBytes("ff05010300ffff340301ffff12"));
             Assert.Equal(2, driver.SubscriptionCount);   // FL, RL remain
         }
 
-        // A firmware unsubscribe report (FF FF param) for the given handles.
-        private static byte[] UnsubReport(params byte[] handles)
-        {
-            var list = new List<byte> { 0xFF, 0x05, 0x01 };
-            foreach (var h in handles) { list.Add(0x03); list.Add(h); list.Add(0xFF); list.Add(0xFF); list.Add(0x00); }
-            return list.ToArray();
-        }
-
         [Fact]
         public void AllUnsubscribed_SendsNoValues()
         {
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);   // seeds the 6 Lap Info handles
+            Sync(driver, clock);
             driver.OnSubscriptionReport(UnsubReport(0, 1, 2, 3, 4, 5));
+            clock.T += 50;
+            driver.Update(Data(NewStatus()));
             Assert.Equal(0, driver.SubscriptionCount);
             t.Sent.Clear();
 
@@ -361,15 +430,29 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void SendValues_UnknownSubscribedParam_LogsOnce()
+        {
+            var t = new RecordingTransport();
+            var clock = new Clock();
+            var logs = new List<string>();
+            var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, logs.Add);
+            Sync(driver, clock);
+
+            // The firmware announces param 9999 (outside every page layout) at handle 2.
+            Push(driver, clock, HexToBytes("ff050103820f2700"));
+            clock.T += 40;
+            driver.Update(EmptyData());   // ticks again — must not re-log
+
+            Assert.Single(logs, m => m.Contains("no encoder for subscribed param 9999"));
+        }
+
+        // ── ParamDefs (unit/total suffixes) ──────────────────────────────
+
+        [Fact]
         public void SubscriptionWithUnits_SendsParamDefsSuffix()
         {
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);          // Lap Info seed
-            driver.OnSubscriptionReport(TyreSubReport);   // tyre temps carry 'C'
-            t.Sent.Clear();
-
-            clock.T += 40;
-            driver.Update(EmptyData());     // ParamDefs refreshed here
+            Sync(driver, clock, TyrePush);   // tyre temps carry 'C'
 
             var pd = t.Sent.First(IsParamDefs);
             // entry: [03][slot][posLo][posHi][suffixLen][suffix]; tyre FL handle 2 -> slot 0x82
@@ -379,39 +462,55 @@ namespace FanaBridge.Tests
             Assert.Equal((byte)'C', pd[8]);            // Celsius
         }
 
-        // A game-exit DisplayReset clears the firmware's suffix; on resume the suffix set is
-        // unchanged, so the sig-latch would suppress the re-send and the suffix would never
-        // come back (value renders, suffix doesn't). The exit reset must clear the sig so the
-        // def re-decorates when telemetry returns.
+        [Fact]
+        public void ParamDefs_SentAfterValueDoubleTap()
+        {
+            // Post-sync ordering: first values, tight second tap, then ParamDefs — matching
+            // official-software post-switch behavior (defs-before-values coincided with a
+            // lost first render in captures).
+            var driver = MakeDriver(out var t, out var clock);
+            driver.Start();
+            driver.Update(EmptyData());
+            driver.OnSubscriptionReport(TyrePush);
+            clock.T += 50;
+            driver.Update(EmptyData());   // sync + first paint — defs must NOT be out yet
+            Assert.Single(t.Sent, IsValueUpdate);
+            Assert.DoesNotContain(t.Sent, IsParamDefs);
+
+            clock.T += 20;
+            driver.Update(EmptyData());   // second tap, then defs
+            Assert.Equal(2, t.Sent.Count(IsValueUpdate));
+            int lastValue = t.Sent.FindLastIndex(IsValueUpdate);
+            int defs = t.Sent.FindIndex(IsParamDefs);
+            Assert.True(defs > lastValue, "ParamDefs go out after the value double-tap");
+        }
+
         [Fact]
         public void GameExitThenResume_ReDecoratesSuffix()
         {
+            // The resume's fresh push may follow decorations being lost (observed after
+            // hot-swaps); the repaint clears the suffix signature so the same suffix set is
+            // re-sent rather than latched away.
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);   // 'C' suffix on the tyre page
-            clock.T += 1000;
-            driver.Update(EmptyData());                   // telemetry live -> def sent
+            Sync(driver, clock, TyrePush);
             Assert.Contains(t.Sent, IsParamDefs);
 
-            driver.Update(NotRunningData());              // game exit -> DisplayReset
+            clock.T += 40;
+            driver.Update(NotRunningData());              // game exit → display gated off
             t.Sent.Clear();
 
             clock.T += 1000;
-            driver.Update(EmptyData());                   // resume, same suffix set -> MUST re-send
-            Assert.Contains(t.Sent, IsParamDefs);
+            driver.Update(EmptyData());                   // resume: PageSet-while-off + gate-on
+            Push(driver, clock, TyrePush);                // the elicited push, same suffix set
+
+            Assert.Contains(t.Sent, IsParamDefs);         // re-decorated despite unchanged sig
         }
 
-        // ParamDefs is fire-and-forget (no ack): a single send is occasionally dropped by the
-        // firmware, so every def is sent as a tight double-tap (~50 ms), matching the official
-        // app's priming. Exactly one extra send, then silence until the suffix set changes.
         [Fact]
         public void ParamDefs_AreTightDoubleTapped()
         {
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
-            clock.T += 1000;
-            driver.Update(EmptyData());                    // first def (tap 1)
+            Sync(driver, clock, TyrePush);                 // first def tap goes out with the sync
             Assert.Equal(1, t.Sent.Count(IsParamDefs));
 
             clock.T += driver.DefDoubleTapMs;              // ~50 ms later
@@ -433,11 +532,7 @@ namespace FanaBridge.Tests
             Set(s, "OpponentsCount", 20);   // field of 20 (list already includes the player)
             Set(s, "Position", 7);
 
-            driver.Start();
-            driver.Update(Data(s));         // Enable + seed Lap Info (lap@h2, position@h3)
-            t.Sent.Clear();
-            clock.T += 40;
-            driver.Update(Data(s));         // ParamDefs with the dynamic totals
+            Sync(driver, clock, LapInfoPush, Data(s));   // lap@h2, position@h3
 
             var pd = t.Sent.First(IsParamDefs);
             // First suffixed slot is lap (handle 2 -> slot 0x82) with "/34".
@@ -454,10 +549,7 @@ namespace FanaBridge.Tests
             var driver = MakeDriver(out var t, out var clock);
             var s = NewStatus();
             Set(s, "OpponentsCount", 2); Set(s, "Position", 2);   // field 2, P2 -> "/2"
-            driver.Start();
-            driver.Update(Data(s));          // Enable + seed (position@h3)
-            clock.T += 40;
-            driver.Update(Data(s));          // sends "/2" on the position slot
+            Sync(driver, clock, LapInfoPush, Data(s));            // sends "/2" on the position slot
             t.Sent.Clear();
 
             Set(s, "Position", 3);           // now P3 in a field of 2 -> implausible
@@ -480,10 +572,7 @@ namespace FanaBridge.Tests
             driver.ShowPositionTotal = false;
             var s = NewStatus();
             Set(s, "OpponentsCount", 20); Set(s, "Position", 7);   // would be "/20"
-            driver.Start();
-            driver.Update(Data(s));
-            clock.T += 40;
-            driver.Update(Data(s));
+            Sync(driver, clock, LapInfoPush, Data(s));
 
             // Position slot (0x83) is present but blanked with a " " suffix (length 1) — a
             // zero-length suffix would leave the firmware's default "/0" showing.
@@ -496,14 +585,9 @@ namespace FanaBridge.Tests
         public void Fuel_FallsBackToUnitLabel_WhenNoCapacity()
         {
             var driver = MakeDriver(out var t, out var clock);
-            driver.OnSubscriptionReport(HexToBytes("ff05010382050018"));   // fuel @ handle 2 (slot 0x82)
-            Enable(driver, clock);                                          // seed skipped; only fuel subscribed
-
             var s = NewStatus();
             Set(s, "Fuel", 12.0); Set(s, "MaxFuel", 0.0);   // no tank capacity reported
-            t.Sent.Clear();
-            clock.T += 40;
-            driver.Update(Data(s));
+            Sync(driver, clock, FuelPush, Data(s));          // fuel @ handle 2 (slot 0x82)
 
             // With no capacity, the fuel slot (0x82) falls back to the unit label "L" (not a
             // blank " "), so a bare fuel value still reads as fuel.
@@ -518,14 +602,9 @@ namespace FanaBridge.Tests
         public void TempSuffix_FollowsFrameUnit()
         {
             var driver = MakeDriver(out var t, out var clock);
-            driver.OnSubscriptionReport(TyreSubReport);   // tyre temps @ 0x82/0x83
-            Enable(driver, clock);
-
             var s = NewStatus();
             Set(s, "TemperatureUnit", "F");   // frame reports Fahrenheit
-            t.Sent.Clear();
-            clock.T += 40;
-            driver.Update(Data(s));
+            Sync(driver, clock, TyrePush, Data(s));
 
             // The tyre slot (0x82) label comes from the frame's TemperatureUnit, not a fixed
             // default — normalized to a single char.
@@ -536,40 +615,89 @@ namespace FanaBridge.Tests
             Assert.True(tyreF);
         }
 
-        private static bool IsParamDefs(byte[] r) => r[1] == 0x05 && r[2] == 0x03;
-
         [Fact]
-        public void Running_SendsValuesForSubscribedParams()
+        public void ParamDefs_DeclinedSend_RetriedUntilAccepted()
         {
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
+
+            // ParamDefs declined during the sync repaint: the suffix signature must NOT
+            // latch, or the decoration would never be retried until the suffix set changes.
+            t.Decide = r => !IsParamDefs(r);
+            Sync(driver, clock, TyrePush);
+            Assert.Contains(t.Sent, IsParamDefs);   // attempted
             t.Sent.Clear();
 
+            t.Decide = null;
+            clock.T += 40;
+            driver.Update(EmptyData());             // unchanged suffix set — still retried
+            Assert.Contains(t.Sent, IsParamDefs);
+        }
+
+        [Fact]
+        public void ParamDefs_DoubleTap_Declined_RetriedNextTick()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            Sync(driver, clock, TyrePush);          // first def tap accepted, second scheduled
+            t.Sent.Clear();
+
+            t.Decide = r => !IsParamDefs(r);        // the tight second tap gets declined
+            clock.T += driver.DefDoubleTapMs;
+            driver.Update(EmptyData());
+            Assert.Contains(t.Sent, IsParamDefs);   // attempted
+            t.Sent.Clear();
+
+            t.Decide = null;
+            clock.T += 5;
+            driver.Update(EmptyData());             // retried next tick
+            Assert.Contains(t.Sent, IsParamDefs);
+        }
+
+        // ── Values ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void Synced_SendsValuesForSubscribedParams()
+        {
+            var driver = MakeDriver(out var t, out var clock);
             var s = NewStatus();
             Set(s, "TyreTemperatureFrontLeft", 88.0);
-            clock.T += 40;
-            driver.Update(Data(s));
+            Sync(driver, clock, TyrePush, Data(s));
 
             var vu = t.Sent.First(IsValueUpdate);
             // Header [FF 05 01], then entries [03][handle][idLo][idHi][size][val...].
             // First subscribed handle is 0 (SPEED).
-            Assert.Equal(0x03, vu[3]);   // entry marker
+            Assert.Equal(0x03, vu[3]);   // entry device id
             Assert.Equal(0x00, vu[4]);   // handle 0
-            Assert.Contains(t.Sent, IsValueUpdate);
+        }
+
+        [Fact]
+        public void FirstValuesAfterSync_AreDoubleTapped()
+        {
+            // The first values after any push get a tight double-tap (~20 ms) — the periodic
+            // re-assert heals whatever single-shot sends lose.
+            var driver = MakeDriver(out var t, out var clock);
+            driver.Start();
+            driver.Update(EmptyData());
+            driver.OnSubscriptionReport(LapInfoPush);
+            clock.T += 50;
+            driver.Update(EmptyData());                  // sync → immediate first paint
+            Assert.Equal(1, t.Sent.Count(IsValueUpdate));
+
+            clock.T += driver.ValueDoubleTapMs;
+            driver.Update(EmptyData());                  // the tight second tap
+            Assert.Equal(2, t.Sent.Count(IsValueUpdate));
+
+            clock.T += 40;
+            driver.Update(EmptyData());                  // unchanged values — no third send
+            Assert.Equal(2, t.Sent.Count(IsValueUpdate));
         }
 
         [Fact]
         public void Values_NotResent_WhenUnchanged()
         {
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
-
             var s = NewStatus();
             Set(s, "TyreTemperatureFrontLeft", 80.0);
-            clock.T += 40;
-            driver.Update(Data(s));
+            Sync(driver, clock, TyrePush, Data(s));
             t.Sent.Clear();
 
             clock.T += 100;
@@ -584,16 +712,69 @@ namespace FanaBridge.Tests
             // ValueUpdate is unacked, so unchanged values are re-asserted every
             // RefreshIntervalMs as insurance against a lost frame sticking.
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
-
             var s = NewStatus();
             Set(s, "TyreTemperatureFrontLeft", 80.0);
+            Sync(driver, clock, TyrePush, Data(s));
+            t.Sent.Clear();
+
+            clock.T += driver.RefreshIntervalMs;   // past the refresh window, telemetry unchanged
+            driver.Update(Data(s));
+
+            Assert.Contains(t.Sent, IsValueUpdate);
+        }
+
+        [Fact]
+        public void Values_Resent_WhenSubscriptionChanges()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            var s = NewStatus();
+            Sync(driver, clock, TyrePush, Data(s));
+            t.Sent.Clear();
+
+            // A new push (page change at the wheel) forces a fresh repaint even with
+            // identical telemetry — the firmware may be showing stale cached values.
+            Push(driver, clock, LapInfoPush, Data(s));
+
+            Assert.Contains(t.Sent, IsValueUpdate);
+        }
+
+        [Fact]
+        public void Values_RateLimited_WithinInterval()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            var s = NewStatus();
+            Set(s, "TyreTemperatureFrontLeft", 80.0);
+            Sync(driver, clock, TyrePush, Data(s));
             clock.T += 40;
             driver.Update(Data(s));
             t.Sent.Clear();
 
-            clock.T += driver.RefreshIntervalMs;   // past the refresh window, telemetry unchanged
+            Set(s, "TyreTemperatureFrontLeft", 90.0);
+            clock.T += 10;   // within ValueIntervalMs
+            driver.Update(Data(s));
+
+            Assert.DoesNotContain(t.Sent, IsValueUpdate);
+        }
+
+        [Fact]
+        public void Values_RetriedAfterFailedSend()
+        {
+            var driver = MakeDriver(out var t, out var clock);
+            var s = NewStatus();
+            Set(s, "TyreTemperatureFrontLeft", 80.0);
+            Sync(driver, clock, TyrePush, Data(s));
+
+            // A value send that fails at the transport must NOT be recorded as last-sent...
+            Set(s, "TyreTemperatureFrontLeft", 85.0);
+            t.SendReturns = false;
+            clock.T += 40;
+            driver.Update(Data(s));
+            t.Sent.Clear();
+
+            // ...so when the transport recovers, the (unchanged) values are retried rather
+            // than skipped as "already sent".
+            t.SendReturns = true;
+            clock.T += 40;
             driver.Update(Data(s));
 
             Assert.Contains(t.Sent, IsValueUpdate);
@@ -611,17 +792,12 @@ namespace FanaBridge.Tests
         [Fact]
         public void Gear_NumericSlot_SendsNumericByte()
         {
-            // TyreSubReport declares GEAR with dataType 0x12 (u8, as a PBME does):
+            // TyrePush declares GEAR with dataType 0x12 (u8, as a PBME does):
             // gear "3" goes on the wire as numeric 0x03.
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
-            t.Sent.Clear();
-
             var s = NewStatus();
             Set(s, "Gear", "3");
-            clock.T += 40;
-            driver.Update(Data(s));
+            Sync(driver, clock, TyrePush, Data(s));
 
             Assert.Equal((byte)0x03, GearValue(t.Sent.First(IsValueUpdate)));
         }
@@ -631,97 +807,31 @@ namespace FanaBridge.Tests
         {
             // A display that declares GEAR as text (low nibble 1, as a Formula V3 does)
             // gets the ASCII form: gear "3" goes on the wire as '3' (0x33).
-            var textSub = HexToBytes("ff0501" + "0300010034" + "0301040011");
+            var textPush = HexToBytes(
+                "ff0501" + "0300010034" + "0301040011" + "03822a0032" + "0383300032" + "03842d0032" + "0385330032");
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(textSub);
-            t.Sent.Clear();
-
             var s = NewStatus();
             Set(s, "Gear", "3");
-            clock.T += 40;
-            driver.Update(Data(s));
+            Sync(driver, clock, textPush, Data(s));
 
             Assert.Equal((byte)0x33, GearValue(t.Sent.First(IsValueUpdate)));
         }
 
-        [Fact]
-        public void Values_Resent_WhenSubscriptionChanges()
-        {
-            var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
-
-            var s = NewStatus();
-            clock.T += 40;
-            driver.Update(Data(s));
-            t.Sent.Clear();
-
-            // A new subscription report forces a fresh send even with identical telemetry.
-            driver.OnSubscriptionReport(TyreSubReport);
-            clock.T += 40;
-            driver.Update(Data(s));
-
-            Assert.Contains(t.Sent, IsValueUpdate);
-        }
-
-        [Fact]
-        public void Values_RateLimited_WithinInterval()
-        {
-            var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
-
-            var s = NewStatus();
-            Set(s, "TyreTemperatureFrontLeft", 80.0);
-            clock.T += 40;
-            driver.Update(Data(s));
-            t.Sent.Clear();
-
-            Set(s, "TyreTemperatureFrontLeft", 90.0);
-            clock.T += 10;   // within ValueIntervalMs
-            driver.Update(Data(s));
-
-            Assert.DoesNotContain(t.Sent, IsValueUpdate);
-        }
-
-        [Fact]
-        public void Values_RetriedAfterFailedSend()
-        {
-            var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
-
-            var s = NewStatus();
-            Set(s, "TyreTemperatureFrontLeft", 80.0);
-
-            // A value send that fails at the transport must NOT be recorded as last-sent...
-            t.SendReturns = false;
-            clock.T += 40;
-            driver.Update(Data(s));
-            t.Sent.Clear();
-
-            // ...so when the transport recovers, the (unchanged) values are retried rather
-            // than skipped as "already sent".
-            t.SendReturns = true;
-            clock.T += 40;
-            driver.Update(Data(s));
-
-            Assert.Contains(t.Sent, IsValueUpdate);
-        }
-
-        // ── Game gating (issue #54) ──────────────────────────────────────
+        // ── Game gating & exit/resume ────────────────────────────────────
 
         [Fact]
         public void BringUp_RunsWithoutLiveTelemetry()
         {
             // ITM is always-on: bring-up runs at connect so the default page (and its
             // live settings preview) works in idle, before any game has run.
-            var driver = MakeDriver(out var t, out _);
+            var driver = MakeDriver(out var t, out var clock);
             driver.Start();
             driver.Update(NotRunningData());
-
             Assert.Contains(t.Sent, IsEnable);
+
+            driver.OnSubscriptionReport(LapInfoPush);
+            clock.T += 50;
+            driver.Update(NotRunningData());
             Assert.True(driver.IsRunning);
         }
 
@@ -732,8 +842,10 @@ namespace FanaBridge.Tests
             // never be painted while no game is running.
             var driver = MakeDriver(out var t, out var clock);
             driver.Start();
-            driver.Update(NotRunningData());   // bring-up in idle
-            driver.OnSubscriptionReport(TyreSubReport);
+            driver.Update(NotRunningData());   // bring-up in idle (never-live: no gate-off)
+            driver.OnSubscriptionReport(TyrePush);
+            clock.T += 50;
+            driver.Update(NotRunningData());   // synced, but no game
             t.Sent.Clear();
 
             var stale = NewStatus();
@@ -744,25 +856,24 @@ namespace FanaBridge.Tests
             Assert.DoesNotContain(t.Sent, IsValueUpdate);
         }
 
-        // DisplayReset (FF 05 05 01): every ITM field reverts to its per-field placeholder
-        // ("--- / -", "--:--.-", …); session/page/subs untouched. No effect on the Legacy ITM page.
-        private static bool IsDisplayReset(byte[] r) => r[1] == 0x05 && r[2] == 0x05 && r[3] == 0x01;
-
         [Fact]
-        public void GameExit_ResetsFields_SessionStaysUp()
+        public void GameExit_GatesDisplayOff_NoDisplayReset()
         {
+            // Exit = gate-off: the screen goes dark — stale values and burn-in solved in one
+            // move. DisplayReset is not part of the lifecycle (resets were observed to degrade
+            // subsequent bring-ups, and the reset leaves the OLED lit with placeholders).
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);             // live game, running (6 Lap Info subs)
+            Sync(driver, clock);               // live game, synced
             t.Sent.Clear();
 
-            driver.Update(NotRunningData());   // game exited — fields revert to placeholders
+            clock.T += 40;
+            driver.Update(NotRunningData());   // game exited
 
-            Assert.Contains(t.Sent, IsDisplayReset);
-            Assert.DoesNotContain(t.Sent, IsItmModeOff);   // session NOT torn down
-            Assert.True(driver.IsRunning);
-            Assert.Equal(6, driver.SubscriptionCount);     // subscriptions kept
+            Assert.Contains(t.Sent, IsItmModeOff);
+            Assert.DoesNotContain(t.Sent, IsDisplayReset);
+            Assert.False(driver.IsRunning);    // parked in TelemetryIdle
 
-            // Idle afterwards: no repeat resets, no values from stale telemetry.
+            // Idle afterwards: dormant.
             t.Sent.Clear();
             clock.T += 500;
             driver.Update(NotRunningData());
@@ -770,18 +881,19 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void GameExit_Reset_RetriedUntilAccepted()
+        public void GameExit_GateOff_RetriedUntilAccepted()
         {
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
+            Sync(driver, clock);
 
-            t.SendReturns = false;             // transport declines the reset
+            t.SendReturns = false;             // transport declines the gate-off
+            clock.T += 40;
             driver.Update(NotRunningData());
             t.Sent.Clear();
 
             t.SendReturns = true;
             driver.Update(NotRunningData());   // retried and accepted
-            Assert.Contains(t.Sent, IsDisplayReset);
+            Assert.Contains(t.Sent, IsItmModeOff);
 
             t.Sent.Clear();
             driver.Update(NotRunningData());   // no repeat after success
@@ -789,26 +901,30 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void GameRestart_AfterExit_RepaintsUnchangedValues()
+        public void GameRestart_AfterExit_ResumesAndRepaints()
         {
+            // Resume = PageSet-while-off then gate-on; the elicited push resyncs, and the
+            // repaint sends even UNCHANGED values — the display was dark and the firmware
+            // shows stale cached values until the first fresh send.
             var driver = MakeDriver(out var t, out var clock);
             var s = NewStatus();
             Set(s, "CurrentLap", 5);
+            Sync(driver, clock, LapInfoPush, Data(s));
 
-            driver.Start();
-            driver.Update(Data(s));            // bring-up (seeds Lap Info)
             clock.T += 40;
-            driver.Update(Data(s));            // values painted
-            driver.Update(Data(s, gameRunning: false));   // exit — fields reset to placeholders
+            driver.Update(Data(s, gameRunning: false));   // exit — gate-off
             t.Sent.Clear();
 
-            clock.T += 40;
-            driver.Update(Data(s));            // game returns with IDENTICAL telemetry
+            clock.T += 1000;
+            driver.Update(Data(s));            // game returns: PageSet-while-off + gate-on
+            int page = t.Sent.FindIndex(IsPageSet);
+            int gateOn = t.Sent.FindIndex(IsItmModeOn);
+            Assert.True(page >= 0 && gateOn >= 0 && page < gateOn,
+                "resume sends the PageSet while off, then the gate-on");
 
-            // The reset cleared the dirty tracking, so even unchanged values are
-            // repainted — otherwise the display would sit on placeholders until a
-            // value actually changed.
-            Assert.Contains(t.Sent, IsValueUpdate);
+            Push(driver, clock, LapInfoPush, Data(s));    // the elicited push, identical telemetry
+
+            Assert.Contains(t.Sent, IsValueUpdate);        // repainted anyway
         }
 
         [Fact]
@@ -819,55 +935,38 @@ namespace FanaBridge.Tests
             var driver = MakeDriver(out var t, out var clock);
             driver.Start();
             driver.Update(NotRunningData());   // bring-up in idle
+            driver.OnSubscriptionReport(LapInfoPush);
+            clock.T += 50;
+            driver.Update(NotRunningData());   // synced in idle
             t.Sent.Clear();
 
             driver.DefaultPage = 3;
             clock.T += 100;
+            driver.Update(NotRunningData());   // request registered; quiet window
+            clock.T += 60;
             driver.Update(NotRunningData());
 
-            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[4] == 0x03);
+            Assert.Contains(t.Sent, r => r.Length > 4 && IsPageSet(r) && r[4] == 0x03);
         }
 
-        [Fact]
-        public void UserDisable_ItmOff_RetriedUntilAccepted()
-        {
-            var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.Enabled = false;
-
-            t.SendReturns = false;             // off command declined — must not latch Disabled
-            driver.Update(EmptyData());
-            t.Sent.Clear();
-
-            t.SendReturns = true;
-            driver.Update(EmptyData());        // retried and accepted
-            Assert.Contains(t.Sent, IsItmModeOff);
-
-            t.Sent.Clear();
-            clock.T += 500;
-            driver.Update(EmptyData());        // dormant after success
-            Assert.Empty(t.Sent);
-        }
-
-        // ── Bring-up / ParamDefs transport-acceptance retries ────────────
+        // ── Bring-up transport-acceptance retries ────────────────────────
 
         [Fact]
-        public void BringUp_DeclinedWrites_RetriedUntilAccepted_NotRunningUntilComplete()
+        public void BringUp_DeclinedWrites_RetriedUntilAccepted()
         {
             var driver = MakeDriver(out var t, out var clock);
             driver.Start();
 
             t.SendReturns = false;             // whole bring-up declined
             driver.Update(EmptyData());
-            Assert.False(driver.IsRunning);    // must NOT latch Running on declined writes
+            Assert.False(driver.IsRunning);
             t.Sent.Clear();
 
             t.SendReturns = true;
-            driver.Update(EmptyData());        // retried and accepted → Running
-            Assert.True(driver.IsRunning);
+            driver.Update(EmptyData());        // retried and accepted
             Assert.Contains(t.Sent, IsItmModeOn);
             Assert.Contains(t.Sent, IsEnable);
-            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04);
+            Assert.Contains(t.Sent, IsPageSet);
         }
 
         [Fact]
@@ -876,102 +975,43 @@ namespace FanaBridge.Tests
             var driver = MakeDriver(out var t, out var clock);
             driver.Start();
 
-            // Gate + Enable accepted, PageSet declined: bring-up stalls before Running.
-            t.Decide = r => !(r[1] == 0x05 && r[2] == 0x04);
+            // Gate + Enable accepted, PageSet declined: bring-up stalls before AwaitPush.
+            t.Decide = r => !IsPageSet(r);
             driver.Update(EmptyData());
-            Assert.False(driver.IsRunning);
             t.Sent.Clear();
 
             t.Decide = null;
             driver.Update(EmptyData());        // only the missing step is retried
-            Assert.True(driver.IsRunning);
             Assert.DoesNotContain(t.Sent, IsItmModeOn);   // already accepted last tick
             Assert.DoesNotContain(t.Sent, IsEnable);      // already accepted last tick
-            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04);
+            Assert.Contains(t.Sent, IsPageSet);
         }
 
-        [Fact]
-        public void ParamDefs_DeclinedSend_RetriedUntilAccepted()
-        {
-            var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
-
-            // ParamDefs declined: the suffix signature must NOT latch, or the
-            // decoration would never be retried until the suffix set changes.
-            t.Decide = r => !IsParamDefs(r);
-            clock.T += 40;
-            driver.Update(EmptyData());
-            Assert.Contains(t.Sent, IsParamDefs);   // attempted
-            t.Sent.Clear();
-
-            t.Decide = null;
-            clock.T += 40;
-            driver.Update(EmptyData());             // unchanged suffix set — still retried
-            Assert.Contains(t.Sent, IsParamDefs);
-        }
+        // ── Wheel change (identity layer) ────────────────────────────────
 
         [Fact]
-        public void ParamDefs_DoubleTap_Declined_RetriedNextTick()
+        public void WheelChanged_RestartsColdAndSuspendsValues()
         {
+            // A hot-swap resets the display cold with zero trace on the ITM channel; the
+            // identity layer's event restarts the lifecycle and nothing is sent until the
+            // fresh push confirms.
             var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
-
-            clock.T += 40;
-            driver.Update(EmptyData());             // first ParamDefs accepted, tap scheduled
+            var s = NewStatus();
+            Set(s, "TyreTemperatureFrontLeft", 80.0);
+            Sync(driver, clock, TyrePush, Data(s));
             t.Sent.Clear();
 
-            t.Decide = r => !IsParamDefs(r);        // the tight second tap is declined
-            clock.T += 60;
-            driver.Update(EmptyData());
-            t.Sent.Clear();
+            driver.OnWheelChanged();
+            Assert.Equal(0, driver.SubscriptionCount);   // stale handles dropped
+            clock.T += 200;
+            driver.Update(Data(s));
 
-            t.Decide = null;
-            clock.T += 10;
-            driver.Update(EmptyData());             // tap retried once accepted
-            Assert.Contains(t.Sent, IsParamDefs);
-        }
+            Assert.Contains(t.Sent, IsItmModeOn);        // full cold bring-up
+            Assert.Contains(t.Sent, IsPageSet);
+            Assert.DoesNotContain(t.Sent, IsValueUpdate);   // no values until the push
 
-        [Fact]
-        public void DefaultPageChange_DeclinedPageSet_RetriedUntilAccepted()
-        {
-            var driver = MakeDriver(out var t, out var clock);
-            driver.Start();
-            driver.Update(NotRunningData());
-            t.Sent.Clear();
-
-            driver.DefaultPage = 3;
-            t.SendReturns = false;                  // live page switch declined
-            driver.Update(NotRunningData());
-            t.Sent.Clear();
-
-            t.SendReturns = true;
-            driver.Update(NotRunningData());        // edge still pending — retried
-            Assert.Contains(t.Sent, r => r.Length > 4 && r[1] == 0x05 && r[2] == 0x04 && r[4] == 0x03);
-        }
-
-        // ── Stop / restart ───────────────────────────────────────────────
-
-        [Fact]
-        public void Stop_ClearsSubscriptionsAndHalts()
-        {
-            var driver = MakeDriver(out var t, out var clock);
-            Enable(driver, clock);
-            driver.OnSubscriptionReport(TyreSubReport);
-
-            driver.Stop();
-            Assert.False(driver.IsRunning);
-            Assert.Equal(0, driver.SubscriptionCount);
-            t.Sent.Clear();
-
-            clock.T += 1000;
-            driver.Update(EmptyData());
-            Assert.Empty(t.Sent);
-
-            driver.Start();
-            driver.Update(EmptyData());
-            Assert.Contains(t.Sent, IsEnable);   // fresh Enable on restart
+            Push(driver, clock, TyrePush, Data(s));      // fresh push after re-seat
+            Assert.Contains(t.Sent, IsValueUpdate);      // repainted
         }
     }
 }

--- a/tests/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/tests/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -495,20 +495,26 @@ namespace FanaBridge.Tests
         [Fact]
         public void GameExitThenResume_ReDecoratesSuffix()
         {
-            // The resume's fresh push may follow decorations being lost (observed after
-            // hot-swaps); the repaint clears the suffix signature so the same suffix set is
-            // re-sent rather than latched away.
+            // On game return the repaint clears the suffix signature so the same suffix set is
+            // re-sent rather than latched away. (Starting page = the tyre page here, so the
+            // return repaints it in place rather than switching to a different default.)
             var driver = MakeDriver(out var t, out var clock);
+            driver.DefaultPage = 5;                       // Tyre Temps — matches TyrePush
             Sync(driver, clock, TyrePush);
             Assert.Contains(t.Sent, IsParamDefs);
 
             clock.T += 40;
-            driver.Update(NotRunningData());              // game exit → display gated off
+            driver.Update(NotRunningData());              // game exit → fields cleared to ---
             t.Sent.Clear();
 
+            // Game returns, repaints in place: first values, tight second tap, then ParamDefs.
+            var s = NewStatus();
             clock.T += 1000;
-            driver.Update(EmptyData());                   // resume: PageSet-while-off + gate-on
-            Push(driver, clock, TyrePush);                // the elicited push, same suffix set
+            driver.Update(Data(s));
+            clock.T += driver.ValueDoubleTapMs;
+            driver.Update(Data(s));
+            clock.T += 40;
+            driver.Update(Data(s));
 
             Assert.Contains(t.Sent, IsParamDefs);         // re-decorated despite unchanged sig
         }
@@ -864,11 +870,10 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void GameExit_GatesDisplayOff_NoDisplayReset()
+        public void GameExit_ClearsFieldsToPlaceholders_StaysVisible()
         {
-            // Exit = gate-off: the screen goes dark — stale values and burn-in solved in one
-            // move. DisplayReset is not part of the lifecycle (resets were observed to degrade
-            // subsequent bring-ups, and the reset leaves the OLED lit with placeholders).
+            // Game exit clears the fields to --- (DisplayReset) and keeps the ITM page visible.
+            // No gate-off — the display never drops to legacy at idle; it stays Synced.
             var driver = MakeDriver(out var t, out var clock);
             Sync(driver, clock);               // live game, synced
             t.Sent.Clear();
@@ -876,11 +881,11 @@ namespace FanaBridge.Tests
             clock.T += 40;
             driver.Update(NotRunningData());   // game exited
 
-            Assert.Contains(t.Sent, IsItmModeOff);
-            Assert.DoesNotContain(t.Sent, IsDisplayReset);
-            Assert.False(driver.IsRunning);    // parked in TelemetryIdle
+            Assert.Contains(t.Sent, IsDisplayReset);         // fields cleared to ---
+            Assert.DoesNotContain(t.Sent, IsItmModeOff);     // no gate-off (no legacy)
+            Assert.True(driver.IsRunning);                   // stays Synced, page visible
 
-            // Idle afterwards: dormant.
+            // Idle afterwards: no repeated resets, no values from stale telemetry.
             t.Sent.Clear();
             clock.T += 500;
             driver.Update(NotRunningData());
@@ -888,19 +893,19 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void GameExit_GateOff_RetriedUntilAccepted()
+        public void GameExit_Reset_RetriedUntilAccepted()
         {
             var driver = MakeDriver(out var t, out var clock);
             Sync(driver, clock);
 
-            t.SendReturns = false;             // transport declines the gate-off
+            t.SendReturns = false;             // transport declines the reset
             clock.T += 40;
             driver.Update(NotRunningData());
             t.Sent.Clear();
 
             t.SendReturns = true;
             driver.Update(NotRunningData());   // retried and accepted
-            Assert.Contains(t.Sent, IsItmModeOff);
+            Assert.Contains(t.Sent, IsDisplayReset);
 
             t.Sent.Clear();
             driver.Update(NotRunningData());   // no repeat after success
@@ -908,30 +913,24 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void GameRestart_AfterExit_ResumesAndRepaints()
+        public void GameRestart_AfterExit_RepaintsInPlace()
         {
-            // Resume = PageSet-while-off then gate-on; the elicited push resyncs, and the
-            // repaint sends even UNCHANGED values — the display was dark and the firmware
-            // shows stale cached values until the first fresh send.
+            // The display never went dark (stayed Synced showing ---); a game returning just
+            // repaints fresh values over the placeholders — no reset, no gate cycle.
             var driver = MakeDriver(out var t, out var clock);
             var s = NewStatus();
             Set(s, "CurrentLap", 5);
             Sync(driver, clock, LapInfoPush, Data(s));
 
             clock.T += 40;
-            driver.Update(Data(s, gameRunning: false));   // exit — gate-off
+            driver.Update(Data(s, gameRunning: false));   // exit — reset to ---
             t.Sent.Clear();
 
-            clock.T += 1000;
-            driver.Update(Data(s));            // game returns: PageSet-while-off + gate-on
-            int page = t.Sent.FindIndex(IsPageSet);
-            int gateOn = t.Sent.FindIndex(IsItmModeOn);
-            Assert.True(page >= 0 && gateOn >= 0 && page < gateOn,
-                "resume sends the PageSet while off, then the gate-on");
-
-            Push(driver, clock, LapInfoPush, Data(s));    // the elicited push, identical telemetry
-
-            Assert.Contains(t.Sent, IsValueUpdate);        // repainted anyway
+            clock.T += 40;
+            driver.Update(Data(s));            // game returns with identical telemetry
+            Assert.Contains(t.Sent, IsValueUpdate);        // repainted over the ---
+            Assert.DoesNotContain(t.Sent, IsItmModeOn);    // no gate cycle
+            Assert.DoesNotContain(t.Sent, IsPageSet);      // no re-page
         }
 
         [Fact]

--- a/tests/FanaBridge.Tests/ItmDisplayDriverTests.cs
+++ b/tests/FanaBridge.Tests/ItmDisplayDriverTests.cs
@@ -438,8 +438,15 @@ namespace FanaBridge.Tests
             var driver = new ItmDisplayDriver(new ItmEncoder(t), clock.Now, logs.Add);
             Sync(driver, clock);
 
-            // The firmware announces param 9999 (outside every page layout) at handle 2.
-            Push(driver, clock, HexToBytes("ff050103820f2700"));
+            // The firmware re-announces the page with param 9999 (outside every page layout)
+            // at handle 2, in place of LAP — a set that matches no catalog page. It's held
+            // through the grace window (suspected mid-flight fragment) then adopted, and the
+            // repaint that follows encounters the unencodable param.
+            driver.OnSubscriptionReport(HexToBytes("ff050103820f2700"));
+            clock.T += 50;
+            driver.Update(EmptyData());   // accumulation judged → grace opens (uncataloged set)
+            clock.T += 120;
+            driver.Update(EmptyData());   // grace expires → adopted → repaint → 9999 logged
             clock.T += 40;
             driver.Update(EmptyData());   // ticks again — must not re-log
 

--- a/tests/FanaBridge.Tests/ItmLifecycleControllerTests.cs
+++ b/tests/FanaBridge.Tests/ItmLifecycleControllerTests.cs
@@ -410,6 +410,30 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void Switching_PushDuringQuietWindow_DefersPageSet_AdoptsThePush()
+        {
+            // A push arriving during the switch quiet window means the display is already
+            // changing (wheel button / late firmware). Don't PageSet over an accumulating push
+            // — let it be judged first; it supersedes the host request. (Guards against
+            // reintroducing the concurrent-traffic hazard the state machine is built to avoid.)
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);                                   // synced on page 1
+
+            c.RequestPage(3);                                    // host switch → Switching, quiet window
+            Tick(c, clock, 10);                                  // still within the quiet window
+            c.OnPush(UnsubAll(8).Concat(PushFor(5)).ToList());   // a wheel-button push arrives
+            Tick(c, clock, c.SwitchQuietMs - 5);                 // quiet elapsed, push still accumulating
+
+            Assert.Equal(ItmLifecycleState.Switching, c.State);  // not judged yet
+            Assert.DoesNotContain(t.Sent, IsPageSetTo(3));       // PageSet deferred, not sent over the push
+
+            Tick(c, clock, c.AccumulateWindowMs);                // the push is judged → adopts page 5
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(5, c.CurrentPage);
+            Assert.DoesNotContain(t.Sent, IsPageSetTo(3));       // host request dropped, never sent
+        }
+
+        [Fact]
         public void RequestPage_WhileSwitching_QueuedAndAppliedAfterConfirm()
         {
             var c = Make(out var t, out var clock);
@@ -658,6 +682,25 @@ namespace FanaBridge.Tests
             t.Sent.Clear();
             Tick(c, clock, 10_000);                      // inside the 30 s backoff
             Assert.Empty(t.Sent);
+        }
+
+        [Fact]
+        public void Ladder_Exhausted_EmptyBackoffList_FallsBackDoesNotThrow()
+        {
+            // UnavailableBackoffMs is publicly settable; an empty (misconfigured) list must not
+            // index out of range when the ladder exhausts — fall back to a default backoff.
+            var c = Make(out var t, out var clock);
+            c.UnavailableBackoffMs = new int[0];
+            Sync(c, t, clock);
+            EnterRecovery(c, t, clock, target: 3);
+
+            for (int i = 0; i < 4; i++)
+            {
+                Tick(c, clock, c.PageSetSpacingMs);
+                Tick(c, clock, c.PushDeadlineMs + 1);
+            }
+
+            Assert.Equal(ItmLifecycleState.Unavailable, c.State);   // reached it without throwing
         }
 
         [Fact]

--- a/tests/FanaBridge.Tests/ItmLifecycleControllerTests.cs
+++ b/tests/FanaBridge.Tests/ItmLifecycleControllerTests.cs
@@ -66,6 +66,8 @@ namespace FanaBridge.Tests
         private static bool IsGateOff(byte[] r) => r[1] == 0x05 && r[2] == 0x02 && r[3] == 0x00;
         private static bool IsEnable(byte[] r) => r[1] == 0x02 && r[2] == 0x02;
         private static bool IsPageSet(byte[] r) => r[1] == 0x05 && r[2] == 0x04;
+        private static bool IsReset(byte[] r) => r[1] == 0x05 && r[2] == 0x05 && r[3] == 0x01;
+        private static bool IsValueUpdate(byte[] r) => r[1] == 0x05 && r[2] == 0x01;
         private static Predicate<byte[]> IsPageSetTo(byte page)
             => r => r[1] == 0x05 && r[2] == 0x04 && r[4] == page;
 
@@ -467,17 +469,22 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void UnsubWithNothingFollowing_GraceExpiry_EntersRecovery()
+        public void UnsubWithNothingFollowing_GraceExpiry_AdoptsLegacyPage()
         {
+            // An unsubscribe-all with nothing following means the display moved to the legacy
+            // ITM page (no telemetry parameters) — a valid destination the wheel button reaches.
+            // Adopt it; never recover it back to a telemetry page (the "can't select legacy" bug).
             var c = Make(out var t, out var clock);
             Sync(c, t, clock);
+            t.Sent.Clear();
 
             c.OnPush(UnsubAll(6));
             Tick(c, clock, c.AccumulateWindowMs);     // grace opens
             Tick(c, clock, c.UnsubGraceMs + 1);       // nothing followed
 
-            Assert.Equal(ItmLifecycleState.Recovery, c.State);
-            Assert.Contains(t.Sent, IsPageSetTo(1));  // rung 1 re-PageSets the lost page
+            Assert.Equal(ItmLifecycleState.Synced, c.State);   // stays synced, not recovering
+            Assert.Equal(LegacyPage(), c.CurrentPage);         // adopted the legacy page
+            Assert.DoesNotContain(t.Sent, IsPageSet);          // never fought it back
         }
 
         [Fact]
@@ -748,159 +755,258 @@ namespace FanaBridge.Tests
             Assert.Equal(3, c.CurrentPage);
         }
 
-        // ── TelemetryIdle (game exit / resume) ───────────────────────────
+        // ── Idle (game exit) — clear to placeholders, stay visible, never legacy ─────────
 
         [Fact]
-        public void GameExit_GatesOff_ScreenDark()
+        public void GameExit_ClearsToPlaceholders_StaysSynced_NoGateOff()
         {
+            // A game exit clears the fields to --- (DisplayReset) and keeps the ITM page up —
+            // no gate-off, so the display never drops to legacy at idle. Stays Synced.
             var c = Make(out var t, out var clock);
             Sync(c, t, clock);
-
-            Tick(c, clock, 10, live: false);
-
-            Assert.Equal(ItmLifecycleState.TelemetryIdle, c.State);
-            Assert.Contains(t.Sent, IsGateOff);
-            Assert.False(c.ValuesAllowed);
-
-            // Dormant afterwards — no repeats, no other traffic.
             t.Sent.Clear();
-            Tick(c, clock, 5000, live: false);
+
+            Tick(c, clock, 10, live: false);                 // game exits
+
+            Assert.Contains(t.Sent, IsReset);                // fields cleared to ---
+            Assert.DoesNotContain(t.Sent, IsGateOff);        // never gate off at idle
+            Assert.Equal(ItmLifecycleState.Synced, c.State); // page stays visible
+
+            // Idle afterwards: one reset, then quiet.
+            t.Sent.Clear();
+            Tick(c, clock, 60000, live: false);
             Assert.Empty(t.Sent);
         }
 
         [Fact]
-        public void GameExit_GateOffDeclined_Retried()
+        public void GameExit_ResetDeclined_Retried()
         {
             var c = Make(out var t, out var clock);
             Sync(c, t, clock);
+            t.Sent.Clear();
 
             t.SendReturns = false;
-            Tick(c, clock, 10, live: false);
+            Tick(c, clock, 10, live: false);                 // reset declined
             t.Sent.Clear();
 
             t.SendReturns = true;
-            Tick(c, clock, 10, live: false);
-            Assert.Contains(t.Sent, IsGateOff);
+            Tick(c, clock, 10, live: false);                 // retried and accepted
+            Assert.Contains(t.Sent, IsReset);
         }
 
         [Fact]
-        public void Resume_PageSetWhileOff_ThenGateOn_NeverBare()
+        public void GameReturn_OnDefaultPage_RepaintsInPlace_NoGateCycle()
         {
+            // Already on the starting page: a game returning just repaints over the --- —
+            // no reset, no gate cycle, no re-page.
             var c = Make(out var t, out var clock);
-            Sync(c, t, clock);                            // synced on page 1
-            Tick(c, clock, 10, live: false);              // exit → gate-off
+            Sync(c, t, clock);                               // synced on page 1 (the default)
+            Tick(c, clock, 10, live: false);                 // exit → cleared to ---
+            int gen = c.SyncGeneration;
             t.Sent.Clear();
 
-            Tick(c, clock, 5000, live: true);             // game returns
+            Tick(c, clock, 1000, live: true);                // game returns
 
-            int page = t.Sent.FindIndex(r => IsPageSetTo(1)(r));
-            int on = t.Sent.FindIndex(IsGateOn);
-            Assert.True(page >= 0 && on >= 0, "resume sends PageSet and gate-on");
-            Assert.True(page < on, "PageSet goes out while gated off, before the gate-on");
-            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
-
-            c.OnPush(PushFor(1));                         // the elicited push (fresh handles)
-            Tick(c, clock, c.AccumulateWindowMs);
             Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.DoesNotContain(t.Sent, IsGateOff);
+            Assert.DoesNotContain(t.Sent, IsGateOn);         // no gate cycle
+            Assert.DoesNotContain(t.Sent, IsPageSet);        // already on the starting page
+            Assert.True(c.SyncGeneration > gen);             // repaint forced over the ---
         }
 
         [Fact]
-        public void Resume_WithoutPush_MustNotSelfConfirm()
+        public void GameStart_OffStartingPage_SwitchesBackToIt()
         {
-            // The handle map still holds the pre-exit page's subscriptions; a resume to the
-            // same page must not read that stale state as confirmation — only a push counts.
+            // The starting (default) page is re-established each game launch: if the wheel
+            // button left the display on a different page across the launch, a game starting
+            // switches back to the starting page.
             var c = Make(out var t, out var clock);
-            Sync(c, t, clock);
-            Tick(c, clock, 10, live: false);
-            Tick(c, clock, 5000, live: true);             // resume commands out, NO push
+            c.DefaultPage = 1;
+            Sync(c, t, clock);                               // synced on page 1
 
-            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
-            Tick(c, clock, c.PushDeadlineMs + 1);
-            Assert.Equal(ItmLifecycleState.Recovery, c.State);
-        }
-
-        [Fact]
-        public void Resume_RestoresLastKnownPage()
-        {
-            var c = Make(out var t, out var clock);
-            Sync(c, t, clock);
-
-            // Wheel button moved the display to page 5 before the exit.
-            c.OnPush(UnsubAll(6).Concat(PushFor(5)).ToList());
+            // Wheel button moved to page 5 during the last session.
+            c.OnPush(UnsubAll(8).Concat(PushFor(5)).ToList());
             Tick(c, clock, c.AccumulateWindowMs);
             Assert.Equal(5, c.CurrentPage);
 
-            Tick(c, clock, 10, live: false);              // exit
+            Tick(c, clock, 10, live: false);                 // game exits → cleared, on page 5
             t.Sent.Clear();
-            Tick(c, clock, 5000, live: true);             // resume
 
-            Assert.Contains(t.Sent, IsPageSetTo(5));      // the page survives the exit
+            Tick(c, clock, 1000, live: true);                // a game starts
+            Assert.Equal(ItmLifecycleState.Switching, c.State);   // switching back to the default
+            Tick(c, clock, c.SwitchQuietMs + c.PageSetSpacingMs);
+            Assert.Contains(t.Sent, IsPageSetTo(1));
+
+            c.OnPush(UnsubAll(8).Concat(PushFor(1)).ToList());
+            Tick(c, clock, c.AccumulateWindowMs);
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(1, c.CurrentPage);
         }
 
         [Fact]
-        public void RequestPage_WhileTelemetryIdle_ChangesResumePage()
+        public void GameExit_DuringRecovery_LetsTheProcedureResolve()
         {
-            var c = Make(out var t, out var clock);
-            Sync(c, t, clock);
-            Tick(c, clock, 10, live: false);
-            t.Sent.Clear();
-
-            c.RequestPage(4);                              // setting changed while dark
-            Tick(c, clock, 100, live: false);
-            Assert.Empty(t.Sent);                          // nothing on the wire while off
-
-            Tick(c, clock, 5000, live: true);
-            Assert.Contains(t.Sent, IsPageSetTo(4));
-        }
-
-        [Fact]
-        public void GameExit_DuringRecovery_ParksInTelemetryIdle()
-        {
-            // An exit mid-ladder abandons the ladder: gate-off now, and the resume shape —
-            // the strongest recovery there is — re-establishes everything later.
+            // A mid-transition exit (not Synced) doesn't clear or gate off — the in-flight
+            // recovery keeps running (it just isn't fed values), and resolves on its own.
             var c = Make(out var t, out var clock);
             Sync(c, t, clock);
             EnterRecovery(c, t, clock);
+            t.Sent.Clear();
 
             Tick(c, clock, 10, live: false);
 
-            Assert.Equal(ItmLifecycleState.TelemetryIdle, c.State);
-            Assert.Contains(t.Sent, IsGateOff);
+            Assert.Equal(ItmLifecycleState.Recovery, c.State);   // still recovering
+            Assert.DoesNotContain(t.Sent, IsGateOff);
+            Assert.DoesNotContain(t.Sent, IsReset);
         }
 
         [Fact]
-        public void BringUp_WithoutLiveTelemetry_StillRuns()
+        public void BringUp_WithoutLiveTelemetry_ClearsToPlaceholders_StaysSynced()
         {
-            // ITM is always-on: bring-up runs at connect so the default page (and the settings
-            // panel's live preview) works before any game has run. TelemetryIdle is entered
-            // only on a live→dead edge, never because telemetry simply hasn't started yet.
+            // Bring-up at connect with no game comes up clean (DisplayReset clears any stale
+            // cache) and stays on the page showing --- — no auto-off, no gate-off.
             var c = Make(out var t, out var clock);
             c.Start();
             c.Tick(false);
-
+            Assert.Contains(t.Sent, IsReset);                // cold entry clears the stale cache
             Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
+
             c.OnPush(PushFor(1));
             Tick(c, clock, c.AccumulateWindowMs, live: false);
+            Assert.Equal(ItmLifecycleState.Synced, c.State); // up, showing placeholders
+
+            t.Sent.Clear();
+            Tick(c, clock, 60000, live: false);              // no game → stays lit, no gate-off
             Assert.Equal(ItmLifecycleState.Synced, c.State);
             Assert.DoesNotContain(t.Sent, IsGateOff);
         }
 
-        [Fact]
-        public void PushWhileGatedOff_AdoptedButNoTransition()
+        // ── Legacy ITM page (no telemetry parameters) ────────────────────
+
+        // The legacy page's wire number on the standard device (device 3).
+        private static byte LegacyPage()
         {
-            // A push while we hold the display off means another program gated it on —
-            // adopt the data (never fight), stay parked.
-            var c = Make(out var t, out var clock, out var logs);
-            Sync(c, t, clock);
-            Tick(c, clock, 10, live: false);
+            foreach (var p in ItmDeviceCatalog.PagesFor(3))
+                if (p.IsLegacy) return p.Number;
+            throw new InvalidOperationException("no legacy page");
+        }
+
+        [Fact]
+        public void DefaultPageLegacy_BringUp_ConfirmsOnEmptyPush()
+        {
+            // Default page = Legacy: the legacy page carries no parameters, so its PageSet
+            // pushes only an unsubscribe-all. That IS its confirmation — not a dropped-subs
+            // failure that recovers away. (The "default page Legacy goes sideways" bug.)
+            byte legacy = LegacyPage();
+            var c = Make(out var t, out var clock);
+            c.DefaultPage = legacy;
+            c.Start();
+            c.Tick(true);
+            Assert.Contains(t.Sent, IsPageSetTo(legacy));
+
+            c.OnPush(UnsubAll(8));                            // the legacy page's empty push
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(legacy, c.CurrentPage);
+        }
+
+        [Fact]
+        public void DefaultPageLegacy_BringUp_ConfirmsOnMissedPush()
+        {
+            // If the display is already on the legacy page, the PageSet pushes nothing at all.
+            // A missed push on a legacy target means we're on legacy — confirm, don't recover.
+            byte legacy = LegacyPage();
+            var c = Make(out var t, out var clock);
+            c.DefaultPage = legacy;
+            c.Start();
+            c.Tick(true);
             t.Sent.Clear();
 
-            c.OnPush(PushFor(2));
-            Tick(c, clock, c.AccumulateWindowMs, live: false);
+            Tick(c, clock, c.PushDeadlineMs + 1);            // no push arrives
 
-            Assert.Equal(ItmLifecycleState.TelemetryIdle, c.State);
-            Assert.Empty(t.Sent);
-            Assert.Contains(logs, m => m.Contains("another program"));
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(legacy, c.CurrentPage);
+            Assert.DoesNotContain(t.Sent, IsPageSet);        // did NOT recover to a telemetry page
+        }
+
+        [Fact]
+        public void WheelButtonToLegacy_Adopted_NotRecoveredAway()
+        {
+            // Synced on a telemetry page, the user presses the wheel button to the legacy page:
+            // the firmware sends an unsubscribe-all with nothing following. Adopt "on legacy" —
+            // never re-PageSet back to a telemetry page. (The "can't select legacy" bug.)
+            byte legacy = LegacyPage();
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);                               // synced on page 1
+            t.Sent.Clear();
+
+            c.OnPush(UnsubAll(8));                            // wheel button → legacy (empty push)
+            Tick(c, clock, c.AccumulateWindowMs);            // unsub-only → grace opens
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+
+            Tick(c, clock, c.UnsubGraceMs + 1);              // nothing follows → adopt legacy
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(legacy, c.CurrentPage);
+            Assert.DoesNotContain(t.Sent, IsPageSet);        // did NOT fight it back to telemetry
+        }
+
+        [Fact]
+        public void ColdEntry_InvalidDefaultPage_FallsBackToARealPage()
+        {
+            // A 0 (unset) or out-of-range starting page must never become PageSet(0) or a
+            // target no push can confirm — bring-up falls back to the device's first page.
+            var c = Make(out var t, out var clock);
+            c.DefaultPage = 0;
+            c.Start();
+            c.Tick(true);
+
+            var pageSet = t.Sent.FirstOrDefault(IsPageSet);
+            Assert.NotNull(pageSet);
+            Assert.NotEqual(0, pageSet[4]);   // byte 4 = page number, never 0
+        }
+
+        [Fact]
+        public void ArmedForLegacy_NonEmptyPush_AdoptsThatPage_NotLegacy()
+        {
+            // Armed for the legacy page (starting page = legacy), a NON-empty telemetry push
+            // must not be mistaken for the legacy page's empty confirmation — it's a real
+            // telemetry page (a straggler re-push, or the page gate-on landed on). Adopt it as
+            // itself, never confirm "on legacy" while holding telemetry subscriptions.
+            byte legacy = LegacyPage();
+            var c = Make(out var t, out var clock);
+            c.DefaultPage = legacy;
+            c.Start();
+            c.Tick(true);                                // bring-up armed for legacy
+            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
+
+            c.OnPush(PushFor(2));                        // a telemetry page pushes instead
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(2, c.CurrentPage);              // adopted page 2, not mislabeled legacy
+            Assert.Equal(ParamsOf(2).Count, c.SubscriptionCount);   // page 2's real params
+        }
+
+        [Fact]
+        public void FromLegacy_WheelButtonToTelemetryPage_Adopted()
+        {
+            // From the legacy page, the wheel button to a telemetry page pushes its full set —
+            // adopt it normally.
+            byte legacy = LegacyPage();
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            c.OnPush(UnsubAll(8));
+            Tick(c, clock, c.AccumulateWindowMs);
+            Tick(c, clock, c.UnsubGraceMs + 1);              // now on legacy
+            Assert.Equal(legacy, c.CurrentPage);
+
+            c.OnPush(PushFor(2));                            // wheel button → a telemetry page
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(2, c.CurrentPage);
         }
 
         // ── User enable/disable ──────────────────────────────────────────
@@ -1195,22 +1301,22 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void WheelChange_WhileTelemetryIdle_StaysDark()
+        public void WheelChange_WhileIdle_ColdRestarts()
         {
-            // A hot-swap while parked dark (game exited) must not light the display with no
-            // game running — it re-asserts gate-off and waits for the resume shape.
+            // A hot-swap while idle (game exited, display showing --- on the ITM page) is a
+            // cold event — drop the old wheel's handles and re-run the full bring-up.
             var c = Make(out var t, out var clock);
             Sync(c, t, clock);
-            Tick(c, clock, 10, live: false);        // game exit → TelemetryIdle (gate-off)
+            Tick(c, clock, 10, live: false);        // game exit → cleared to ---, still Synced
             t.Sent.Clear();
 
             c.OnWheelChanged();
+            Assert.Equal(0, c.SubscriptionCount);   // old wheel's handles dropped
             Tick(c, clock, c.PageSetSpacingMs, live: false);
 
-            Assert.Equal(ItmLifecycleState.TelemetryIdle, c.State);
-            Assert.Contains(t.Sent, IsGateOff);
-            Assert.DoesNotContain(t.Sent, IsGateOn);   // never lit while dark
-            Assert.Equal(0, c.SubscriptionCount);      // old wheel's handles dropped
+            Assert.Contains(t.Sent, IsGateOn);      // full cold bring-up
+            Assert.Contains(t.Sent, IsPageSet);
+            Assert.DoesNotContain(t.Sent, IsValueUpdate);   // nothing until the fresh push
         }
 
         [Fact]

--- a/tests/FanaBridge.Tests/ItmLifecycleControllerTests.cs
+++ b/tests/FanaBridge.Tests/ItmLifecycleControllerTests.cs
@@ -716,10 +716,11 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void Recovery_TargetPushDuringFlipAway_ConfirmsDirectly()
+        public void Recovery_TargetPushDuringFlipAway_DoesNotConfirmMidFlip()
         {
-            // A late push from an earlier rung can land while the flip is in flight; if it is
-            // the target's set, the recovery is simply done.
+            // A late push for the TARGET can land while the flip is in flight — but the flip
+            // PageSet is already accepted, so the display is about to move again. Confirming
+            // now would resume values mid-transition; instead the flip completes normally.
             var c = Make(out var t, out var clock);
             Sync(c, t, clock);
             EnterRecovery(c, t, clock, target: 3);
@@ -729,9 +730,20 @@ namespace FanaBridge.Tests
             Tick(c, clock, c.PushDeadlineMs + 1);
             Tick(c, clock, c.PageSetSpacingMs);          // flip-away out (expects page 1)
 
-            c.OnPush(UnsubAll(6).Concat(PushFor(3)).ToList());   // but the TARGET pushes
+            // UnsubAll(8) clears every handle a page might occupy (page 3 uses 7), mirroring
+            // how the firmware unsubscribes the whole outgoing page on each change.
+            c.OnPush(UnsubAll(8).Concat(PushFor(3)).ToList());   // late TARGET push
             Tick(c, clock, c.AccumulateWindowMs);
+            Assert.Equal(ItmLifecycleState.Recovery, c.State);   // not confirmed mid-flip
+            Assert.False(c.ValuesAllowed);
 
+            c.OnPush(UnsubAll(8).Concat(PushFor(1)).ToList());   // the flip page's push
+            Tick(c, clock, c.AccumulateWindowMs);
+            Tick(c, clock, c.PageSetSpacingMs);                   // flip-back PageSet out
+            Assert.Contains(t.Sent, IsPageSetTo(3));
+
+            c.OnPush(UnsubAll(8).Concat(PushFor(3)).ToList());   // target confirms
+            Tick(c, clock, c.AccumulateWindowMs);
             Assert.Equal(ItmLifecycleState.Synced, c.State);
             Assert.Equal(3, c.CurrentPage);
         }
@@ -1045,6 +1057,183 @@ namespace FanaBridge.Tests
             Sync(c, t, clock);
             Assert.Contains("page 1", c.Describe());
             Assert.Contains("6 params", c.Describe());
+        }
+
+        // ── Regressions (review findings) ────────────────────────────────
+
+        [Fact]
+        public void Start_HonorsDefaultPageSetBeforeFirstTick()
+        {
+            // Start() defers the cold entry to the next Tick, so a DefaultPage assigned after
+            // Start() but before Tick() (the device instance's frame order) is still honored —
+            // otherwise bring-up targets the ctor default and the configured page is ignored.
+            var c = Make(out var t, out _);
+            c.Start();
+            c.DefaultPage = 5;      // configured page arrives after Start(), before the tick
+            c.Tick(true);
+
+            Assert.Contains(t.Sent, IsPageSetTo(5));
+            Assert.DoesNotContain(t.Sent, IsPageSetTo(1));
+        }
+
+        [Fact]
+        public void UserOff_ReassertedAfterReconnect()
+        {
+            // The user's "off" must be re-enforced after a reconnect: the re-appearing device
+            // (power cycle, re-seat) comes up with whatever gate setting persisted, not
+            // necessarily off. Edge-only application would send nothing on reconnect.
+            var c = Make(out var t, out var clock);
+            c.SetUserEnabled(false);
+            c.Tick(true);
+            Assert.Contains(t.Sent, IsGateOff);
+
+            c.Stop();               // connection lost
+            t.Sent.Clear();
+
+            c.SetUserEnabled(false);   // same setting, fresh connection
+            c.Tick(true);
+            Assert.Contains(t.Sent, IsGateOff);   // re-asserted, not skipped as unchanged
+        }
+
+        [Fact]
+        public void WheelChange_DropsOpenAccumulation_NoSelfConfirm()
+        {
+            // A push that arrived just before the wheel changed (still accumulating) must not
+            // survive the cold restart and confirm the NEW wheel's bring-up against the OLD
+            // wheel's page.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.OnPush(PushFor(1));   // old wheel re-pushes page 1; accumulation opens
+            c.OnWheelChanged();     // ...and the wheel is swapped mid-window
+            Assert.Equal(0, c.SubscriptionCount);   // old handles dropped
+
+            Tick(c, clock, c.AccumulateWindowMs + 10);   // the stale window must not be judged
+            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);   // still awaiting the NEW push
+            Assert.False(c.ValuesAllowed);
+        }
+
+        [Fact]
+        public void StalePreSwapReports_DrainedAfterColdEntry_DoNotSelfConfirm()
+        {
+            // The device instance drains buffered pushes AFTER OnWheelChanged. A stale report
+            // from the old wheel (same param set as the bring-up target) fed post-restart must
+            // not confirm the new wheel's bring-up without a genuine fresh push.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.OnWheelChanged();                 // cold restart; bring-up queued
+            Tick(c, clock, c.PageSetSpacingMs); // bring-up drains, expectation armed for page 1
+            c.OnPush(PushFor(1));               // a STALE page-1 report from the old wheel
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            // It matches the armed page, so by protocol it is indistinguishable from a genuine
+            // page-1 push — confirmation is correct here. The guarantee under test is the
+            // buffer being CLEARED on wheel change (FanatecWheelbase), so this stale report
+            // never reaches the controller in production; see the wheelbase test.
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+        }
+
+        [Fact]
+        public void Switching_StragglerRepushOfCurrentPage_DoesNotCancelSwitch()
+        {
+            // A straggler re-announcement of the page we're LEAVING (not a user action) must
+            // not be mistaken for a wheel-button change and silently cancel the host switch.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);   // synced on page 1
+
+            c.RequestPage(3);
+            Tick(c, clock, c.SwitchQuietMs + c.PageSetSpacingMs);   // PageSet(3) out
+            c.OnPush(PushFor(1));   // straggler re-push of the CURRENT page (1)
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Switching, c.State);   // switch NOT cancelled
+            c.OnPush(UnsubAll(8).Concat(PushFor(3)).ToList());     // the real page-3 push
+            Tick(c, clock, c.AccumulateWindowMs);
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(3, c.CurrentPage);
+        }
+
+        [Fact]
+        public void Synced_FragmentMatchingNoPage_SuspendsValues_NoForcedRepaint()
+        {
+            // A wheel-button change fragmented slower than the accumulation window leaves a
+            // set matching no page. It must suspend values (grace) and wait for the rest, not
+            // force-repaint onto a half-rebound handle map.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            int gen = c.SyncGeneration;
+
+            // First fragment: unsubscribe page 1's h2 (LAP) and leave a partial set.
+            c.OnPush(new List<ItmSubscription> { new ItmSubscription(2, ItmParam.Unsubscribe) });
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.False(c.ValuesAllowed);              // suspended, not streaming
+            Assert.Equal(gen, c.SyncGeneration);        // no forced repaint
+
+            // The rest of the change lands within grace → adopted as the new page.
+            c.OnPush(UnsubAll(8).Concat(PushFor(4)).ToList());
+            Tick(c, clock, c.AccumulateWindowMs);
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(4, c.CurrentPage);
+            Assert.True(c.ValuesAllowed);
+        }
+
+        [Fact]
+        public void GraceWindow_SuspendsValues()
+        {
+            // Grace opens on an unsubscribe-only push in Synced (the front half of a page
+            // change). Values must be suspended for its duration — the firmware may be
+            // re-binding the surviving handles.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            Assert.True(c.ValuesAllowed);
+
+            c.OnPush(UnsubAll(6));
+            Tick(c, clock, c.AccumulateWindowMs);   // unsub-only judged → grace opens
+            Assert.False(c.ValuesAllowed);          // suspended through grace
+        }
+
+        [Fact]
+        public void WheelChange_WhileTelemetryIdle_StaysDark()
+        {
+            // A hot-swap while parked dark (game exited) must not light the display with no
+            // game running — it re-asserts gate-off and waits for the resume shape.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            Tick(c, clock, 10, live: false);        // game exit → TelemetryIdle (gate-off)
+            t.Sent.Clear();
+
+            c.OnWheelChanged();
+            Tick(c, clock, c.PageSetSpacingMs, live: false);
+
+            Assert.Equal(ItmLifecycleState.TelemetryIdle, c.State);
+            Assert.Contains(t.Sent, IsGateOff);
+            Assert.DoesNotContain(t.Sent, IsGateOn);   // never lit while dark
+            Assert.Equal(0, c.SubscriptionCount);      // old wheel's handles dropped
+        }
+
+        [Fact]
+        public void Subscriptions_SnapshotStableUntilNextPush()
+        {
+            // The handle map is exposed as a cached snapshot (allocation-free per-frame reads);
+            // it must reflect the latest push and refresh when the map changes.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            var first = c.Subscriptions;
+            Assert.Same(first, c.Subscriptions);       // same instance until the map changes
+            Assert.Equal(6, first.Count);
+
+            Push(c, clock, UnsubAll(8).Concat(PushFor(5)).ToList());
+            Assert.NotSame(first, c.Subscriptions);    // rebuilt after the push
+            Assert.Equal(6, c.Subscriptions.Count);    // page 5 (tyres) — 6 params
+        }
+
+        // Delivers a push mid-session and runs the judgment tick.
+        private static void Push(ItmLifecycleController c, Clock clock, List<ItmSubscription> entries)
+        {
+            c.OnPush(entries);
+            Tick(c, clock, c.AccumulateWindowMs);
         }
     }
 }

--- a/tests/FanaBridge.Tests/ItmLifecycleControllerTests.cs
+++ b/tests/FanaBridge.Tests/ItmLifecycleControllerTests.cs
@@ -1,0 +1,1050 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FanaBridge.Protocol;
+using FanaBridge.Transport;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// Exercises every state transition, recovery rung, deadline, and the push-accumulation
+    /// window of <see cref="ItmLifecycleController"/>. The scenarios mirror the hardware
+    /// behavior the design is built on (see docs/reference/protocol.md, "ITM Display"):
+    /// pushes are the only acknowledgment, values are suspended around switches, exits gate
+    /// the display off, resumes send the PageSet while off, and unexpected pushes are
+    /// adopted in every state.
+    /// </summary>
+    public class ItmLifecycleControllerTests
+    {
+        // ── Test doubles ─────────────────────────────────────────────────
+
+        private class RecordingTransport : IDeviceTransport
+        {
+            public bool IsConnected { get; set; } = true;
+            public int Col03MaxInputReportLength { get; set; } = 64;
+            public List<byte[]> Sent { get; } = new List<byte[]>();
+            public bool SendReturns { get; set; } = true;
+            public Func<byte[], bool>? Decide { get; set; }
+
+            public bool SendCol03(byte[] data)
+            {
+                var copy = new byte[data.Length];
+                Array.Copy(data, copy, data.Length);
+                Sent.Add(copy);
+                return Decide?.Invoke(copy) ?? SendReturns;
+            }
+
+            public bool SendCol01(byte[] data) => true;
+            public IReportStream IdentityReports => FakeReportStream.Empty;
+            public IReportStream ItmReports => FakeReportStream.Empty;
+            public IReportStream SrmReports => FakeReportStream.Empty;
+            public IReportStream TuningReports => FakeReportStream.Empty;
+            public int ReadCol01(byte[] buffer, int timeoutMs) => -1;
+            public int Col01MaxInputReportLength => 34;
+            public IDisposable BeginBatch() => new NoOp();
+            private sealed class NoOp : IDisposable { public void Dispose() { } }
+        }
+
+        private sealed class Clock { public long T; public long Now() => T; }
+
+        private static ItmLifecycleController Make(out RecordingTransport t, out Clock clock,
+            out List<string> logs, byte deviceId = 3)
+        {
+            t = new RecordingTransport();
+            clock = new Clock();
+            var l = new List<string>();
+            logs = l;
+            return new ItmLifecycleController(new ItmEncoder(t), deviceId, clock.Now, l.Add);
+        }
+
+        private static ItmLifecycleController Make(out RecordingTransport t, out Clock clock)
+            => Make(out t, out clock, out _);
+
+        // ── Wire frame classifiers (col03: [0]=0xFF, [1]=class, [2]=subcmd) ──
+        private static bool IsGateOn(byte[] r) => r[1] == 0x05 && r[2] == 0x02 && r[3] == 0x01;
+        private static bool IsGateOff(byte[] r) => r[1] == 0x05 && r[2] == 0x02 && r[3] == 0x00;
+        private static bool IsEnable(byte[] r) => r[1] == 0x02 && r[2] == 0x02;
+        private static bool IsPageSet(byte[] r) => r[1] == 0x05 && r[2] == 0x04;
+        private static Predicate<byte[]> IsPageSetTo(byte page)
+            => r => r[1] == 0x05 && r[2] == 0x04 && r[4] == page;
+
+        // ── Push builders (parsed entries, as the driver would hand them over) ──
+
+        private static IReadOnlyList<ushort> ParamsOf(byte page, byte deviceId = 3)
+        {
+            foreach (var p in ItmDeviceCatalog.PagesFor(deviceId))
+                if (p.Number == page)
+                    return p.Params;
+            throw new InvalidOperationException("no such page " + page);
+        }
+
+        // The full subscription push for a page: params at handles firstHandle..N-1. The
+        // handle base is arbitrary on real hardware (allocation is setup-specific), which is
+        // exactly why matching is on the param set.
+        private static List<ItmSubscription> PushFor(byte page, byte firstHandle = 0, byte deviceId = 3)
+        {
+            var ps = ParamsOf(page, deviceId);
+            var list = new List<ItmSubscription>();
+            for (int i = 0; i < ps.Count; i++)
+                list.Add(new ItmSubscription((byte)(firstHandle + i), ps[i], 0x12));
+            return list;
+        }
+
+        private static List<ItmSubscription> UnsubAll(int handles, byte firstHandle = 0)
+        {
+            var list = new List<ItmSubscription>();
+            for (int i = 0; i < handles; i++)
+                list.Add(new ItmSubscription((byte)(firstHandle + i), ItmParam.Unsubscribe));
+            return list;
+        }
+
+        // ── Flow helpers ─────────────────────────────────────────────────
+
+        private static void Tick(ItmLifecycleController c, Clock clock, long advance = 0, bool live = true)
+        {
+            clock.T += advance;
+            c.Tick(live);
+        }
+
+        // Start + bring-up + confirming push: lands the controller in Synced on DefaultPage.
+        private static void Sync(ItmLifecycleController c, RecordingTransport t, Clock clock, bool live = true)
+        {
+            c.Start();
+            c.Tick(live);                              // bring-up commands drain, deadline armed
+            c.OnPush(PushFor(c.DefaultPage));
+            Tick(c, clock, c.AccumulateWindowMs, live);   // accumulation closes → confirmed
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            t.Sent.Clear();
+        }
+
+        // ── Bring-up ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void Start_SendsGateEnablePageSet_InOrder_ThenAwaitsPush()
+        {
+            var c = Make(out var t, out _);
+            c.Start();
+            c.Tick(true);
+
+            int gate = t.Sent.FindIndex(IsGateOn);
+            int enable = t.Sent.FindIndex(IsEnable);
+            int page = t.Sent.FindIndex(IsPageSet);
+            Assert.True(gate >= 0 && enable >= 0 && page >= 0, "all three bring-up frames sent");
+            Assert.True(gate < enable && enable < page, "order: gate → enable → PageSet");
+            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
+            Assert.False(c.ValuesAllowed);
+        }
+
+        [Fact]
+        public void Start_TargetsConfiguredDefaultPage()
+        {
+            var c = Make(out var t, out _);
+            c.DefaultPage = 5;
+            c.Start();
+            c.Tick(true);
+
+            Assert.Contains(t.Sent, IsPageSetTo(5));
+        }
+
+        [Fact]
+        public void BringUp_PushMatchingTarget_Syncs_AndAdoptsHandles()
+        {
+            var c = Make(out var t, out var clock);
+            c.Start();
+            c.Tick(true);
+
+            // Handles from an arbitrary base (6..11) — allocation is setup-specific, so
+            // confirmation must match on the param set and adopt whatever handles came.
+            c.OnPush(PushFor(1, firstHandle: 6));
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(1, c.CurrentPage);
+            Assert.Equal(1, c.SyncGeneration);
+            Assert.True(c.ValuesAllowed);
+            var handles = c.Subscriptions.Select(kv => (int)kv.Key).ToList();
+            Assert.Equal(new[] { 6, 7, 8, 9, 10, 11 }, handles);
+            // The declared dataType travels with the adoption.
+            Assert.All(c.Subscriptions, kv => Assert.Equal(0x12, kv.Value.DataType));
+        }
+
+        [Fact]
+        public void BringUp_NoSeeding_NoValuesBeforePush()
+        {
+            // Values sent at guessed handles are ignored at best and — after a page change —
+            // can land on re-bound parameters. There is no pre-push seed.
+            var c = Make(out var t, out var clock);
+            c.Start();
+            Tick(c, clock, 100);
+
+            Assert.Equal(0, c.SubscriptionCount);
+            Assert.False(c.ValuesAllowed);
+        }
+
+        [Fact]
+        public void BringUp_DeclinedWrites_RetriedUntilAccepted()
+        {
+            var c = Make(out var t, out var clock);
+            t.SendReturns = false;
+            c.Start();
+            c.Tick(true);
+            Assert.Equal(ItmLifecycleState.BringUp, c.State);   // stuck on the first step
+            t.Sent.Clear();
+
+            t.SendReturns = true;
+            Tick(c, clock, 10);
+            Assert.Contains(t.Sent, IsGateOn);
+            Assert.Contains(t.Sent, IsEnable);
+            Assert.Contains(t.Sent, IsPageSet);
+            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
+        }
+
+        [Fact]
+        public void BringUp_AcceptedSteps_NotResent_OnRetry()
+        {
+            var c = Make(out var t, out var clock);
+            t.Decide = r => !IsPageSet(r);   // gate + enable accepted, PageSet declined
+            c.Start();
+            c.Tick(true);
+            Assert.Equal(ItmLifecycleState.BringUp, c.State);
+            t.Sent.Clear();
+
+            t.Decide = null;
+            Tick(c, clock, 10);
+            Assert.DoesNotContain(t.Sent, IsGateOn);
+            Assert.DoesNotContain(t.Sent, IsEnable);
+            Assert.Contains(t.Sent, IsPageSet);
+        }
+
+        [Fact]
+        public void BringUp_PushDeadlineMissed_EntersRecovery()
+        {
+            // A PageSet to the page the display is already on correctly pushes nothing, so a
+            // restart onto the current page looks exactly like a lost command — the ladder
+            // (ending in flip-away-and-back) disambiguates.
+            var c = Make(out var t, out var clock);
+            c.Start();
+            c.Tick(true);
+            t.Sent.Clear();
+
+            Tick(c, clock, c.PushDeadlineMs + 1);
+
+            Assert.Equal(ItmLifecycleState.Recovery, c.State);
+        }
+
+        [Fact]
+        public void Push_FragmentedAcrossReports_JudgedOnce()
+        {
+            // One tested setup delivers a push as one entry per report over ~15 ms; the
+            // accumulation window must join them into a single judgment.
+            var c = Make(out var t, out var clock);
+            c.Start();
+            c.Tick(true);
+
+            var full = PushFor(1);
+            foreach (var entry in full)
+            {
+                c.OnPush(new List<ItmSubscription> { entry });
+                Tick(c, clock, 2);
+            }
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(1, c.SyncGeneration);   // exactly one adoption event
+            Assert.Equal(6, c.SubscriptionCount);
+        }
+
+        [Fact]
+        public void Push_PartialSet_DoesNotConfirm()
+        {
+            // Half a page's params is not a match — the deadline (not the fragment) decides.
+            var c = Make(out var t, out var clock);
+            c.Start();
+            c.Tick(true);
+
+            var half = PushFor(1).Take(3).ToList();
+            c.OnPush(half);
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
+        }
+
+        [Fact]
+        public void BringUp_PushForDifferentPage_Adopted()
+        {
+            // An unexpected push is adopted in every state — the firmware is the source of
+            // truth and is never fought.
+            var c = Make(out var t, out var clock);
+            c.Start();
+            c.Tick(true);
+
+            c.OnPush(PushFor(4));
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(4, c.CurrentPage);
+        }
+
+        [Fact]
+        public void Push_ArrivingWhileCommandsStillDeclined_ConfirmsAtDrain()
+        {
+            // The push can beat the tail of the command sequence (a declined write being
+            // retried). It is adopted immediately and confirms once the sequence completes.
+            var c = Make(out var t, out var clock);
+            t.Decide = r => !IsPageSet(r);       // PageSet keeps being declined
+            c.Start();
+            c.Tick(true);
+
+            c.OnPush(PushFor(1));                 // push lands mid-procedure
+            Tick(c, clock, c.AccumulateWindowMs); // accumulation judged; transition deferred
+            Assert.Equal(ItmLifecycleState.BringUp, c.State);
+
+            t.Decide = null;
+            Tick(c, clock, 10);                   // PageSet finally accepted → confirm
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+        }
+
+        // ── Switching (host page requests) ───────────────────────────────
+
+        [Fact]
+        public void RequestPage_SuspendsValues_QuietWindow_ThenPageSet()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.RequestPage(3);
+            Assert.Equal(ItmLifecycleState.Switching, c.State);
+            Assert.False(c.ValuesAllowed);        // suspended from the request instant
+
+            Tick(c, clock, c.SwitchQuietMs - 10);
+            Assert.DoesNotContain(t.Sent, IsPageSet);   // still inside the quiet window
+
+            Tick(c, clock, 20);                    // quiet window over (and past PageSet spacing)
+            Assert.Contains(t.Sent, IsPageSetTo(3));
+        }
+
+        [Fact]
+        public void RequestPage_SamePage_Ignored()
+        {
+            // A PageSet to the current page pushes nothing (hardware-consistent), which would
+            // guarantee a pointless recovery — never ask for one.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.RequestPage(c.CurrentPage);
+            Tick(c, clock, 500);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Empty(t.Sent);
+        }
+
+        [Fact]
+        public void Switch_PushConfirms_ResumesValues()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            int gen = c.SyncGeneration;
+
+            c.RequestPage(3);
+            Tick(c, clock, c.SwitchQuietMs + c.PageSetSpacingMs);
+            c.OnPush(UnsubAll(6).Concat(PushFor(3)).ToList());
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(3, c.CurrentPage);
+            Assert.Equal(gen + 1, c.SyncGeneration);
+            Assert.True(c.ValuesAllowed);
+        }
+
+        [Fact]
+        public void Switch_NoPush_EntersRecovery()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.RequestPage(3);
+            Tick(c, clock, c.SwitchQuietMs + c.PageSetSpacingMs);   // PageSet out
+            Tick(c, clock, c.PushDeadlineMs + 1);
+
+            Assert.Equal(ItmLifecycleState.Recovery, c.State);
+            Assert.False(c.ValuesAllowed);
+        }
+
+        [Fact]
+        public void PageSets_RespectSpacingFloor()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);                 // bring-up PageSet accepted at T=0
+            c.SwitchQuietMs = 10;              // quiet window shorter than the spacing floor
+
+            c.RequestPage(3);
+            Tick(c, clock, 20);                // quiet over, but only ~70 ms since last PageSet
+            Assert.DoesNotContain(t.Sent, IsPageSet);
+
+            Tick(c, clock, c.PageSetSpacingMs);   // spacing satisfied now
+            Assert.Contains(t.Sent, IsPageSetTo(3));
+        }
+
+        [Fact]
+        public void WheelButtonPush_DuringSwitch_Adopted_HostRequestDropped()
+        {
+            // The user pressed the wheel button while our switch was in flight: adopt, never
+            // fight — the queued host request is dropped, not replayed over the user's choice.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.RequestPage(3);
+            Tick(c, clock, c.SwitchQuietMs + c.PageSetSpacingMs);   // PageSet(3) out
+            c.OnPush(UnsubAll(6).Concat(PushFor(5)).ToList());       // but page 5 arrives
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(5, c.CurrentPage);
+
+            t.Sent.Clear();
+            Tick(c, clock, 1000);
+            Assert.DoesNotContain(t.Sent, IsPageSetTo(3));   // no replay of the host request
+        }
+
+        [Fact]
+        public void RequestPage_WhileSwitching_QueuedAndAppliedAfterConfirm()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.RequestPage(3);
+            Tick(c, clock, c.SwitchQuietMs + c.PageSetSpacingMs);
+            c.RequestPage(4);                                        // second request mid-switch
+            c.OnPush(UnsubAll(6).Concat(PushFor(3)).ToList());       // first switch confirms
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Switching, c.State);      // second switch begins
+            Tick(c, clock, c.SwitchQuietMs + c.PageSetSpacingMs);
+            Assert.Contains(t.Sent, IsPageSetTo(4));
+        }
+
+        // ── Synced: wheel-button changes and subscription drops ──────────
+
+        [Fact]
+        public void WheelButton_UnsubThenSubs_AdoptedAsPageChange()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            int gen = c.SyncGeneration;
+
+            // The button's change arrives as unsub burst + new subs (here: two reports
+            // inside one accumulation window).
+            c.OnPush(UnsubAll(6));
+            Tick(c, clock, 10);
+            c.OnPush(PushFor(2, firstHandle: 6));   // double-buffered region — new handles
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(2, c.CurrentPage);
+            Assert.Equal(gen + 1, c.SyncGeneration);
+            Assert.Empty(t.Sent);   // adopted — nothing sent back, never fought
+        }
+
+        [Fact]
+        public void WheelButton_SubsArriveWithinGrace_NoRecovery()
+        {
+            // Unsub burst first, subs arriving in a separate (later) accumulation but within
+            // the grace window: a page change, not a drop.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.OnPush(UnsubAll(6));
+            Tick(c, clock, c.AccumulateWindowMs);     // unsub-only judgment → grace opens
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+
+            Tick(c, clock, 30);
+            c.OnPush(PushFor(4));
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(4, c.CurrentPage);
+        }
+
+        [Fact]
+        public void UnsubWithNothingFollowing_GraceExpiry_EntersRecovery()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.OnPush(UnsubAll(6));
+            Tick(c, clock, c.AccumulateWindowMs);     // grace opens
+            Tick(c, clock, c.UnsubGraceMs + 1);       // nothing followed
+
+            Assert.Equal(ItmLifecycleState.Recovery, c.State);
+            Assert.Contains(t.Sent, IsPageSetTo(1));  // rung 1 re-PageSets the lost page
+        }
+
+        [Fact]
+        public void ValuesSuspended_WhileAPushIsAccumulating()
+        {
+            // An in-flight push means the page is changing under us — pause values until the
+            // accumulation is judged.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.OnPush(UnsubAll(6));
+            Assert.False(c.ValuesAllowed);
+
+            c.OnPush(PushFor(2));
+            Tick(c, clock, c.AccumulateWindowMs);
+            Assert.True(c.ValuesAllowed);
+        }
+
+        [Fact]
+        public void HandleRebind_AdoptedFromPush()
+        {
+            // The same handle can be re-bound to a different parameter on any change — the
+            // adopted map must follow the push, never a cached page→handle association.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);   // page 1: handle 2 = LAP (505)
+            Assert.Equal(ItmParam.Lap, c.Subscriptions.First(kv => kv.Key == 2).Value.ParamId);
+
+            c.OnPush(UnsubAll(6).Concat(PushFor(4)).ToList());   // page 4 rebinds handle 2
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(4, c.CurrentPage);
+            Assert.Equal(ItmParam.LastLapTime, c.Subscriptions.First(kv => kv.Key == 2).Value.ParamId);
+        }
+
+        // ── Recovery ladder ──────────────────────────────────────────────
+
+        // Drives a synced controller into Recovery by requesting a page and letting the
+        // deadline lapse. On return the first ladder rung (re-PageSet 1/2) is active.
+        private static void EnterRecovery(ItmLifecycleController c, RecordingTransport t, Clock clock, byte target = 3)
+        {
+            c.RequestPage(target);
+            Tick(c, clock, c.SwitchQuietMs + c.PageSetSpacingMs);   // PageSet out
+            Tick(c, clock, c.PushDeadlineMs + 1);                    // deadline missed
+            Assert.Equal(ItmLifecycleState.Recovery, c.State);
+        }
+
+        [Fact]
+        public void Ladder_Rung1_RePageSets_Twice_WithSpacing()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            EnterRecovery(c, t, clock);
+            t.Sent.Clear();
+
+            Tick(c, clock, c.PageSetSpacingMs);                      // rung 1 attempt 1 sends
+            Assert.Equal(1, t.Sent.Count(r => IsPageSetTo(3)(r)));
+
+            Tick(c, clock, c.PushDeadlineMs + 1);                    // attempt 1 deadline
+            Tick(c, clock, c.PageSetSpacingMs);                      // attempt 2 sends
+            Assert.Equal(2, t.Sent.Count(r => IsPageSetTo(3)(r)));
+            Assert.Equal(ItmLifecycleState.Recovery, c.State);
+        }
+
+        [Fact]
+        public void Ladder_Rung1Confirmed_ResyncsAndResumes()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            int gen = c.SyncGeneration;
+            EnterRecovery(c, t, clock);
+
+            Tick(c, clock, c.PageSetSpacingMs);                      // rung 1 PageSet out
+            c.OnPush(UnsubAll(6).Concat(PushFor(3)).ToList());
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(3, c.CurrentPage);
+            Assert.Equal(gen + 1, c.SyncGeneration);
+        }
+
+        [Fact]
+        public void Ladder_Rung2_FlipAwayAndBack()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            EnterRecovery(c, t, clock, target: 3);
+
+            // Exhaust rung 1 (two re-PageSets, no push).
+            Tick(c, clock, c.PageSetSpacingMs);
+            Tick(c, clock, c.PushDeadlineMs + 1);
+            Tick(c, clock, c.PageSetSpacingMs);
+            Tick(c, clock, c.PushDeadlineMs + 1);
+            t.Sent.Clear();
+
+            // Rung 2: flip away to a different telemetry page (a genuine change MUST push).
+            Tick(c, clock, c.PageSetSpacingMs);
+            Assert.Contains(t.Sent, IsPageSetTo(1));    // flip page: first telemetry page ≠ 3
+
+            c.OnPush(UnsubAll(6).Concat(PushFor(1)).ToList());   // flip page pushes
+            Tick(c, clock, c.AccumulateWindowMs);
+            Assert.Equal(ItmLifecycleState.Recovery, c.State);   // not synced — flipping back
+
+            Tick(c, clock, c.PageSetSpacingMs);
+            Assert.Contains(t.Sent, IsPageSetTo(3));    // flip back to the target
+
+            c.OnPush(UnsubAll(6).Concat(PushFor(3)).ToList());
+            Tick(c, clock, c.AccumulateWindowMs);
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(3, c.CurrentPage);
+        }
+
+        [Fact]
+        public void Ladder_Rung3_GateCycle_WithPageSetWhileOff()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            EnterRecovery(c, t, clock, target: 3);
+
+            // Exhaust rungs 1 (×2) and 2 (flip page silent).
+            Tick(c, clock, c.PageSetSpacingMs);
+            Tick(c, clock, c.PushDeadlineMs + 1);
+            Tick(c, clock, c.PageSetSpacingMs);
+            Tick(c, clock, c.PushDeadlineMs + 1);
+            Tick(c, clock, c.PageSetSpacingMs);          // flip-away PageSet out
+            Tick(c, clock, c.PushDeadlineMs + 1);        // flip silent → gate cycle
+            t.Sent.Clear();
+
+            Tick(c, clock, c.PageSetSpacingMs);
+            // Gate cycle order: gate-off → PageSet(target) while off → gate-on.
+            int off = t.Sent.FindIndex(IsGateOff);
+            int page = t.Sent.FindIndex(r => IsPageSetTo(3)(r));
+            int on = t.Sent.FindIndex(IsGateOn);
+            Assert.True(off >= 0 && page >= 0 && on >= 0, "gate cycle frames all sent");
+            Assert.True(off < page && page < on, "PageSet sent while gated off, never a bare gate-on");
+
+            c.OnPush(PushFor(3));                        // the elicited push
+            Tick(c, clock, c.AccumulateWindowMs);
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+        }
+
+        [Fact]
+        public void Ladder_Exhausted_Unavailable_WithBackoffRetries()
+        {
+            var c = Make(out var t, out var clock, out var logs);
+            Sync(c, t, clock);
+            EnterRecovery(c, t, clock, target: 3);
+
+            // Silence through the whole ladder.
+            for (int i = 0; i < 4; i++)
+            {
+                Tick(c, clock, c.PageSetSpacingMs);
+                Tick(c, clock, c.PushDeadlineMs + 1);
+            }
+            Assert.Equal(ItmLifecycleState.Unavailable, c.State);
+            t.Sent.Clear();
+
+            // Quiet during backoff.
+            Tick(c, clock, 1000);
+            Assert.Empty(t.Sent);
+
+            // First backoff (5 s) expires → the strongest rung (gate cycle) retries.
+            Tick(c, clock, 4500);
+            Tick(c, clock, c.PageSetSpacingMs);
+            Assert.Contains(t.Sent, IsGateOff);
+            Assert.Contains(t.Sent, IsPageSetTo(3));
+            Assert.Contains(t.Sent, IsGateOn);
+
+            // Still silent → Unavailable again, with the next (30 s) backoff.
+            Tick(c, clock, c.PushDeadlineMs + 1);
+            Assert.Equal(ItmLifecycleState.Unavailable, c.State);
+            t.Sent.Clear();
+            Tick(c, clock, 10_000);                      // inside the 30 s backoff
+            Assert.Empty(t.Sent);
+        }
+
+        [Fact]
+        public void Unavailable_LatePush_AdoptedAndResyncs()
+        {
+            // Boot-cold firmware has answered a PageSet ~14 s late; a late push is just an
+            // unexpected push, and every state adopts it.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            EnterRecovery(c, t, clock, target: 3);
+            for (int i = 0; i < 4; i++)
+            {
+                Tick(c, clock, c.PageSetSpacingMs);
+                Tick(c, clock, c.PushDeadlineMs + 1);
+            }
+            Assert.Equal(ItmLifecycleState.Unavailable, c.State);
+
+            c.OnPush(PushFor(3));
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(3, c.CurrentPage);
+        }
+
+        [Fact]
+        public void Recovery_ValuesSuspended_ThroughEveryRung()
+        {
+            // A streaming recovery has been observed to wedge the display where a quiet one
+            // succeeded — the whole ladder runs with values suspended.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            EnterRecovery(c, t, clock);
+
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.False(c.ValuesAllowed);
+                Tick(c, clock, c.PageSetSpacingMs);
+                Assert.False(c.ValuesAllowed);
+                Tick(c, clock, c.PushDeadlineMs + 1);
+            }
+            Assert.Equal(ItmLifecycleState.Unavailable, c.State);
+            Assert.False(c.ValuesAllowed);
+        }
+
+        [Fact]
+        public void Ladder_EscalationsAreLogged()
+        {
+            // The ladder doubles as field diagnostics — every rung logs what it tried.
+            var c = Make(out var t, out var clock, out var logs);
+            Sync(c, t, clock);
+            EnterRecovery(c, t, clock);
+            for (int i = 0; i < 4; i++)
+            {
+                Tick(c, clock, c.PageSetSpacingMs);
+                Tick(c, clock, c.PushDeadlineMs + 1);
+            }
+
+            Assert.Contains(logs, m => m.Contains("re-PageSet 1/2"));
+            Assert.Contains(logs, m => m.Contains("re-PageSet 2/2"));
+            Assert.Contains(logs, m => m.Contains("flip-away"));
+            Assert.Contains(logs, m => m.Contains("gate cycle"));
+            Assert.Contains(logs, m => m.Contains("unavailable"));
+        }
+
+        [Fact]
+        public void Recovery_TargetPushDuringFlipAway_ConfirmsDirectly()
+        {
+            // A late push from an earlier rung can land while the flip is in flight; if it is
+            // the target's set, the recovery is simply done.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            EnterRecovery(c, t, clock, target: 3);
+            Tick(c, clock, c.PageSetSpacingMs);
+            Tick(c, clock, c.PushDeadlineMs + 1);
+            Tick(c, clock, c.PageSetSpacingMs);
+            Tick(c, clock, c.PushDeadlineMs + 1);
+            Tick(c, clock, c.PageSetSpacingMs);          // flip-away out (expects page 1)
+
+            c.OnPush(UnsubAll(6).Concat(PushFor(3)).ToList());   // but the TARGET pushes
+            Tick(c, clock, c.AccumulateWindowMs);
+
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.Equal(3, c.CurrentPage);
+        }
+
+        // ── TelemetryIdle (game exit / resume) ───────────────────────────
+
+        [Fact]
+        public void GameExit_GatesOff_ScreenDark()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            Tick(c, clock, 10, live: false);
+
+            Assert.Equal(ItmLifecycleState.TelemetryIdle, c.State);
+            Assert.Contains(t.Sent, IsGateOff);
+            Assert.False(c.ValuesAllowed);
+
+            // Dormant afterwards — no repeats, no other traffic.
+            t.Sent.Clear();
+            Tick(c, clock, 5000, live: false);
+            Assert.Empty(t.Sent);
+        }
+
+        [Fact]
+        public void GameExit_GateOffDeclined_Retried()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            t.SendReturns = false;
+            Tick(c, clock, 10, live: false);
+            t.Sent.Clear();
+
+            t.SendReturns = true;
+            Tick(c, clock, 10, live: false);
+            Assert.Contains(t.Sent, IsGateOff);
+        }
+
+        [Fact]
+        public void Resume_PageSetWhileOff_ThenGateOn_NeverBare()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);                            // synced on page 1
+            Tick(c, clock, 10, live: false);              // exit → gate-off
+            t.Sent.Clear();
+
+            Tick(c, clock, 5000, live: true);             // game returns
+
+            int page = t.Sent.FindIndex(r => IsPageSetTo(1)(r));
+            int on = t.Sent.FindIndex(IsGateOn);
+            Assert.True(page >= 0 && on >= 0, "resume sends PageSet and gate-on");
+            Assert.True(page < on, "PageSet goes out while gated off, before the gate-on");
+            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
+
+            c.OnPush(PushFor(1));                         // the elicited push (fresh handles)
+            Tick(c, clock, c.AccumulateWindowMs);
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+        }
+
+        [Fact]
+        public void Resume_WithoutPush_MustNotSelfConfirm()
+        {
+            // The handle map still holds the pre-exit page's subscriptions; a resume to the
+            // same page must not read that stale state as confirmation — only a push counts.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            Tick(c, clock, 10, live: false);
+            Tick(c, clock, 5000, live: true);             // resume commands out, NO push
+
+            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
+            Tick(c, clock, c.PushDeadlineMs + 1);
+            Assert.Equal(ItmLifecycleState.Recovery, c.State);
+        }
+
+        [Fact]
+        public void Resume_RestoresLastKnownPage()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            // Wheel button moved the display to page 5 before the exit.
+            c.OnPush(UnsubAll(6).Concat(PushFor(5)).ToList());
+            Tick(c, clock, c.AccumulateWindowMs);
+            Assert.Equal(5, c.CurrentPage);
+
+            Tick(c, clock, 10, live: false);              // exit
+            t.Sent.Clear();
+            Tick(c, clock, 5000, live: true);             // resume
+
+            Assert.Contains(t.Sent, IsPageSetTo(5));      // the page survives the exit
+        }
+
+        [Fact]
+        public void RequestPage_WhileTelemetryIdle_ChangesResumePage()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            Tick(c, clock, 10, live: false);
+            t.Sent.Clear();
+
+            c.RequestPage(4);                              // setting changed while dark
+            Tick(c, clock, 100, live: false);
+            Assert.Empty(t.Sent);                          // nothing on the wire while off
+
+            Tick(c, clock, 5000, live: true);
+            Assert.Contains(t.Sent, IsPageSetTo(4));
+        }
+
+        [Fact]
+        public void GameExit_DuringRecovery_ParksInTelemetryIdle()
+        {
+            // An exit mid-ladder abandons the ladder: gate-off now, and the resume shape —
+            // the strongest recovery there is — re-establishes everything later.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            EnterRecovery(c, t, clock);
+
+            Tick(c, clock, 10, live: false);
+
+            Assert.Equal(ItmLifecycleState.TelemetryIdle, c.State);
+            Assert.Contains(t.Sent, IsGateOff);
+        }
+
+        [Fact]
+        public void BringUp_WithoutLiveTelemetry_StillRuns()
+        {
+            // ITM is always-on: bring-up runs at connect so the default page (and the settings
+            // panel's live preview) works before any game has run. TelemetryIdle is entered
+            // only on a live→dead edge, never because telemetry simply hasn't started yet.
+            var c = Make(out var t, out var clock);
+            c.Start();
+            c.Tick(false);
+
+            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
+            c.OnPush(PushFor(1));
+            Tick(c, clock, c.AccumulateWindowMs, live: false);
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+            Assert.DoesNotContain(t.Sent, IsGateOff);
+        }
+
+        [Fact]
+        public void PushWhileGatedOff_AdoptedButNoTransition()
+        {
+            // A push while we hold the display off means another program gated it on —
+            // adopt the data (never fight), stay parked.
+            var c = Make(out var t, out var clock, out var logs);
+            Sync(c, t, clock);
+            Tick(c, clock, 10, live: false);
+            t.Sent.Clear();
+
+            c.OnPush(PushFor(2));
+            Tick(c, clock, c.AccumulateWindowMs, live: false);
+
+            Assert.Equal(ItmLifecycleState.TelemetryIdle, c.State);
+            Assert.Empty(t.Sent);
+            Assert.Contains(logs, m => m.Contains("another program"));
+        }
+
+        // ── User enable/disable ──────────────────────────────────────────
+
+        [Fact]
+        public void UserDisable_GatesOffOnce_ThenDormant()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.SetUserEnabled(false);
+            Tick(c, clock, 10);
+            Assert.Equal(ItmLifecycleState.Disabled, c.State);
+            Assert.Single(t.Sent, IsGateOff);
+
+            Tick(c, clock, 5000);
+            Assert.Single(t.Sent, IsGateOff);   // no repeats
+        }
+
+        [Fact]
+        public void UserDisable_GateOffDeclined_Retried()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            t.SendReturns = false;
+            c.SetUserEnabled(false);
+            Tick(c, clock, 10);
+            t.Sent.Clear();
+
+            t.SendReturns = true;
+            Tick(c, clock, 10);
+            Assert.Contains(t.Sent, IsGateOff);
+        }
+
+        [Fact]
+        public void UserDisable_FromIdle_StillEnforcesOff()
+        {
+            var c = Make(out var t, out var clock);
+            c.SetUserEnabled(false);
+            c.Tick(true);
+
+            Assert.Contains(t.Sent, IsGateOff);
+            Assert.DoesNotContain(t.Sent, IsGateOn);
+            Assert.DoesNotContain(t.Sent, IsEnable);
+        }
+
+        [Fact]
+        public void ReEnable_RunsColdBringUp()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            c.SetUserEnabled(false);
+            Tick(c, clock, 10);
+            t.Sent.Clear();
+
+            c.SetUserEnabled(true);
+            c.Start();
+            Tick(c, clock, c.PageSetSpacingMs);
+
+            Assert.Contains(t.Sent, IsGateOn);
+            Assert.Contains(t.Sent, IsEnable);
+            Assert.Contains(t.Sent, IsPageSet);
+            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);
+        }
+
+        // ── Wheel change / stop ──────────────────────────────────────────
+
+        [Fact]
+        public void WheelChanged_TreatedAsColdStart()
+        {
+            // A hot-swap is invisible on the ITM channel and resets the display cold; the
+            // identity layer's event drops everything and re-runs the full bring-up.
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+            Assert.Equal(6, c.SubscriptionCount);
+
+            c.OnWheelChanged();
+            Assert.Equal(0, c.SubscriptionCount);   // stale handles must not survive
+            Assert.False(c.ValuesAllowed);
+            Tick(c, clock, c.PageSetSpacingMs);
+
+            Assert.Contains(t.Sent, IsGateOn);
+            Assert.Contains(t.Sent, IsEnable);
+            Assert.Contains(t.Sent, IsPageSet);
+        }
+
+        [Fact]
+        public void WheelChanged_WhileIdle_DoesNothing()
+        {
+            var c = Make(out var t, out var clock);
+            c.OnWheelChanged();
+            c.Tick(true);
+            Assert.Empty(t.Sent);
+        }
+
+        [Fact]
+        public void WheelChanged_WhileDisabled_ReassertsGateOff()
+        {
+            // The new wheel comes up with whatever gate setting persisted — the user's "off"
+            // is re-asserted on it.
+            var c = Make(out var t, out var clock);
+            c.SetUserEnabled(false);
+            c.Tick(true);
+            t.Sent.Clear();
+
+            c.OnWheelChanged();
+            Tick(c, clock, 10);
+
+            Assert.Contains(t.Sent, IsGateOff);
+            Assert.Equal(ItmLifecycleState.Disabled, c.State);
+        }
+
+        [Fact]
+        public void Stop_DropsEverything_StartRunsColdAgain()
+        {
+            var c = Make(out var t, out var clock);
+            Sync(c, t, clock);
+
+            c.Stop();
+            Assert.Equal(ItmLifecycleState.Idle, c.State);
+            Assert.Equal(0, c.SubscriptionCount);
+            c.Tick(true);
+            Assert.Empty(t.Sent);                    // nothing on the wire from Stop
+
+            c.Start();
+            Tick(c, clock, c.PageSetSpacingMs);
+            Assert.Contains(t.Sent, IsGateOn);       // full cold bring-up
+        }
+
+        // ── Deadline/accumulation interplay ──────────────────────────────
+
+        [Fact]
+        public void PushArrivingJustBeforeDeadline_NotMissed()
+        {
+            var c = Make(out var t, out var clock);
+            c.Start();
+            c.Tick(true);
+
+            Tick(c, clock, c.PushDeadlineMs - 5);     // 5 ms before the deadline
+            c.OnPush(PushFor(1));                      // accumulation opens — deadline defers
+            Tick(c, clock, 10);                        // past the nominal deadline
+            Assert.Equal(ItmLifecycleState.AwaitPush, c.State);   // not missed
+
+            Tick(c, clock, c.AccumulateWindowMs);
+            Assert.Equal(ItmLifecycleState.Synced, c.State);
+        }
+
+        [Fact]
+        public void Describe_SurfacesStateForDeviceStatus()
+        {
+            var c = Make(out var t, out var clock);
+            Assert.Equal("Idle", c.Describe());
+            Sync(c, t, clock);
+            Assert.Contains("page 1", c.Describe());
+            Assert.Contains("6 params", c.Describe());
+        }
+    }
+}


### PR DESCRIPTION
# ITM lifecycle state machine: push-confirmed page control, recovery, and clean idle

## Why

The old ITM driver handled bring-up carefully but everything after it was send-and-hope: PageSets were trusted without verification, values kept flowing on handles that could already be stale, and a SimHub restart couldn't tell what state the display was in. The redesign makes the firmware's subscription push the spine of the whole lifecycle.

Hardware testing established the root causes:

- The firmware's subscription push is the **only acknowledgment** in this protocol — and value traffic concurrent with a page switch is the identified cause of dropped switches (quiet switches confirmed 80/80; with values streaming, 14/20 and one wedged display).
- A handle can be **re-bound to a different parameter on any page change**, so mid-switch values don't just get lost — they can render on the wrong field.
- A PageSet to the already-shown page correctly pushes nothing, so "no push" is ambiguous; only a **genuine** page change converts silence into signal.
- The `FF 05 02` gate is the real screen control: gate-off drops to the legacy 7-segment view; gate-on **with a PageSet sent while off** deterministically elicits that page's push (20/20); a bare gate-on lands on the legacy page with no subscriptions.
- The runtime session does not survive a power cycle or wheel re-seat (the gate *setting* does), and a hot-swap is completely invisible on the ITM channel — only the system-report identity channel sees it.

See `docs/reference/protocol.md` ("ITM Display", freshly corrected in this branch) for the full behavioral reference.

## What

**`ItmLifecycleController`** (FanaBridge.Core) — a pure state machine (injected clock, no HID, no threads): `Idle / Disabled / BringUp / AwaitPush / Switching / Synced / Recovery / Unavailable`.

- Every state that asked for a page change carries an expected **parameter set** and a deadline. Matching is on the param set (accumulated ~50 ms across reports — push fragmentation varies by setup); handles and declared data types are **adopted** from the push, never cached.
- Values and ParamDefs are suspended from the instant a switch begins until its push confirms, and through the whole recovery ladder.
- **Recovery ladder**: re-PageSet ×2 → flip-away-and-back → gate cycle with PageSet-while-off → Unavailable (5 s → 30 s → 5 min backoff, retrying the gate-cycle rung). Every escalation logs what it tried and saw — the ladder doubles as field diagnostics for the flaky cases we can't reproduce on demand.
- **Unexpected pushes** (wheel-button page changes, late pushes from a boot-cold base) are adopted in every state: adopt, never fight.
- **Wheel/hub/module changes** from the identity layer restart the lifecycle cold — the handle map is dropped, and nothing is sent until the fresh push confirms.

**Idle & the gate.** Gate-off is never used at idle. A game exit clears the fields to placeholders (`DisplayReset`) and keeps the ITM page visible; a game returning repaints over the placeholders in place. Cold entries also `DisplayReset` so a page never comes up showing a previous session's cached values. Gate-off is reserved for the user's explicit ITM-off and for the recovery ladder's last-resort gate-cycle rung — its brief drop to legacy is the escape hatch that re-establishes a wedged display, not something the display does on its own.

**Starting page.** The starting-page setting is a real default: the display returns to it at each game start, while the wheel's display button owns navigation within a session (previously the setting applied once at connect, so the button's choice became permanently sticky). Legacy is a valid pick.

**Legacy ITM page.** The legacy page carries no telemetry parameters, so its PageSet pushes only an unsubscribe-all (or nothing if already shown). That was being read as "subscriptions dropped → recover," which yanked the display back to a telemetry page — so the wheel button couldn't stay on legacy and picking legacy as the default wedged the state. Now an empty-set push (or a missed push) on a legacy target is adopted as "on the legacy page."

**`ItmDisplayDriver`** slims to telemetry→values mapping, suffix logic, and pacing. On every adopted push it repaints: first values immediately, a tight ~20 ms double-tap, then ParamDefs — the ordering official software uses where rendering is reliable.

**Visibility.** Device Status shows the live ITM lifecycle state (with recovery rung / retry countdown), and warns when the Fanatec app/service is running alongside FanaBridge — both drive the same display, the protocol has no arbitration, and there is no wire-level way to see the other writer. The same lines ride along in Copy Debug Info.

## Tests

554 total, all green. The controller suite covers every transition, every ladder rung, deadlines, the push-accumulation window, the handle re-bind hazard, the stale-map self-confirmation trap on same-page resume, the idle clear-and-repaint, the legacy-page cases, and the starting-page-on-game-start behavior.

## Review

Two adversarial review passes (multi-agent, high effort). Findings fixed with regression tests: bring-up targeting the wrong page (settings applied after `Start()`), the user's ITM-off not re-asserted after a reconnect, an open push accumulation surviving a wheel change and self-confirming against the old wheel's page, values flowing during the grace window / on a no-match fragment, a straggler re-push cancelling a host switch, `WheelChangeCount` bumped by an unrelated settings save, `SetEqualsPage` matching a telemetry push against the (empty) legacy page, and a 0/out-of-range starting page becoming `PageSet(0)`.

Automated PR review added four more: a stale ITM status-string cache surviving a driver rebind, the "ITM enabled" log not re-arming after a hot-swap, an out-of-range index if the `Unavailable` backoff list is emptied, and a switch-window PageSet that could be sent over an in-flight push. The last two carry new regression tests.

## Validation

Driven on hardware (Podium DD+ / PBME) across the settle: page switches under load, game exit/return, wheel hot-swap, base power-cycle, legacy selection, and starting-page behavior. Known follow-up (separate): a periodic re-assert for ParamDefs and a bounded idle-clear re-assert, to harden against the occasional firmware drop of those unacked frames.
