### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
-## Unreleased
+## v0.6.0 - 2026-07-14
 
 ### Changed
-- Internal: the device stack (HID transport, Fanatec protocol, wheel profiles) now lives in a separate `FanaBridge.Core` project, merged into the shipped `FanaBridge.dll` at package time — installation is unchanged (still a single DLL).
+- ITM display reworked for reliable page switching and automatic recovery (experimental): page changes are confirmed by the display instead of sent blind, a stuck display self-recovers, fields clear cleanly outside a game, and the starting-page setting re-applies each game start. Device Status shows the live ITM state and warns when Fanatec's own software is running alongside FanaBridge. ([#69](https://github.com/kelchm/FanaBridge/pull/69))
+- Internal: the device stack now lives in a separate `FanaBridge.Core` project, merged into the shipped `FanaBridge.dll` at package time — installation is unchanged. ([#67](https://github.com/kelchm/FanaBridge/pull/67))
+- Internal: repository reorganized (`src`/`tests`/`scripts`) with build, test-seam, and CI improvements — no functional or install impact. ([#58](https://github.com/kelchm/FanaBridge/pull/58), [#61](https://github.com/kelchm/FanaBridge/pull/61), [#62](https://github.com/kelchm/FanaBridge/pull/62), [#66](https://github.com/kelchm/FanaBridge/pull/66))
+
+### Fixed
+- Gear now renders on Formula V3 and GT Extreme wheels, which declare the gear field as text rather than a number. ([#68](https://github.com/kelchm/FanaBridge/pull/68), fixes [#70](https://github.com/kelchm/FanaBridge/issues/70))
+- ITM bring-up, page changes, and "/total" suffixes are retried when the wheel briefly declines a write, so the display no longer streams to a session that never started. ([#60](https://github.com/kelchm/FanaBridge/pull/60))
+- Display-type and ITM device-id profile overrides now take effect live, without a restart. ([#64](https://github.com/kelchm/FanaBridge/pull/64))
+- Control Mapper integration failures now show a clear status line instead of stopping silently, and a transient startup hiccup no longer disables it for the session. ([#63](https://github.com/kelchm/FanaBridge/pull/63))
+- Pulling a wheel mid-session no longer logs a warning every second (a re-armed SRM Conversion Kit ping loop). ([#65](https://github.com/kelchm/FanaBridge/pull/65))
+- Fixed an LED-pipeline stall when a profile changed mid-write, wrong LED bindings after changing counts via Back in the profile wizard, and the 7-segment display test fighting live gear/speed. ([#60](https://github.com/kelchm/FanaBridge/pull/60))
 
 ## v0.5.0 - 2026-07-07
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <LangVersion>latest</LangVersion>
 
     <!-- Single source of truth for product versioning. -->
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
 


### PR DESCRIPTION
Version bump to **0.6.0** and the changelog section covering everything merged since v0.5.0.

### Highlights
- **ITM display lifecycle rework (experimental)** — reliable, display-confirmed page switching, automatic recovery from a stuck display, clean idle behavior, and live ITM status in Device Status ([#69](https://github.com/kelchm/FanaBridge/pull/69)).
- Gear renders on text-declared displays (Formula V3, GT Extreme) ([#68](https://github.com/kelchm/FanaBridge/pull/68)).
- Reliability fixes: ITM write-retry on bring-up, live display/ITM overrides, visible Control Mapper failure state, and no more per-second warnings after a mid-session rim pull ([#60](https://github.com/kelchm/FanaBridge/pull/60), [#63](https://github.com/kelchm/FanaBridge/pull/63), [#64](https://github.com/kelchm/FanaBridge/pull/64), [#65](https://github.com/kelchm/FanaBridge/pull/65)).
- Internal: `FanaBridge.Core` split, repo reorg, build/test/CI hygiene — no install impact ([#58](https://github.com/kelchm/FanaBridge/pull/58), [#61](https://github.com/kelchm/FanaBridge/pull/61), [#62](https://github.com/kelchm/FanaBridge/pull/62), [#66](https://github.com/kelchm/FanaBridge/pull/66), [#67](https://github.com/kelchm/FanaBridge/pull/67)).

### Changes
- `Directory.Build.props`: `VersionPrefix` 0.5.0 → 0.6.0
- `CHANGELOG.md`: new `v0.6.0 - 2026-07-14` section

Merge this, then tag `v0.6.0` on main.