### PR TITLE
fix: ITM display never syncs on an SRM Conversion Kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixed
-- **The ITM display works on wheels run through an SRM Conversion Kit.** On a converted wheel the display never came up — Device Status sat at "Unavailable — retry in …" indefinitely. FanaBridge stopped collecting the display's own status messages once it had identified the wheel through the conversion kit, so it was waiting on a confirmation that had already arrived and gone unread.
+- **FanaBridge now collects the ITM display's status messages on a wheel run through an SRM Conversion Kit.** On a converted wheel the display never came up — Device Status sat at "Unavailable — retry in …" indefinitely — because FanaBridge stopped reading those messages once it had identified the wheel through the conversion kit, leaving it waiting on a confirmation that had already arrived and gone unread. Not yet confirmed on hardware, and it does not rule out a conversion kit that never relays the messages in the first place.
 
 ## v0.6.0 - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **The ITM display works on wheels run through an SRM Conversion Kit.** On a converted wheel the display never came up — Device Status sat at "Unavailable — retry in …" indefinitely. FanaBridge stopped collecting the display's own status messages once it had identified the wheel through the conversion kit, so it was waiting on a confirmation that had already arrived and gone unread.
+
 ## v0.6.0 - 2026-07-14
 
 ### Changed

--- a/src/FanaBridge.Core/Transport/FanatecWheelbase.cs
+++ b/src/FanaBridge.Core/Transport/FanatecWheelbase.cs
@@ -463,13 +463,18 @@ namespace FanaBridge.Transport
             if (!IsConnected)
                 return false;
 
-            // ITM subscription pushes are a display concern, not an identity one: they keep
-            // arriving on col03 for the life of the connection no matter how the connection was
-            // identified. Drain them BEFORE the converter short-circuit below — an SRM kit's
-            // identity is a one-shot, but its ITM channel is not, and skipping this drain leaves
-            // the ITM lifecycle waiting on a confirming push that is sitting unread in the
-            // transport queue, so bring-up runs the whole recovery ladder and settles into
-            // Unavailable forever.
+            // ITM subscription pushes are a display concern, not an identity one, so they are
+            // drained for the life of the connection regardless of how identity was established.
+            // This MUST stay above the converter short-circuit below: an SRM kit's identity is a
+            // one-shot, but its ITM channel is not, and skipping the drain leaves the lifecycle
+            // waiting on a confirming push that is sitting unread in the transport queue — so
+            // bring-up runs the whole recovery ladder and settles into Unavailable forever.
+            // (Whether a given kit relays those pushes at all is a separate, open question; this
+            // only guarantees we read whatever does arrive.) Draining here rather than alongside
+            // the identity streams below widens, by a few microseconds of same-thread work, the
+            // pre-existing window in which a late push from a previous attachment can outlive the
+            // wheel-change clear in the transport queue — one drain site is worth that over two
+            // that can drift apart.
             DrainFamily(Transport.ItmReports, _bufferItm);
 
             // An SRM converter's identity is a fixed one-shot — nothing to drain or re-settle once

--- a/src/FanaBridge.Core/Transport/FanatecWheelbase.cs
+++ b/src/FanaBridge.Core/Transport/FanatecWheelbase.cs
@@ -463,6 +463,15 @@ namespace FanaBridge.Transport
             if (!IsConnected)
                 return false;
 
+            // ITM subscription pushes are a display concern, not an identity one: they keep
+            // arriving on col03 for the life of the connection no matter how the connection was
+            // identified. Drain them BEFORE the converter short-circuit below — an SRM kit's
+            // identity is a one-shot, but its ITM channel is not, and skipping this drain leaves
+            // the ITM lifecycle waiting on a confirming push that is sitting unread in the
+            // transport queue, so bring-up runs the whole recovery ladder and settles into
+            // Unavailable forever.
+            DrainFamily(Transport.ItmReports, _bufferItm);
+
             // An SRM converter's identity is a fixed one-shot — nothing to drain or re-settle once
             // committed. Genuine bases fall through to the unchanged FF 08 path.
             if (IsSrmConverter)
@@ -478,12 +487,11 @@ namespace FanaBridge.Transport
                 catch { /* transient; the next tick retries */ }
             }
 
-            // Drain this device's three input streams (the transport's reader thread
-            // routes frames by signature). Lock-free: the wheelbase is the single
-            // owner of all three, and reads never touch the write lock.
+            // Drain this device's identity streams (the transport's reader thread routes
+            // frames by signature; the ITM stream is already drained above). Lock-free: the
+            // wheelbase is the single owner of all three, and reads never touch the write lock.
             _drainNow = now;
             _reportReader.DrainIdentity(_transport, _ingest);
-            DrainFamily(Transport.ItmReports, _bufferItm);
             DrainFamily(Transport.SrmReports, _ingestSrm);
 
             // Commit a converter identity the drain routed to us — outside the drain,

--- a/tests/FanaBridge.Tests/FanatecWheelbaseTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelbaseTests.cs
@@ -650,14 +650,22 @@ namespace FanaBridge.Tests
             wb.UpdateIdentity();
             Assert.True(wb.IsSrmConverter);
 
-            t.Itm.Enqueue(new byte[] { 0xFF, 0x05, 0x01, 0x11 });
+            // A realistic push rather than a marker byte: FF 05 01 then one 5-byte entry
+            // [deviceId][fwHandle][paramId-LE][dataType] for display device 4 (the Bentley).
+            // The sibling tests above only need a distinguishable frame, but this one is the
+            // converter path's only coverage — so it drains AND parses, which would also catch
+            // a future regression that hands the driver a frame it silently discards.
+            t.Itm.Enqueue(new byte[] { 0xFF, 0x05, 0x01, 0x04, 0x00, (byte)ItmParam.Speed, 0x00, 0x34 });
             clock.T += 10;
             Assert.False(wb.UpdateIdentity());   // no identity change — but the ITM drain still runs
 
             var drained = new List<byte[]>();
             wb.DrainItmReports(drained.Add);
             Assert.Single(drained);
-            Assert.Equal(0x11, drained[0][3]);
+
+            var subs = ItmTelemetry.ParseSubscriptionReport(drained[0], drained[0].Length, deviceId: 4);
+            var sub = Assert.Single(subs);
+            Assert.Equal(ItmParam.Speed, sub.ParamId);
         }
 
         [Fact]

--- a/tests/FanaBridge.Tests/FanatecWheelbaseTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelbaseTests.cs
@@ -633,6 +633,34 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void ItmReports_StillDrained_OnAnSrmConverter()
+        {
+            // Regression (v0.6.0 field report, SRM kit + Podium Bentley GT3): once a
+            // converter identity committed, UpdateIdentity short-circuited BEFORE the ITM
+            // drain. The kit's FF 05 subscription pushes then sat unread in the transport
+            // queue forever, so the ITM lifecycle never got its confirming push — bring-up
+            // ran the whole recovery ladder and parked in Unavailable. Identity is a
+            // one-shot on a converter; the ITM channel is not.
+            var wb = Make(out var t, out var bus, out var clock);
+            bus.Devices.Add(new HidDeviceInfo(0x0005, 64, 64, "CSL Elite"));
+            Assert.True(wb.AutoConnect());
+
+            t.Srm.Enqueue(SrmReply());
+            clock.T += 10;
+            wb.UpdateIdentity();
+            Assert.True(wb.IsSrmConverter);
+
+            t.Itm.Enqueue(new byte[] { 0xFF, 0x05, 0x01, 0x11 });
+            clock.T += 10;
+            Assert.False(wb.UpdateIdentity());   // no identity change — but the ITM drain still runs
+
+            var drained = new List<byte[]>();
+            wb.DrainItmReports(drained.Add);
+            Assert.Single(drained);
+            Assert.Equal(0x11, drained[0][3]);
+        }
+
+        [Fact]
         public void ItmReports_BufferBounded_DropsOldestWhenFull()
         {
             // Cap is 32; a stalled consumer (e.g. during the wizard) must cost the


### PR DESCRIPTION
Fixes #74

## Summary

The ITM display never comes up on a wheel run through an **SRM Conversion Kit** — Device Status parks at `Unavailable — retry in …` and cycles the retry backoff forever. Reported on a Podium Bentley GT3 (kit firmware 6.10) on v0.6.0, but it affects any ITM-capable wheel behind a conversion kit.

## Why it broke

The ITM display confirms every page change by sending a message back to the host; that reply is the protocol's only acknowledgment, and the lifecycle draws nothing until it arrives. Those replies are harvested in `FanatecWheelbase.UpdateIdentity()`, the once-per-frame device-status pass.

A conversion kit's identity is a one-shot — it is fixed for the life of the connection — so that pass returns early once the kit has been identified. The early return was placed *above* the ITM drain:

```csharp
if (IsSrmConverter)
    return false;                                    // ← identity is settled, nothing to do
...
DrainFamily(Transport.ItmReports, _bufferItm);       // ← unreachable
```

That `DrainFamily` call is the only producer for the ITM buffer. The transport's reader thread keeps classifying and queueing the display's replies correctly, but nothing ever dequeues them, so `DrainItmReports` hands the driver an empty batch every frame and `ItmLifecycleController` never sees a push.

With no push, bring-up runs the entire recovery ladder — re-select the page twice, flip away and back, gate cycle — and then parks in `Unavailable` on the 5 s / 30 s / 300 s backoff. That is exactly the state the field report captured.

Regressed in v0.5.0 by #47, which restored conversion-kit wheel detection; the guard was added above what was then a single combined drain call. ITM support shipped in the same release, so this has never worked on a converted wheel.

## The fix

Move the ITM drain above the converter short-circuit. Identity on a converter is a one-shot; the ITM channel is not.

## Evidence from the report

- **Outbound writes were fine.** Reaching `Unavailable` requires the wheel to have accepted every command in the ladder (display reset, gate on, enable, page select) — a declined write parks the lifecycle in `BringUp` instead. The failure is entirely inbound.
- The identity source is the conversion kit's own channel, so `IsSrmConverter` is true and the early return is live.
- `PSWBENT` resolves correctly (`display: itm`, `itmDeviceId: 4`), so the driver was created and started as intended.

## Scope

Nothing else is affected. Tuning drains its replies through its own path, and LED / 7-segment output is outbound-only. Genuine bases never take the early return, so their behaviour is unchanged.

## Testing

- New regression test `ItmReports_StillDrained_OnAnSrmConverter` — verified failing on the current `main` and passing with this change.
- Full suite: 555 passed, 0 failed.
- **Not yet verified on hardware.** Draft until a converted wheel confirms it.

## Open question

This fix is necessary but may not be sufficient. It guarantees FanaBridge *reads* whatever the kit sends; whether the kit relays the display's replies upstream at all is unverified, and the diagnostic report gives no evidence either way. Distinguishable from the SimHub log — a successful bring-up logs `ITM: push confirmed — page N: …`. Continued silence after this change would point at the kit, not at FanaBridge.
