### PR TITLE
Fix rev stripe colors on CSL Elite P1 and WRC

### DIFF
--- a/docs/reference/devices.md
+++ b/docs/reference/devices.md
@@ -216,7 +216,7 @@ These wheels have a single-color LED strip instead of individually-addressable r
 | CSLESWP1PS4 | RGB333 | Legacy (col01) |
 | CSLESWWRC | RGB333 | Legacy (col01) |
 
-RevStripe is controlled as a single unit (index 0 only) with RGB333 color encoding (512 possible colors, of which 8 discrete colors are commonly used). See [RevStripe protocol](protocol.md#0x06--revstripe-enabledisable).
+RevStripe is controlled as a single unit (index 0 only) with RGB333 color encoding. 512 values are representable, but no hardware tested to date renders more than eight — red, green, blue, cyan, magenta, yellow, white and off. See [RevStripe protocol](protocol.md#0x08--rev-led-data-bitmask--color).
 
 #### No Rev LEDs
 

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -12,12 +12,13 @@ Fanatec wheelbases communicate with the host PC over USB HID (Human Interface De
 - [Collection Routing](#collection-routing)
 - [col01 Reference](#col01-reference)
   - [0x09 — General Control](#0x09--general-control)
-    - [0x02 — Rev LED Global On/Off](#0x02--rev-led-global-onoff)
-    - [0x06 — RevStripe Enable/Disable](#0x06--revstripe-enabledisable)
-    - [0x07 — Rev LED Blink Enable](#0x07--rev-led-blink-enable)
+    - [0x02 — Rim White LED](#0x02--rim-white-led)
+    - [0x06 — RevStripe Enable/Disable (Setting)](#0x06--revstripe-enabledisable-setting)
+    - [0x07 — Rev LED Mode (Color / Bitmask)](#0x07--rev-led-mode-color--bitmask)
     - [0x08 — Rev LED Data (Bitmask / Color)](#0x08--rev-led-data-bitmask--color)
-    - [0x09 / 0x0A — RGB Rev LED Data (Legacy)](#0x09--0x0a--rgb-rev-led-data-legacy)
-    - [0x0C — Flag LED Data (Legacy)](#0x0c--flag-led-data-legacy)
+    - [0x0A — Legacy RGB Rev LEDs](#0x0a--legacy-rgb-rev-leds-per-led-3-bit-color)
+    - [0x0B — Legacy Flag LEDs](#0x0b--legacy-flag-leds)
+    - [0x0C — LED Brightness (Legacy RGB)](#0x0c--led-brightness-legacy-rgb)
     - [0x01 — Extended Operations (Group)](#0x01--extended-operations-group)
       - [0x02 — 7-Segment Display Data](#0x02--7-segment-display-data)
       - [0x06 — Report Trigger / ACK](#0x06--report-trigger--ack)
@@ -67,7 +68,7 @@ Fanatec wheelbases communicate with the host PC over USB HID (Human Interface De
   - [Tuning & Configuration](#tuning--configuration)
 - [Appendix](#appendix)
   - [RGB333 Color Encoding](#rgb333-color-encoding)
-  - [RGB565 Color Encoding](#rgb565-color-encoding)
+  - [BGR565 Color Encoding](#bgr565-color-encoding)
   - [7-Segment Encoding Tables](#7-segment-encoding-tables)
   - [ITM Parameter IDs](#itm-parameter-ids)
   - [ITM Page Layouts](#itm-page-layouts)
@@ -174,9 +175,9 @@ Most col01 commands use the `[ReportID, 0xF8, 0x09, ...]` framing described in [
 
 The catch-all control class — rev and flag LEDs, displays, and configuration. The **subcommand** sits in byte[3]; most subcommands are complete there (listed below). The exception is subcommand `0x01`, a *group* whose [operations](#0x01--extended-operations-group) are selected by byte[4].
 
-#### 0x02 — Rev LED Global On/Off
+#### 0x02 — Rim White LED
 
-Enables or disables the rev LED strip globally.
+Turns a single white LED on the rim on or off. It has no effect on rev LED output; the rev LEDs are driven entirely by [`0x08`](#0x08--rev-led-data-bitmask--color) and need no enable command.
 
 ```
 [ReportID, 0xF8, 0x09, 0x02, enable, 0x00, 0x00, 0x00]
@@ -186,7 +187,9 @@ Enables or disables the rev LED strip globally.
 |------|-------|--------|
 | 4 | enable | `0x01` = on, `0x00` = off |
 
-#### 0x06 — RevStripe Enable/Disable
+Thought to correspond to the small status LED next to the XBox button on some wheels, but this has not yet been verified.
+
+#### 0x06 — RevStripe Enable/Disable (Setting)
 
 Enables or disables the RevStripe LED strip. Found on three rims: CSLESWP1X, CSLESWP1PS4, CSLESWWRC.
 
@@ -201,25 +204,35 @@ Disable: [ReportID, 0xF8, 0x09, 0x06, 0x01, 0x00, 0x00, 0x00]
 |------|-------|--------|
 | 4 | enable | `0x00` = on, `0x01` = off (inverted) |
 
-**Typical RevStripe sequence:**
+**Typical RevStripe sequence**, as captured from official software driving the strip:
 
 ```
-1. Enable RevStripe:  [RID, F8, 09, 06, 00, 00, 00, 00]
-2. Global LEDs on:    [RID, F8, 09, 02, 01, 00, 00, 00]
-3. Set color (red):   [RID, F8, 09, 08, 00, 38, 00, 00]
-
-To turn off:
-4. Set color (off):   [RID, F8, 09, 08, 00, 00, 00, 00]
-5. Global LEDs off:   [RID, F8, 09, 02, 00, 00, 00, 00]
+1. Base rev LEDs off: [RID, F8, 14, FF, 00, 00, 00, 00]
+2. Set color (red):   [RID, F8, 09, 08, 00, 38, 00, 00]     (repeated per color)
+3. Base rev LEDs on:  [RID, F8, 14, 00, 00, 00, 00, 00]
 ```
 
-#### 0x07 — Rev LED Blink Enable
+#### 0x07 — Rev LED Mode (Color / Bitmask)
 
-Enables blinking mode for rev LEDs.
+Selects how the rim interprets subsequent [`0x08`](#0x08--rev-led-data-bitmask--color) writes.
 
 ```
-[ReportID, 0xF8, 0x09, 0x07, 0x01, 0x00, 0x00, 0x00]
+[ReportID, 0xF8, 0x09, 0x07, mode, 0x00, 0x00, 0x00]
 ```
+
+| Byte | Field | Values |
+|------|-------|--------|
+| 4 | mode | `0x00` = `0x08` payloads are colors, `0x01` = payloads are on/off patterns |
+
+**The driver stack sends this command on your behalf.** On CSL Elite P1 (Xbox), CSL Elite P1 (PS4) and CSL Elite WRC, Fanatec's driver watches `0x08` writes and injects a mode change in response to specific payloads:
+
+| Payload written | Driver injects | Resulting mode |
+|---|---|---|
+| `01 00` | `0x07` with `0x01` | pattern |
+| `00 07` (blue) | `0x07` with `0x00` | color |
+| `00 38` (red) | `0x07` with `0x00` | color |
+
+This is edge-triggered, so it fires only on transitions. `0x08` is ambiguous — `01 00` is both a valid color and the "LED 0 only" pattern — so the driver infers intent from the payload. RGB333 `r=0, g=4, b=0` encodes to `01 00`, which puts the rim into pattern mode. Later color writes are then read as bitmasks: on a RevStripe rim the strip lights in its fixed pattern color whenever `data_lo` bit 0 is set (green, cyan, yellow, white) and stays dark otherwise. Pure red or pure blue returns it to color mode.
 
 #### 0x08 — Rev LED Data (Bitmask / Color)
 
@@ -229,14 +242,14 @@ Sends LED data — interpreted as either a bitmask or a color depending on the c
 [ReportID, 0xF8, 0x09, 0x08, data_lo, data_hi, 0x00, 0x00]
 ```
 
-**Non-RGB rims** (e.g., CSSWBMWV2): 9-bit bitmask where each bit controls one LED (bit 0 = LED 0):
+**Non-RGB rims** (e.g., CSSWBMWV2): 9-bit bitmask. LED 0 sits alone in `data_lo` bit 0; LEDs 1-8 pack into `data_hi` **most-significant-first**, so LED 1 is bit 7 and LED 8 is bit 0. Note this differs from the `0x13` base ordering.
 
 ```
 Example: LEDs 0, 1, 2 on, rest off
-  data_lo = 0x07, data_hi = 0x00   (bitmask: 0b000000111)
+  data_lo = 0x01, data_hi = 0xC0   (LED0; LED1 = bit7, LED2 = bit6)
 
 Example: All 9 LEDs on
-  data_lo = 0xFF, data_hi = 0x01   (bitmask: 0b111111111)
+  data_lo = 0x01, data_hi = 0xFF
 ```
 
 **RevStripe rims** (CSLESWP1X, CSLESWP1PS4, CSLESWWRC): [RGB333](#rgb333-color-encoding) color value controlling the entire strip as one unit:
@@ -246,22 +259,41 @@ Example: Red     → data_lo = 0x00, data_hi = 0x38
 Example: Green   → data_lo = 0x01, data_hi = 0xC0
 ```
 
-#### 0x09 / 0x0A — RGB Rev LED Data (Legacy)
+#### 0x0A — Legacy RGB Rev LEDs (per-LED 3-bit color)
 
-Color data for RGB-capable rims sent via col01. Used by older RGB rims that lack col03 support.
-
-```
-[ReportID, 0xF8, 0x09, 0x09, data...]
-[ReportID, 0xF8, 0x09, 0x0A, data...]
-```
-
-#### 0x0C — Flag LED Data (Legacy)
-
-Sets flag LED color via legacy protocol. Only a subset of wheels have flag LEDs — see the [devices reference](devices.md#flag-leds) for the support matrix.
+Per-LED color for **RGB rims without col03**, one bit per channel — seven colors plus off.
 
 ```
-[ReportID, 0xF8, 0x09, 0x0C, flag_color, dirty_flag, 0x00, 0x00]
+[ReportID, 0xF8, 0x09, 0x0A, data0, data1, data2, data3]
 ```
+
+27 bits packed LSB-first across the four data bytes, three bits per LED for nine LEDs, in the order `[LED0.R, LED0.G, LED0.B, LED1.R, ...]`. So LED *n*'s red bit is `3n`, green `3n+1`, blue `3n+2`.
+
+```
+Example: LED 0 red        → data0 = 0x01
+Example: LED 0 blue       → data0 = 0x04
+Example: all nine green   → 92 24 49 02
+```
+
+Note the channel order here is **R, G, B** — the only conventional ordering in this protocol, and different from both [`0x08`](#0x08--rev-led-data-bitmask--color) (G, R, B) and the col03 color paths (B, G, R).
+
+#### 0x0B — Legacy Flag LEDs
+
+Per-LED 3-bit color for flag LEDs on col01, packed the same way as [`0x0A`](#0x0a--legacy-rgb-rev-leds-per-led-3-bit-color) but for six flag LEDs (18 bits). Only a subset of wheels have flag LEDs — see the [devices reference](devices.md#flag-leds) for the support matrix.
+
+```
+[ReportID, 0xF8, 0x09, 0x0B, data0, data1, data2, data3]
+```
+
+#### 0x0C — LED Brightness (Legacy RGB)
+
+Sets overall brightness for the legacy RGB rev LEDs driven by [`0x0A`](#0x0a--legacy-rgb-rev-leds-per-led-3-bit-color).
+
+```
+[ReportID, 0xF8, 0x09, 0x0C, brightness, dirty_flag, 0x00, 0x00]
+```
+
+The brightness value goes through the same conversion the col03 intensity path applies.
 
 #### 0x01 — Extended Operations (Group)
 
@@ -423,9 +455,9 @@ For non-OLED devices (including LED 7-segment displays and the PBMR's small OLED
 
 ### 0x13 / 0x14 — Base Rev LEDs
 
-Some older wheelbases (e.g., CSL Elite Wheel Base) have a resident 9-LED rev strip on the base unit — separate from any rev indicator on the connected wheel — driven by its own command class at byte[2] = `0x13`.
+Some older wheelbases (e.g., CSL Elite Wheel Base) have a resident 9-LED rev strip on the wheelbase itself — separate from any rev indicator on the connected wheel. This can be driven by its own command class at byte[2] = `0x13`.
 
-**The base and wheel share the rev-LED channel, then split.** At power-on both the base strip and the wheel's rev LEDs follow the legacy [`0x08`](#0x08--rev-led-data-bitmask--color) writes, gated by the shared [`0x02`](#0x02--rev-led-global-onoff) enable. The first `0x13` write moves the base onto its own channel; afterward `0x13` drives the base and `0x08` drives only the wheel — independently, until power-cycle. That's how an RPM display can run on the base strip and a [RevStripe](#0x06--revstripe-enabledisable) wheel at once (enable with `0x02`, drive the wheel via `0x06` + `0x08`, then the base via `0x13`).
+**The base and wheel share the rev-LED channel, then split.** At power-on both the base strip and the wheel's rev LEDs follow the legacy [`0x08`](#0x08--rev-led-data-bitmask--color) writes. The first `0x13` write moves the base onto its own channel; afterward `0x13` drives the base and `0x08` drives only the wheel — independently, until power-cycle. That's how an RPM display can run on the base strip and a RevStripe wheel at once: drive the wheel via `0x08` and the base via `0x13`.
 
 #### 0x13 — Base Rev LED Data
 
@@ -448,7 +480,7 @@ Enable:  [ReportID, 0xF8, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00]
 Disable: [ReportID, 0xF8, 0x14, 0xFF, 0x00, 0x00, 0x00, 0x00]
 ```
 
-In practice you don't need it: the base is turned on by the shared [`0x02`](#0x02--rev-led-global-onoff) enable and lit by [`0x13`](#0x13--base-rev-led-data).
+Captures of official software driving a RevStripe wheel bracket the color writes with `0x14` — `0xFF` first, `0x00` afterwards.
 
 ---
 
@@ -465,7 +497,7 @@ Byte:  [0]   [1]   [2]      [3..4]    [5..6]    ...
        0xFF  0x01  subcmd   LED0_RGB  LED1_RGB  ...
 ```
 
-Each LED color is a **16-bit [RGB565](#rgb565-color-encoding)** value stored in **big-endian** byte order. A color value of `0x0000` means the LED is off.
+Each LED color is a **16-bit [BGR565](#bgr565-color-encoding)** value stored in **big-endian** byte order. A color value of `0x0000` means the LED is off.
 
 #### 0x00 — Rev LEDs
 
@@ -487,7 +519,7 @@ FF 01 01 [F0hi F0lo] [F1hi F1lo] ... [F5hi F5lo] 00...
 
 Button backlight RGB colors. Up to 12 RGB565 values. Only applies to devices with RGB-capable button LEDs (currently PSWBMW, GTSWX, and the PBMR module).
 
-> **Note — PBMR color inconsistency:** The PBMR is the only known device that interprets these RGB565 values as RGB555 (5 bits per channel, green MSB ignored). This means the 6th green bit (G5) is silently discarded. For example, `0x0400` (RGB565: R=0, G=32, B=0 — a dim green) renders as **black** on the PBMR because only G5 is set and it's the ignored bit. In practice, colors should be constructed with 5-bit green values (shift left by 6, not 5) to display correctly on PBMR. See [PBMR](devices.md#pbmr-podium-button-module-rally) for details.
+> **Note — PBMR color inconsistency:** The PBMR is the only known device that interprets these 16-bit values as [BGR555](#bgr555-variant) (5 bits per channel, green MSB ignored). The 6th green bit — bit 10 — is silently discarded. For example, `0x0400` (G=32, a dim green) renders as **black** on the PBMR because bit 10 is the only bit set and it's the ignored one. Construct colors for the PBMR by quantizing green to 5 bits and shifting it left by **5**, which leaves bit 10 clear. See [PBMR](devices.md#pbmr-podium-button-module-rally) for details.
 
 ```
 Byte:  [0]   [1]   [2]   [3..4]    ... [25..26]  [27]
@@ -1043,16 +1075,16 @@ Fanatec steering wheels support several types of LEDs controlled through two dis
 | **Rev LEDs** | RPM / shift indicator strip | 9 | Per-LED RGB (modern) or on/off (legacy) |
 | **Flag LEDs** | Status / warning indicators | 6 | Per-LED RGB (modern) or single color (legacy) |
 | **Button LEDs** | Button backlighting (RGB devices only) | Up to 12 | Per-LED RGB + intensity |
-| **RevStripe** | Single-color LED strip | 1 (entire strip) | RGB333 (8 colors via official software, 512 via raw HID) |
+| **RevStripe** | Single-color LED strip | 1 (entire strip) | RGB333, 7 colors plus off |
 
 **Protocol selection by wheel type:**
 
 | Capability | Protocol | Collection | Color Depth |
 |------------|----------|------------|-------------|
 | RGB LED + col03 support | Modern | [col03 0x01](#0x01--led-control) | RGB565 (65K colors) |
-| RGB LED + no col03 | Legacy RGB | [col01 0x09/0x0A](#0x09--0x0a--rgb-rev-led-data-legacy) | RGB333 via col01 |
+| RGB LED + no col03 | Legacy RGB | [col01 0x0A](#0x0a--legacy-rgb-rev-leds-per-led-3-bit-color) | 3-bit per LED via col01 |
 | Non-RGB LED | Legacy bitmask | [col01 0x08](#0x08--rev-led-data-bitmask--color) | On/off only + global RGB333 |
-| RevStripe | Legacy color | [col01 0x06](#0x06--revstripe-enabledisable) + [0x08](#0x08--rev-led-data-bitmask--color) | RGB333 (512 colors) |
+| RevStripe | Legacy color | [col01 0x08](#0x08--rev-led-data-bitmask--color) | RGB333, 7 colors plus off |
 
 See the [devices reference](devices.md#wheel-protocol-summary) for the per-wheel capability matrix.
 
@@ -1094,7 +1126,7 @@ byte[5] (data_hi):  [ G1 G0 | R2 R1 R0 | B2 B1 B0 ]   (GG_RRR_BBB)
 byte[4] (data_lo):  [  0  0   0  0  0   0  0  G2  ]   (.......G)
 ```
 
-Each channel has 3 bits (0–7), yielding 512 possible colors:
+Each channel has 3 bits (0–7), so 512 values are representable, but no hardware tested to date renders more than the eight fully saturated combinations — seven colors plus off. Those eight are also the only values official software emits, and at least one of the remainder (`01 00`) puts the rim into pattern mode, see [`0x07`](#0x07--rev-led-mode-color--bitmask).
 
 | Color | R | G | B | data_lo (byte[4]) | data_hi (byte[5]) |
 |-------|---|---|---|-------------------|-------------------|
@@ -1107,22 +1139,43 @@ Each channel has 3 bits (0–7), yielding 512 possible colors:
 | Cyan | 0 | 7 | 7 | `0x01` | `0xC7` |
 | White | 7 | 7 | 7 | `0x01` | `0xFF` |
 
-> **Note:** The official software only uses 8 discrete colors (each channel fully on or fully off). The hardware encoding supports 3 bits per channel, so intermediate values (e.g., R=4, G=2, B=0) may work but are not officially exercised.
 
-### RGB565 Color Encoding
+### BGR565 Color Encoding
 
-The modern col03 protocol uses **16-bit RGB565** values in **big-endian** byte order:
+The modern col03 protocol uses 16-bit colors in **big-endian** byte order, packed **blue-high, red-low**:
 
 ```
-Bits:  RRRRR GGGGGG BBBBB
+Bits:  BBBBB GGGGGG RRRRR
        15-11  10-5   4-0
 ```
 
-- Red: 5 bits (0–31)
-- Green: 6 bits (0–63)
 - Blue: 5 bits (0–31)
+- Green: 6 bits (0–63)
+- Red: 5 bits (0–31)
 - 65,536 possible colors
 - `0x0000` = LED off
+
+Sanity check: pure red is `0x001F`, pure blue is `0xF800`.
+
+**Channel order is per-interface**, and no format name carries it:
+
+| Path | Channel order (high → low) |
+|---|---|
+| col03 color (`FF 01 00/01/02`) | **B, G, R** |
+| col01 [`0x08`](#0x08--rev-led-data-bitmask--color) RevStripe color | **G, R, B** |
+| col01 [`0x0A`](#0x0a--legacy-rgb-rev-leds-per-led-3-bit-color) per-LED 3-bit | **R, G, B** (bits `3n`, `3n+1`, `3n+2`) |
+
+Green sits in bits 10-5 under either 565 layout, so a green-only value cannot distinguish them. Verify ordering with red or blue.
+
+#### BGR555 variant
+
+Some hardware reads only 5 green bits and ignores the sixth. For those devices, quantize green to 5 bits and place it in the **low 5 bits of the green field**, leaving bit 10 clear:
+
+```
+Bits:  BBBBB _GGGGG RRRRR
+       15-11 10 9-5  4-0
+        (bit 10 always zero)
+```
 
 ### 7-Segment Encoding Tables
 

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -33,10 +33,10 @@ These profiles are based on SDK data and should work, but have not been tested o
 | ClubSport RS | On/Off | — | — | 3-digit |
 | CSL Elite McLaren GT3 V1.0 | — | — | — | 3-digit |
 | CSL Elite McLaren GT3 V2 | — | — | — | 3-digit |
-| CSL Elite P1 (Xbox) | 512 colors (RevStripe) | — | — | 3-digit |
-| CSL Elite P1 (PS4) | 512 colors (RevStripe) | — | — | 3-digit |
+| CSL Elite P1 (Xbox) | 8 colors (RevStripe) | — | — | 3-digit |
+| CSL Elite P1 (PS4) | 8 colors (RevStripe) | — | — | 3-digit |
 | CSL Elite Porsche Vision GT | — | — | — | 3-digit |
-| CSL Elite WRC | 512 colors (RevStripe) | — | — | 3-digit |
+| CSL Elite WRC | 8 colors (RevStripe) | — | — | 3-digit |
 | CSL GT3 | — | — | — | 3-digit |
 | GT PRO | 8 colors | — | — | 3-digit |
 | Podium Bentley GT3 | Full color | Full color | — | ITM |

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -76,7 +76,7 @@ LEDs associated with rotary encoders on button modules. Controlled via the butto
 15-bit color encoding: 5 bits per channel. Slightly reduced color range vs RGB565 (green channel has 5 bits instead of 6).
 
 ### RGB333
-9-bit color encoding: 3 bits per channel, packed across 2 bytes. Used by the legacy col01 LED protocol for RevStripe and global rev LED color. The SDK only exercises 8 discrete values (each channel fully on or fully off), but the hardware supports the full 512-color range. See [RGB333 Color Encoding](reference/protocol.md#rgb333-color-encoding).
+9-bit color encoding: 3 bits per channel, packed across 2 bytes. Used by the legacy col01 LED protocol for RevStripe color. 512 values are representable, but no hardware tested to date renders more than the eight fully saturated combinations — seven colors plus off. Official software emits no others, and at least one of the remainder switches the rim into pattern mode. See [RGB333 Color Encoding](reference/protocol.md#rgb333-color-encoding).
 
 ---
 

--- a/src/FanaBridge.Core/Profiles/LedColorLimitation.cs
+++ b/src/FanaBridge.Core/Profiles/LedColorLimitation.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FanaBridge.Profiles
+{
+    /// <summary>
+    /// A way in which a wheel's LEDs cannot show what SimHub's color picker offers.
+    /// </summary>
+    /// <remarks>
+    /// SimHub presents a full 24-bit picker for every LED regardless of what the
+    /// hardware can do. Most Fanatec LEDs are RGB565 and near enough, but several
+    /// channels are far more limited — and the difference is invisible until the
+    /// wheel does something unexpected. These descriptions drive the notice shown
+    /// in the LEDs tab.
+    /// </remarks>
+    public sealed class LedColorLimitation
+    {
+        public LedColorLimitation(string text)
+        {
+            Text = text;
+        }
+
+        /// <summary>One plain sentence the user can act on. Shown verbatim.</summary>
+        public string Text { get; }
+
+        /// <summary>
+        /// Describes every color limitation present on a wheel, or an empty list
+        /// when its LEDs can render the picker's range faithfully.
+        /// </summary>
+        public static IReadOnlyList<LedColorLimitation> ForCapabilities(WheelCapabilities caps)
+        {
+            var result = new List<LedColorLimitation>();
+            if (caps == null) return result;
+
+            var leds = caps.Profile?.Leds;
+            string device = DeviceNoun(caps.Profile);
+
+            const string Palette = "red, green, blue, cyan, magenta, yellow and white";
+            // Shared so the two palette messages can't drift apart.
+            const string Matched = " Any other color is matched to the closest.";
+
+            if (caps.HasLegacyRevOnOff)
+            {
+                result.Add(new LedColorLimitation(
+                    "This " + device + "'s " + Subject(leds, "Rev LEDs", LedChannel.LegacyRevOnOff) +
+                    " can only be switched on or off, so only brightness matters — the hue is ignored."));
+            }
+
+            // The RevStripe and the per-LED case say the same thing, so each leads
+            // with what distinguishes it rather than repeating the other verbatim
+            // when a device has both.
+            if (caps.HasLegacyRevStripe)
+            {
+                result.Add(new LedColorLimitation(
+                    // "RevStripe" is Fanatec's name for this part, so it stays literal
+                    // rather than being described. See docs/terminology.md.
+                    "This " + device + "'s RevStripe is a single light supporting a limited color " +
+                    "palette: " + Palette + "." + Matched));
+            }
+
+            if (caps.HasLegacyRev3Bit || caps.HasLegacyFlag3Bit)
+            {
+                result.Add(new LedColorLimitation(
+                    "This " + device + "'s " +
+                    Subject(leds, "LEDs", LedChannel.LegacyRev3Bit, LedChannel.LegacyFlag3Bit) +
+                    " only support a limited color palette: " + Palette + "." + Matched));
+            }
+
+            if (caps.ButtonAuxIntensityCount > 0)
+            {
+                result.Add(new LedColorLimitation(
+                    "This " + device + "'s " + Subject(leds, "LEDs", LedChannel.ButtonAuxIntensity) +
+                    " can't have their color controlled — only their brightness."));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// What to call the thing the LEDs are on. A hub has no LEDs of its own —
+        /// they belong to the button module attached to it — so a hub+module
+        /// profile describes the module, and everything else describes the wheel.
+        /// </summary>
+        private static string DeviceNoun(WheelProfile profile)
+        {
+            if (profile == null) return "device";
+            return string.IsNullOrEmpty(profile.Match?.ModuleType) ? "wheel" : "module";
+        }
+
+        /// <summary>
+        /// Names the LEDs a limitation applies to, in the user's terms, by reading
+        /// the roles the profile assigned them — "Rev LEDs", "Rev and Flag LEDs",
+        /// "Encoder LEDs". A channel is not tied to one role, and custom profiles
+        /// assign them freely, so this cannot be hardcoded per channel. Names follow
+        /// docs/terminology.md.
+        /// </summary>
+        /// <param name="fallback">
+        /// Used when no profile is available to read roles from.
+        /// </param>
+        private static string Subject(
+            IReadOnlyList<LedDefinition> leds, string fallback, params LedChannel[] channels)
+        {
+            var roles = RolesFor(leds, channels);
+            if (roles.Count == 0) return fallback;
+
+            // Roles share the noun: "rev and flag LEDs", not "rev LEDs and flag LEDs".
+            return Join(roles.Select(Adjective).ToList()) + " LEDs";
+        }
+
+        private static List<LedRole> RolesFor(
+            IReadOnlyList<LedDefinition> leds, LedChannel[] channels)
+        {
+            if (leds == null) return new List<LedRole>();
+
+            return leds
+                .Where(l => channels.Contains(l.Channel))
+                .Select(l => l.Role)
+                .Distinct()
+                .OrderBy(r => (int)r)
+                .ToList();
+        }
+
+        // "a", "a and b", "a, b and c" — no Oxford comma, matching ordinary prose.
+        private static string Join(IReadOnlyList<string> parts)
+        {
+            if (parts.Count == 1) return parts[0];
+            return string.Join(", ", parts.Take(parts.Count - 1)) + " and " + parts[parts.Count - 1];
+        }
+
+        private static string Adjective(LedRole role)
+        {
+            switch (role)
+            {
+                case LedRole.Rev: return "Rev";
+                case LedRole.Flag: return "Flag";
+                case LedRole.Button: return "Button";
+                case LedRole.Encoder: return "Encoder";
+                case LedRole.Indicator: return "Indicator";
+                default: return "";
+            }
+        }
+    }
+}

--- a/src/FanaBridge.Core/Protocol/ColorHelper.cs
+++ b/src/FanaBridge.Core/Protocol/ColorHelper.cs
@@ -193,10 +193,10 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
-        /// Converts a Color to per-channel RGB booleans, with alpha premultiply.
-        /// Each channel is true when its premultiplied value rounds to >= 1
-        /// (i.e. the raw value is >= 0.5).
-        /// Used for col01 subcmd 0x0A per-LED RGB encoding (8 discrete colors).
+        /// Converts a Color to per-channel RGB booleans. A channel is lit when it
+        /// is at least half the brightest channel's value. Alpha determines whether
+        /// the LED is lit at all, but does not change which channels are selected.
+        /// Used for col01 subcmd 0x0A/0x0B per-LED RGB encoding (7 colors plus off).
         /// </summary>
         public static (bool R, bool G, bool B) ColorToRgbBools(System.Drawing.Color color)
         {

--- a/src/FanaBridge.Core/Protocol/ColorHelper.cs
+++ b/src/FanaBridge.Core/Protocol/ColorHelper.cs
@@ -116,6 +116,83 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
+        /// Converts 24-bit RGB to the col01 RGB333 encoding, snapped to the eight
+        /// fully saturated values (each channel fully on or fully off) that official
+        /// software emits.
+        /// <para>
+        /// The col01 <c>0x08</c> command carries either a per-LED on/off pattern or a
+        /// single RGB333 color, and both share one wire format. RGB333 <c>(r=0, g=4,
+        /// b=0)</c> — a mid-dark green — encodes to the same two bytes as the "LED 0
+        /// on, rest off" pattern, and the Fanatec driver stack reacts to that pattern
+        /// by switching the rim into on/off mode. Later colors are then read as
+        /// patterns, so the strip lights in its fixed pattern color for the values
+        /// whose low byte has bit 0 set and stays dark for the rest, until pure red
+        /// or pure blue returns it to color mode. Snapping keeps output inside the
+        /// set the hardware is known to be driven with and cannot produce that
+        /// encoding.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Each channel is judged <em>relative to the brightest channel</em>, not against
+        /// a fixed level. Thresholding channels absolutely would make the hue depend on
+        /// brightness — amber dimmed past the point where green falls below the cut but
+        /// red does not would turn red, then black. Scaling all channels by the same
+        /// factor cannot change which side of a relative threshold they sit on, so the
+        /// chosen color survives dimming. Deciding whether the strip is lit at all is a
+        /// separate question, handled by <see cref="ToRgb333PalettePremultiplied"/>.
+        /// </remarks>
+        public static ushort RgbToRgb333Palette(byte r, byte g, byte b)
+        {
+            var (litR, litG, litB) = LitChannels(r, g, b);
+            return RgbToRgb333(
+                litR ? (byte)0xFF : (byte)0x00,
+                litG ? (byte)0xFF : (byte)0x00,
+                litB ? (byte)0xFF : (byte)0x00);
+        }
+
+        /// <summary>
+        /// Which color channels count as lit, judged relative to the brightest one.
+        /// Shared by every col01 path that has one bit per channel to work with.
+        /// </summary>
+        private static (bool R, bool G, bool B) LitChannels(byte r, byte g, byte b)
+        {
+            int max = Math.Max(r, Math.Max(g, b));
+            if (max == 0) return (false, false, false);
+            return (IsLit(r, max), IsLit(g, max), IsLit(b, max));
+        }
+
+        // channel >= max/2, written to avoid integer truncation: at max=1 a truncated
+        // threshold of 0 would count every channel — including the zero ones — as lit
+        // and turn a near-black red into white.
+        private static bool IsLit(byte channel, int max)
+        {
+            return channel > 0 && channel * 2 >= max;
+        }
+
+        /// <summary>
+        /// Converts a System.Drawing.Color to the snapped RGB333 palette encoding,
+        /// pre-multiplying alpha. See <see cref="RgbToRgb333Palette"/>.
+        /// <para>
+        /// The rim has no separate intensity channel, so brightness cannot dim the
+        /// strip — it can only decide whether the strip is lit. That cut-off uses the
+        /// same rule <c>legacyRevOnOff</c> applies to individual LEDs, so both col01
+        /// channels agree on when hardware counts as on.
+        /// </para>
+        /// </summary>
+        public static ushort ToRgb333PalettePremultiplied(System.Drawing.Color color)
+        {
+            if (ColorToIntensity(color) == 0) return 0;
+
+            // Hue comes from the original channels, not the premultiplied ones.
+            // Alpha scales all three equally, so it cannot change which side of a
+            // relative threshold they fall on — but rounding each channel to a byte
+            // first can, and did: ARGB(255,20,9,0) and ARGB(240,20,9,0) resolved to
+            // red while ARGB(248,20,9,0) resolved to yellow. Alpha decides only
+            // whether the strip is lit.
+            return RgbToRgb333Palette(color.R, color.G, color.B);
+        }
+
+        /// <summary>
         /// Converts a Color to per-channel RGB booleans, with alpha premultiply.
         /// Each channel is true when its premultiplied value rounds to >= 1
         /// (i.e. the raw value is >= 0.5).
@@ -123,12 +200,13 @@ namespace FanaBridge.Protocol
         /// </summary>
         public static (bool R, bool G, bool B) ColorToRgbBools(System.Drawing.Color color)
         {
-            double a = color.A / 255.0;
-            return (
-                Math.Round(color.R * a) > 0,
-                Math.Round(color.G * a) > 0,
-                Math.Round(color.B * a) > 0
-            );
+            // Same rule as the RGB333 palette: a channel is lit relative to the
+            // brightest one, and alpha decides only whether the LED is lit at all.
+            // Thresholding each channel at "greater than zero" instead would turn
+            // RGB(255,1,0) — visually pure red — into yellow, and light an LED for
+            // any trace value a gradient happens to pass through.
+            if (ColorToIntensity(color) == 0) return (false, false, false);
+            return LitChannels(color.R, color.G, color.B);
         }
 
         /// <summary>

--- a/src/FanaBridge.Core/Protocol/LegacyLedEncoder.cs
+++ b/src/FanaBridge.Core/Protocol/LegacyLedEncoder.cs
@@ -26,8 +26,11 @@ namespace FanaBridge.Protocol
         private const int REPORT_LENGTH = 8;
 
         // Subcmd bytes (byte[3] in the report)
-        private const byte SUBCMD_GLOBAL_ENABLE = 0x02;
+        //
+        // 0x02 is deliberately absent: it addresses a separate white LED on the rim,
+        // not the rev LEDs, so it has no business in an LED write path.
         private const byte SUBCMD_REVSTRIPE_ENABLE = 0x06;
+        private const byte SUBCMD_REV_LED_MODE = 0x07;
         private const byte SUBCMD_LED_DATA = 0x08;
         private const byte SUBCMD_LED_RGB_DATA = 0x0A;
         private const byte SUBCMD_FLAG_RGB_DATA = 0x0B;
@@ -44,9 +47,10 @@ namespace FanaBridge.Protocol
         // overwritten by that send's re-latch of the old state.
         private volatile bool _forceDirty;
 
-        // ── State tracking for enable sequences ────────────────────────────
-        private bool _globalEnabled;
-        private bool _revStripeEnabled;
+        // ── State tracking ─────────────────────────────────────────────────
+        // Whether we have prepared this rim for stripe color yet. One-shot per
+        // connection; re-armed by ForceDirty so a wheel change re-prepares.
+        private bool _revStripePrepared;
 
         // ── Pooled report buffer ───────────────────────────────────────────
         private readonly byte[] _reportBuf = new byte[REPORT_LENGTH];
@@ -59,7 +63,7 @@ namespace FanaBridge.Protocol
         /// <summary>
         /// Sets bitmask rev LED state for non-RGB rims.
         /// Each element in <paramref name="onOff"/> maps to one LED (index 0 = LED 0).
-        /// Sends a global enable on first use, then sends the bitmask via subcmd 0x08.
+        /// Sends the bitmask via subcmd 0x08.
         /// Skips the HID write when the bitmask hasn't changed.
         /// </summary>
         /// <param name="onOff">Per-LED on/off state. Max 9 LEDs.</param>
@@ -88,13 +92,10 @@ namespace FanaBridge.Protocol
             if (bitmask == _lastBitmask)
                 return true;
 
-            // Ensure global rev LEDs are enabled
-            if (!_globalEnabled)
-            {
-                if (!SendGlobalEnable(true))
-                    return false;
-                _globalEnabled = true;
-            }
+            // A bitmask write can itself make the driver stack switch the rim into
+            // pattern mode, so any previously asserted color mode is no longer known
+            // to hold.
+            _revStripePrepared = false;
 
             // Send bitmask: [RID, F8, 09, 08, data_lo, data_hi, 00, 00]
             bool ok = SendLedData(dataLo, dataHi);
@@ -106,27 +107,43 @@ namespace FanaBridge.Protocol
         /// <summary>
         /// Sets the RevStripe color for single-strip rims.
         /// The <paramref name="rgb333"/> value is a packed RGB333 color from
-        /// <see cref="ColorHelper.RgbToRgb333"/> (high byte = data_hi, low byte = data_lo).
-        /// Sends the enable sequence on first use.
+        /// <see cref="ColorHelper.RgbToRgb333Palette"/> (high byte = data_hi, low byte = data_lo).
+        /// Asserts color mode on first use.
         /// Skips the HID write when the color hasn't changed.
         /// </summary>
+        /// <remarks>
+        /// Values outside the eight-color palette are snapped here rather than
+        /// trusted from the caller. RGB333 <c>0x0001</c> is byte-identical to the
+        /// "LED 0 only" pattern and makes the driver stack switch the rim out of
+        /// color mode — so the guarantee has to hold at the wire boundary, not only
+        /// in whichever caller happens to be wired up today.
+        /// </remarks>
         public bool SetRevStripeColor(ushort rgb333)
         {
             ConsumePendingForceDirty();
+
+            rgb333 = SnapToPalette(rgb333);
 
             // Dirty check
             if (rgb333 == _lastRevStripeColor)
                 return true;
 
-            // Ensure RevStripe is enabled (inverted semantics: 0x00 = ON)
-            if (!_revStripeEnabled)
+            // Prepare the rim once per connection.
+            //
+            // 0x06 is a stored preference rather than a per-frame control, so it is
+            // sent once and never with the disable value — a user whose stripe is
+            // switched off has no other way to turn it back on from here, but
+            // flipping it off again on every clear would be trampling their setting.
+            //
+            // 0x07 recovers a rim another application left interpreting 0x08 as an
+            // on/off pattern; nothing in a color write alone undoes that.
+            if (!_revStripePrepared)
             {
-                if (!SendRevStripeEnable(true))
+                if (!SendRevStripeEnable())
                     return false;
-                if (!SendGlobalEnable(true))
+                if (!SendRevLedMode(false))
                     return false;
-                _revStripeEnabled = true;
-                _globalEnabled = true;
+                _revStripePrepared = true;
             }
 
             byte dataHi = (byte)((rgb333 >> 8) & 0xFF);
@@ -143,7 +160,7 @@ namespace FanaBridge.Protocol
         /// Each LED gets 3 consecutive bytes (R, G, B) in <paramref name="rgbBools"/>,
         /// where any nonzero value means "on" for that channel (1 bit per channel =
         /// 7 colors + off). Max 9 LEDs (27 bytes).
-        /// Sends a global enable on first use, then packs 27 bits into 4 data bytes.
+        /// Packs 27 bits into 4 data bytes.
         /// Skips the HID write when the packed state hasn't changed.
         /// </summary>
         /// <param name="rgbBools">Flat array: [LED0.R, LED0.G, LED0.B, LED1.R, ...]. Max 27 bytes.</param>
@@ -164,14 +181,6 @@ namespace FanaBridge.Protocol
             // Dirty check
             if (packed == _lastRev3BitPacked)
                 return true;
-
-            // Ensure global rev LEDs are enabled
-            if (!_globalEnabled)
-            {
-                if (!SendGlobalEnable(true))
-                    return false;
-                _globalEnabled = true;
-            }
 
             // Send: [RID, F8, 09, 0A, data0, data1, data2, data3]
             bool ok = SendLedRgbData(
@@ -212,14 +221,6 @@ namespace FanaBridge.Protocol
             if (packed == _lastFlag3BitPacked)
                 return true;
 
-            // Ensure global rev LEDs are enabled
-            if (!_globalEnabled)
-            {
-                if (!SendGlobalEnable(true))
-                    return false;
-                _globalEnabled = true;
-            }
-
             // Send: [RID, F8, 09, 0B, d0, d1, d2, d3]
             bool ok = SendFlagRgbData(
                 (byte)(packed & 0xFF),
@@ -232,24 +233,25 @@ namespace FanaBridge.Protocol
         }
 
         /// <summary>
-        /// Clears all legacy LEDs — turns off bitmask LEDs or RevStripe.
+        /// Clears every legacy LED channel this encoder has driven.
         /// </summary>
         public void Clear()
         {
-            // Send all-off bitmask / zero color
-            SendLedData(0x00, 0x00);
+            // Each channel has to be zeroed on its own subcommand — a 0x08 frame does
+            // nothing for LEDs addressed via 0x0A or 0x0B, which would otherwise stay
+            // lit at their last color. Untouched channels are left alone so we don't
+            // write to hardware the profile never claimed.
+            //
+            // Nothing else is sent: turning LEDs off is not a reason to touch the
+            // rim's white LED or its stored preferences.
+            if (_lastBitmask != 0xFFFF || _lastRevStripeColor != 0xFFFF)
+                SendLedData(0x00, 0x00);
 
-            if (_globalEnabled)
-            {
-                SendGlobalEnable(false);
-                _globalEnabled = false;
-            }
+            if (_lastRev3BitPacked != 0xFFFFFFFF)
+                SendLedRgbData(0x00, 0x00, 0x00, 0x00);
 
-            if (_revStripeEnabled)
-            {
-                SendRevStripeEnable(false);
-                _revStripeEnabled = false;
-            }
+            if (_lastFlag3BitPacked != 0xFFFFFFFF)
+                SendFlagRgbData(0x00, 0x00, 0x00, 0x00);
 
             ForceDirty();
         }
@@ -275,30 +277,49 @@ namespace FanaBridge.Protocol
             _lastRevStripeColor = 0xFFFF;
             _lastRev3BitPacked = 0xFFFFFFFF;
             _lastFlag3BitPacked = 0xFFFFFFFF;
-            _globalEnabled = false;
-            _revStripeEnabled = false;
+            _revStripePrepared = false;
         }
 
         // ── Low-level report senders ───────────────────────────────────────
 
         /// <summary>
-        /// Sends the Rev LED Global On/Off command.
-        /// [RID, F8, 09, 02, enable, 00, 00, 00]
+        /// Forces a packed RGB333 value onto the eight-color palette, unpacking it
+        /// and re-snapping rather than trusting the caller.
         /// </summary>
-        private bool SendGlobalEnable(bool enable)
+        private static ushort SnapToPalette(ushort rgb333)
         {
-            BuildReport(SUBCMD_GLOBAL_ENABLE, enable ? (byte)0x01 : (byte)0x00, 0x00, 0x00, 0x00);
+            int dataHi = (rgb333 >> 8) & 0xFF;
+            int dataLo = rgb333 & 0xFF;
+
+            // Inverse of ColorHelper.RgbToRgb333
+            int g3 = ((dataLo & 0x01) << 2) | ((dataHi >> 6) & 0x03);
+            int r3 = (dataHi >> 3) & 0x07;
+            int b3 = dataHi & 0x07;
+
+            return ColorHelper.RgbToRgb333Palette(
+                (byte)(r3 * 255 / 7), (byte)(g3 * 255 / 7), (byte)(b3 * 255 / 7));
+        }
+
+        /// <summary>
+        /// Enables the RevStripe. Inverted semantics — <c>0x00</c> means on. There is
+        /// deliberately no disable: this is stored state, not a per-frame control.
+        /// [RID, F8, 09, 06, 00, 00, 00, 00]
+        /// </summary>
+        private bool SendRevStripeEnable()
+        {
+            BuildReport(SUBCMD_REVSTRIPE_ENABLE, 0x00, 0x00, 0x00, 0x00);
             return _transport.SendCol01(_reportBuf);
         }
 
         /// <summary>
-        /// Sends the RevStripe Enable/Disable command.
-        /// Inverted semantics: 0x00 = ON, 0x01 = OFF.
-        /// [RID, F8, 09, 06, enable, 00, 00, 00]
+        /// Selects how the rim interprets subsequent <c>0x08</c> writes.
+        /// <c>false</c> = the payload is an RGB333 color, <c>true</c> = it is a
+        /// per-LED on/off pattern.
+        /// [RID, F8, 09, 07, mode, 00, 00, 00]
         /// </summary>
-        private bool SendRevStripeEnable(bool enable)
+        private bool SendRevLedMode(bool bitmask)
         {
-            BuildReport(SUBCMD_REVSTRIPE_ENABLE, enable ? (byte)0x00 : (byte)0x01, 0x00, 0x00, 0x00);
+            BuildReport(SUBCMD_REV_LED_MODE, bitmask ? (byte)0x01 : (byte)0x00, 0x00, 0x00, 0x00);
             return _transport.SendCol01(_reportBuf);
         }
 

--- a/src/FanaBridge.Core/Protocol/LegacyLedEncoder.cs
+++ b/src/FanaBridge.Core/Protocol/LegacyLedEncoder.cs
@@ -48,9 +48,11 @@ namespace FanaBridge.Protocol
         private volatile bool _forceDirty;
 
         // ── State tracking ─────────────────────────────────────────────────
-        // Whether we have prepared this rim for stripe color yet. One-shot per
-        // connection; re-armed by ForceDirty so a wheel change re-prepares.
-        private bool _revStripePrepared;
+        // 0x06 is a stored enable preference, while 0x07 selects how the next 0x08
+        // payload is interpreted. A bitmask write invalidates only the latter;
+        // ForceDirty invalidates both when the physical connection may have changed.
+        private bool _revStripeEnabled;
+        private bool _revStripeColorModeAsserted;
 
         // ── Pooled report buffer ───────────────────────────────────────────
         private readonly byte[] _reportBuf = new byte[REPORT_LENGTH];
@@ -93,9 +95,11 @@ namespace FanaBridge.Protocol
                 return true;
 
             // A bitmask write can itself make the driver stack switch the rim into
-            // pattern mode, so any previously asserted color mode is no longer known
-            // to hold.
-            _revStripePrepared = false;
+            // pattern mode, and it overwrites the shared 0x08 payload. The next
+            // stripe write therefore has to restore both color mode and color, even
+            // when the requested color matches the one sent before this pattern.
+            _revStripeColorModeAsserted = false;
+            _lastRevStripeColor = 0xFFFF;
 
             // Send bitmask: [RID, F8, 09, 08, data_lo, data_hi, 00, 00]
             bool ok = SendLedData(dataLo, dataHi);
@@ -124,11 +128,18 @@ namespace FanaBridge.Protocol
 
             rgb333 = SnapToPalette(rgb333);
 
-            // Dirty check
-            if (rgb333 == _lastRevStripeColor)
+            // The cached color is meaningful only while color mode is still known
+            // to hold. Bitmask writes invalidate both facts above.
+            if (rgb333 == _lastRevStripeColor && _revStripeColorModeAsserted)
                 return true;
 
-            // Prepare the rim once per connection.
+            // Entering color mode or writing color data invalidates the cached
+            // bitmask state that shares this 0x08 payload. Do this before sending
+            // so partial success cannot leave a later bitmask shortcut armed.
+            _lastBitmask = 0xFFFF;
+
+            // Enable the stripe once per connection, and assert color mode whenever
+            // a bitmask write has made its interpretation of 0x08 uncertain.
             //
             // 0x06 is a stored preference rather than a per-frame control, so it is
             // sent once and never with the disable value — a user whose stripe is
@@ -137,13 +148,18 @@ namespace FanaBridge.Protocol
             //
             // 0x07 recovers a rim another application left interpreting 0x08 as an
             // on/off pattern; nothing in a color write alone undoes that.
-            if (!_revStripePrepared)
+            if (!_revStripeEnabled)
             {
                 if (!SendRevStripeEnable())
                     return false;
+                _revStripeEnabled = true;
+            }
+
+            if (!_revStripeColorModeAsserted)
+            {
                 if (!SendRevLedMode(false))
                     return false;
-                _revStripePrepared = true;
+                _revStripeColorModeAsserted = true;
             }
 
             byte dataHi = (byte)((rgb333 >> 8) & 0xFF);
@@ -277,7 +293,8 @@ namespace FanaBridge.Protocol
             _lastRevStripeColor = 0xFFFF;
             _lastRev3BitPacked = 0xFFFFFFFF;
             _lastFlag3BitPacked = 0xFFFFFFFF;
-            _revStripePrepared = false;
+            _revStripeEnabled = false;
+            _revStripeColorModeAsserted = false;
         }
 
         // ── Low-level report senders ───────────────────────────────────────

--- a/src/FanaBridge/Adapters/FanatecLedDriver.cs
+++ b/src/FanaBridge/Adapters/FanatecLedDriver.cs
@@ -243,7 +243,7 @@ namespace FanaBridge.Adapters
                         break;
 
                     case LedChannel.LegacyRevStripe:
-                        legacyRevStripeColor = ColorHelper.ToRgb333Premultiplied(color);
+                        legacyRevStripeColor = ColorHelper.ToRgb333PalettePremultiplied(color);
                         break;
 
                     case LedChannel.LegacyRev3Bit:

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -134,6 +134,16 @@ namespace FanaBridge.Adapters
         // ── LED module setup ─────────────────────────────────────────────
 
         /// <summary>
+        /// Resolves this descriptor's capabilities as of now, rather than as of
+        /// whenever the LED module happened to be created.
+        /// </summary>
+        private WheelCapabilities ResolveCurrentCapabilities()
+        {
+            var plugin = _boundPlugin ?? PluginResolver();
+            return plugin == null ? WheelCapabilities.None : plugin.ResolveCapsFor(_config);
+        }
+
+        /// <summary>
         /// Lazily creates the LedModuleSettings for this device.
         /// A single module handles all LED types (Rev, Flag, Button/Encoder)
         /// through the unified <see cref="FanatecLedDriver"/>.
@@ -174,6 +184,19 @@ namespace FanaBridge.Adapters
                 ShowConnectionStatus = true,
                 VID = FanatecWheelbase.FANATEC_VENDOR_ID,
             };
+
+            // Wheels whose LEDs can't render the picker's range get a note in the
+            // LEDs tab. The picker stays stock — constraining it would break
+            // gradients and imported profiles without fixing anything, since those
+            // never pass through it.
+            //
+            // The factory is installed unconditionally and the notice resolves
+            // capabilities itself when the tab is opened. This method runs once, and
+            // usually before identity has settled or a user profile override has
+            // been applied — deciding here would miss wheels whose real profile
+            // arrives later, and could never correct itself.
+            options.ExtraSettingsControlFactory =
+                _ => new UI.LedColorLimitationNotice(() => ResolveCurrentCapabilities());
 
             _ledModule = new LedModuleSettings<FanatecLedManager>(options);
             _ledModule.IsEmbedded = true;

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -137,9 +137,9 @@ namespace FanaBridge.Adapters
         /// Resolves this descriptor's capabilities as of now, rather than as of
         /// whenever the LED module happened to be created.
         /// </summary>
-        private WheelCapabilities ResolveCurrentCapabilities()
+        internal WheelCapabilities ResolveCurrentCapabilities()
         {
-            var plugin = _boundPlugin ?? PluginResolver();
+            var plugin = PluginResolver() ?? _boundPlugin;
             return plugin == null ? WheelCapabilities.None : plugin.ResolveCapsFor(_config);
         }
 

--- a/src/FanaBridge/UI/LedColorLimitationNotice.xaml
+++ b/src/FanaBridge/UI/LedColorLimitationNotice.xaml
@@ -1,0 +1,33 @@
+<UserControl x:Class="FanaBridge.UI.LedColorLimitationNotice"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Matches the info box on the Screen tab (ScreenSettingsPanel.xaml).
+         One sentence per limitation, no heading — a heading above a single
+         sentence just reads as two titles. -->
+    <!-- Side margins align this with the section headings and rules below it; the
+         host's extra-settings slot has no horizontal padding of its own, so
+         without them the box is visibly wider than everything it sits above. -->
+    <Border x:Name="root" Visibility="Collapsed"
+            Background="#1A4488CC" BorderBrush="#4488CC" BorderThickness="1"
+            CornerRadius="4" Padding="10,8" Margin="20,0,20,0">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Column="0" Text="&#x2139;" Foreground="#AADDFF"
+                       FontSize="12" Margin="0,0,8,0" VerticalAlignment="Top" />
+
+            <ItemsControl Grid.Column="1" x:Name="listLimitations">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Text}" Foreground="#AADDFF"
+                                   FontSize="12" TextWrapping="Wrap"
+                                   Margin="0,0,0,4" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/FanaBridge/UI/LedColorLimitationNotice.xaml.cs
+++ b/src/FanaBridge/UI/LedColorLimitationNotice.xaml.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using FanaBridge.Profiles;
+
+namespace FanaBridge.UI
+{
+    /// <summary>
+    /// Explains, in the SimHub LEDs tab, the ways this wheel's LEDs cannot show
+    /// the colors the picker offers.
+    /// <para>
+    /// This is presentation only. The colors are matched in the encoder, because
+    /// they also arrive from gradients, the brightness slider and imported LED
+    /// profiles — none of which pass through this UI, so constraining the picker
+    /// would mislead without fixing anything.
+    /// </para>
+    /// </summary>
+    public partial class LedColorLimitationNotice : UserControl
+    {
+        private readonly Func<WheelCapabilities> _resolveCaps;
+
+        /// <param name="resolveCaps">
+        /// Queried when this control is built — i.e. when the user opens the LEDs
+        /// tab — rather than when the LED module was created. The module is created
+        /// once, often before the wheel's identity has settled and before a user
+        /// profile override has been applied, so capabilities captured then can be
+        /// the built-in registration set rather than what is actually driving the
+        /// wheel.
+        /// </param>
+        public LedColorLimitationNotice(Func<WheelCapabilities> resolveCaps)
+        {
+            _resolveCaps = resolveCaps ?? throw new ArgumentNullException(nameof(resolveCaps));
+            InitializeComponent();
+            Refresh();
+        }
+
+        private void Refresh()
+        {
+            WheelCapabilities caps;
+            try
+            {
+                caps = _resolveCaps();
+            }
+            catch (Exception ex)
+            {
+                SimHub.Logging.Current.Warn("LedColorLimitationNotice: caps lookup failed: " + ex.Message);
+                return;
+            }
+
+            var limitations = LedColorLimitation.ForCapabilities(caps);
+            if (limitations.Count == 0) return;
+
+            listLimitations.ItemsSource = limitations;
+            root.Visibility = Visibility.Visible;
+        }
+    }
+}

--- a/tests/FanaBridge.Tests/ColorHelperTests.cs
+++ b/tests/FanaBridge.Tests/ColorHelperTests.cs
@@ -92,11 +92,27 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void ColorToRgbBools_LowAlpha_AboveRoundingThreshold_True()
+        public void ColorToRgbBools_BelowLowestIntensityStep_IsOff()
         {
-            // R=255, A=1 → premultiplied = 1.0, rounds to 1 → true
+            // A=1 is 0.4% brightness — below the hardware's lowest step, so the LED
+            // is off rather than lit at full red. Same cut-off legacyRevOnOff uses,
+            // so both col01 paths agree on when an LED counts as lit.
             var c = System.Drawing.Color.FromArgb(1, 255, 0, 0);
+            Assert.Equal(0, ColorHelper.ColorToIntensity(c));
+
             var (r, g, b) = ColorHelper.ColorToRgbBools(c);
+            Assert.False(r);
+            Assert.False(g);
+            Assert.False(b);
+        }
+
+        [Fact]
+        public void ColorToRgbBools_TraceChannel_DoesNotShiftTheHue()
+        {
+            // Thresholding each channel at "greater than zero" turned visually pure
+            // red into yellow, and lit a channel for any value a gradient passed
+            // through.
+            var (r, g, b) = ColorHelper.ColorToRgbBools(System.Drawing.Color.FromArgb(255, 255, 1, 0));
             Assert.True(r);
             Assert.False(g);
             Assert.False(b);
@@ -111,6 +127,115 @@ namespace FanaBridge.Tests
             Assert.True(r);
             Assert.False(g);
             Assert.True(b);
+        }
+
+        // ── RGB333 palette snapping (#76) ──────────────────────────────
+        //
+        // The col01 0x08 payload is ambiguous: RGB333 (0,4,0) is byte-identical to
+        // the "LED 0 only" on/off pattern, and the driver stack reacts to it by
+        // switching the rim out of color mode. Snapping to the eight saturated
+        // values makes that encoding unreachable.
+
+        // packed RGB333 for each saturated combination
+        private const ushort PalOff = 0x0000;
+        private const ushort PalRed = 0x3800;
+        private const ushort PalGreen = 0xC001;
+        private const ushort PalBlue = 0x0700;
+        private const ushort PalCyan = 0xC701;
+        private const ushort PalMagenta = 0x3F00;
+        private const ushort PalYellow = 0xF801;
+        private const ushort PalWhite = 0xFF01;
+        private const ushort Trigger = 0x0001;
+
+        private static readonly ushort[] Palette =
+        {
+            PalOff, PalRed, PalGreen, PalBlue, PalCyan, PalMagenta, PalYellow, PalWhite
+        };
+
+        [Theory]
+        [InlineData(255, 0, 0, PalRed)]
+        [InlineData(0, 255, 0, PalGreen)]
+        [InlineData(0, 0, 255, PalBlue)]
+        [InlineData(0, 255, 255, PalCyan)]
+        [InlineData(255, 0, 255, PalMagenta)]
+        [InlineData(255, 255, 0, PalYellow)]
+        [InlineData(255, 255, 255, PalWhite)]
+        [InlineData(0, 0, 0, PalOff)]
+        public void RgbToRgb333Palette_SaturatedInputs_RoundTrip(byte r, byte g, byte b, ushort expected)
+        {
+            Assert.Equal(expected, ColorHelper.RgbToRgb333Palette(r, g, b));
+        }
+
+        [Fact]
+        public void RgbToRgb333Palette_MidDarkGreen_NeverProducesTrigger()
+        {
+            // The whole 128-159 green band quantizes to g3=4 without snapping.
+            for (byte g = 128; g <= 159; g++)
+                Assert.NotEqual(Trigger, ColorHelper.RgbToRgb333Palette(0, g, 0));
+        }
+
+        [Fact]
+        public void RgbToRgb333Palette_NearBlackSingleChannel_KeepsItsHue()
+        {
+            // max=1: a truncated max/2 threshold of 0 counts the zero channels as lit
+            // and turns this white.
+            Assert.Equal(PalRed, ColorHelper.RgbToRgb333Palette(1, 0, 0));
+            Assert.Equal(PalBlue, ColorHelper.RgbToRgb333Palette(0, 0, 1));
+        }
+
+        [Fact]
+        public void RgbToRgb333Palette_ChannelAtExactlyHalf_IsLit()
+        {
+            // 10 is exactly half of 20 — inclusive, and not subject to truncation.
+            Assert.Equal(PalYellow, ColorHelper.RgbToRgb333Palette(20, 10, 0));
+            Assert.Equal(PalRed, ColorHelper.RgbToRgb333Palette(20, 9, 0));
+        }
+
+        [Theory]
+        // Thresholding after premultiplication made these three disagree: red,
+        // yellow, red — same color, three neighbouring alphas.
+        [InlineData(255)]
+        [InlineData(248)]
+        [InlineData(240)]
+        public void ToRgb333PalettePremultiplied_NearBlackHue_DoesNotDependOnAlpha(int alpha)
+        {
+            var c = System.Drawing.Color.FromArgb(alpha, 20, 9, 0);
+            Assert.Equal(PalRed, ColorHelper.ToRgb333PalettePremultiplied(c));
+        }
+
+        [Fact]
+        public void ToRgb333PalettePremultiplied_HueSurvivesDimming()
+        {
+            // Amber: thresholding channels against a fixed level would drop green
+            // before red and turn this red, then black, as brightness falls.
+            for (int alpha = 255; alpha >= 32; alpha -= 1)
+            {
+                var c = System.Drawing.Color.FromArgb(alpha, 255, 200, 0);
+                Assert.Equal(PalYellow, ColorHelper.ToRgb333PalettePremultiplied(c));
+            }
+        }
+
+        [Fact]
+        public void ToRgb333PalettePremultiplied_UnlitColorIsOff()
+        {
+            // Matches the rule legacyRevOnOff uses, so both col01 channels agree.
+            var c = System.Drawing.Color.FromArgb(4, 255, 255, 255);
+            Assert.Equal(0, ColorHelper.ColorToIntensity(c));
+            Assert.Equal(PalOff, ColorHelper.ToRgb333PalettePremultiplied(c));
+        }
+
+        [Fact]
+        public void ToRgb333PalettePremultiplied_OnlyEverEmitsPaletteValues()
+        {
+            foreach (var alpha in new[] { 255, 200, 160, 128, 96, 64, 32, 16, 8, 0 })
+                for (int r = 0; r < 256; r += 5)
+                    for (int g = 0; g < 256; g += 5)
+                        for (int b = 0; b < 256; b += 5)
+                        {
+                            var v = ColorHelper.ToRgb333PalettePremultiplied(
+                                System.Drawing.Color.FromArgb(alpha, r, g, b));
+                            Assert.Contains(v, Palette);
+                        }
         }
     }
 }

--- a/tests/FanaBridge.Tests/FanatecLedDriverTests.cs
+++ b/tests/FanaBridge.Tests/FanatecLedDriverTests.cs
@@ -87,6 +87,20 @@ namespace FanaBridge.Tests
             return transport;
         }
 
+        // As RunAllWhite, but drives every LED with a chosen color.
+        private static RecordingTransport RunAllColor(WheelCapabilities caps, Color color)
+        {
+            var transport = new RecordingTransport();
+            var driver = BuildDriver(caps, transport);
+            var raw = new Color[caps.AllLedCount];
+            for (int i = 0; i < raw.Length; i++) raw[i] = color;
+            var state = new LedDeviceState(new Color[0], new Color[0], new Color[0], new Color[0], raw);
+
+            Assert.True(driver.SendLeds(state, forceRefresh: true));
+            driver.Dispose();
+            return transport;
+        }
+
         private static bool Col03Has(RecordingTransport t, byte subcmd) => t.Col03.Any(r => r[2] == subcmd);
         private static bool Col01Has(RecordingTransport t, byte subcmd) => t.Col01.Any(r => r[3] == subcmd);
         private static byte[] Col03Last(RecordingTransport t, byte subcmd) => t.Col03.Last(r => r[2] == subcmd);
@@ -222,44 +236,89 @@ namespace FanaBridge.Tests
         }
 
         [Fact] // CSL P1 / WRC
-        public void Dispatch_LegacyRevStripe_SendsEnableSequenceAndData()
+        public void Dispatch_LegacyRevStripe_AssertsColorModeAndSendsData()
         {
             var t = RunAllWhite(Caps(("legacyRevStripe", 1)));
 
             Assert.Empty(t.Col03);
-            Assert.True(Col01Has(t, 0x06), "RevStripe enable (0x06) missing");
-            Assert.True(Col01Has(t, 0x02), "global enable (0x02) missing");
+            Assert.True(Col01Has(t, 0x07), "color-mode assert (0x07) missing");
             Assert.True(Col01Has(t, 0x08), "LED data (0x08) missing");
         }
 
         [Fact] // CSSWBMW etc.
-        public void Dispatch_LegacyRevOnOff_SendsGlobalEnableAndBitmask()
+        public void Dispatch_LegacyRevOnOff_SendsBitmask()
         {
             var t = RunAllWhite(Caps(("legacyRevOnOff", 9)));
 
             Assert.Empty(t.Col03);
-            Assert.True(Col01Has(t, 0x02), "global enable (0x02) missing");
             Assert.True(Col01Has(t, 0x08), "bitmask LED data (0x08) missing");
         }
 
         [Fact] // GTSWPRO
-        public void Dispatch_LegacyRev3Bit_SendsGlobalEnableAndRgbData()
+        public void Dispatch_LegacyRev3Bit_SendsRgbData()
         {
             var t = RunAllWhite(Caps(("legacyRev3Bit", 9)));
 
             Assert.Empty(t.Col03);
-            Assert.True(Col01Has(t, 0x02), "global enable (0x02) missing");
             Assert.True(Col01Has(t, 0x0A), "3-bit rev data (0x0A) missing");
         }
 
         [Fact] // supported channel, no shipped profile yet
-        public void Dispatch_LegacyFlag3Bit_SendsGlobalEnableAndFlagData()
+        public void Dispatch_LegacyFlag3Bit_SendsFlagData()
         {
             var t = RunAllWhite(Caps(("legacyFlag3Bit", 6)));
 
             Assert.Empty(t.Col03);
-            Assert.True(Col01Has(t, 0x02), "global enable (0x02) missing");
             Assert.True(Col01Has(t, 0x0B), "3-bit flag data (0x0B) missing");
+        }
+
+        [Fact] // #76 — the exact color that breaks the rim must never reach the wire
+        public void Dispatch_LegacyRevStripe_MidDarkGreen_IsSnappedNotSentRaw()
+        {
+            // Unsnapped, RGB(0,128,0) encodes to RGB333 0x0001 -> wire "01 00", which
+            // is byte-identical to the "LED 0 only" pattern and makes the driver stack
+            // switch the rim out of color mode. White would pass this test under
+            // either encoder, so it has to be this color.
+            var t = RunAllColor(Caps(("legacyRevStripe", 1)), Color.FromArgb(255, 0, 128, 0));
+
+            var colorFrames = t.Col01.Where(r => r[3] == 0x08).ToList();
+            Assert.NotEmpty(colorFrames);
+            Assert.All(colorFrames, r =>
+                Assert.False(r[4] == 0x01 && r[5] == 0x00, "raw 01 00 payload reached the wire"));
+
+            // Snapped to full green: data_lo = 0x01, data_hi = 0xC0.
+            Assert.Contains(colorFrames, r => r[4] == 0x01 && r[5] == 0xC0);
+        }
+
+        [Fact] // #82 — the rim white LED has no business in an LED write path
+        public void Dispatch_LegacyChannels_NeverSendWhiteLed()
+        {
+            foreach (var caps in new[]
+                     {
+                         Caps(("legacyRevStripe", 1)),
+                         Caps(("legacyRevOnOff", 9)),
+                         Caps(("legacyRev3Bit", 9)),
+                         Caps(("legacyFlag3Bit", 6)),
+                     })
+            {
+                var t = RunAllWhite(caps);
+                Assert.False(Col01Has(t, 0x02), "rim white LED (0x02) must not be sent");
+            }
+        }
+
+        [Fact] // #82 — 0x06 is stored state, only the stripe path may touch it
+        public void Dispatch_NonStripeChannels_NeverTouchStripePreference()
+        {
+            foreach (var caps in new[]
+                     {
+                         Caps(("legacyRevOnOff", 9)),
+                         Caps(("legacyRev3Bit", 9)),
+                         Caps(("legacyFlag3Bit", 6)),
+                     })
+            {
+                var t = RunAllWhite(caps);
+                Assert.False(Col01Has(t, 0x06), "stripe preference (0x06) must not be sent");
+            }
         }
     }
 }

--- a/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
@@ -71,11 +71,14 @@ namespace FanaBridge.Tests
 
         // A plugin generation whose core is a wheelbase with a committed,
         // settled identity for the given wheel code (or none when null).
-        private static FanatecPlugin PluginWithWheel(string? wheelCode, out FanatecWheelbase wheelbase)
+        private static FanatecPlugin PluginWithWheel(
+            string? wheelCode, out FanatecWheelbase wheelbase, string? overrideProfileId = null)
         {
             var t = new FakeTransport();
             var clock = new Clock();
             wheelbase = new FanatecWheelbase(t, new FakeBus(), clock.Now);
+            if (overrideProfileId != null)
+                wheelbase.ProfileOverrideResolver = _ => overrideProfileId;
             Assert.True(wheelbase.AutoConnect());
 
             if (wheelCode != null)
@@ -206,6 +209,28 @@ namespace FanaBridge.Tests
             inst.PluginResolver = () => pluginB;
             inst.DataUpdate(null, ref data);
             Assert.Same(pluginB, inst.BoundPluginForTest);
+        }
+
+        [Fact]
+        public void ResolveCurrentCapabilities_PluginReplacedBeforeDataUpdate_UsesNewGeneration()
+        {
+            var inst = InstanceFor("PSWBMW");
+            var pluginA = PluginWithWheel(null, out _);
+            var pluginB = PluginWithWheel("PSWBMW", out _, "CSLESWP1X");
+
+            var data = new GameData();
+            inst.PluginResolver = () => pluginA;
+            inst.DataUpdate(null, ref data);
+            Assert.Same(pluginA, inst.BoundPluginForTest);
+
+            // SimHub can build the LEDs tab after the singleton changes but before
+            // its next DataUpdate. The notice must resolve through the new singleton,
+            // not through the generation that still owns the cached drivers.
+            inst.PluginResolver = () => pluginB;
+
+            var caps = inst.ResolveCurrentCapabilities();
+            Assert.Equal("CSLESWP1X", caps.Profile?.Id);
+            Assert.True(caps.HasLegacyRevStripe);
         }
 
         [Fact]

--- a/tests/FanaBridge.Tests/LedColorLimitationTests.cs
+++ b/tests/FanaBridge.Tests/LedColorLimitationTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using System.Linq;
+using FanaBridge.Profiles;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace FanaBridge.Tests
+{
+    /// <summary>
+    /// SimHub offers a full color picker for every LED. These tests pin which
+    /// channels are honest about that and which need explaining to the user.
+    /// </summary>
+    public class LedColorLimitationTests
+    {
+        private static WheelCapabilities Caps(params (string channel, int count)[] groups)
+        {
+            var leds = new List<object>();
+            foreach (var (channel, count) in groups)
+                for (int i = 0; i < count; i++)
+                    leds.Add(new
+                    {
+                        channel,
+                        hwIndex = i,
+                        // Roles as the shipped profiles assign them — the notice
+                        // reads these, not the channel names.
+                        role = channel == "buttonAuxIntensity" ? "encoder"
+                             : channel.StartsWith("button") ? "button"
+                             : channel.ToLowerInvariant().Contains("flag") ? "flag"
+                             : "rev",
+                        label = channel + i,
+                    });
+
+            var json = JsonConvert.SerializeObject(new { id = "TEST", name = "Test", leds });
+            return new WheelCapabilities(JsonConvert.DeserializeObject<WheelProfile>(json));
+        }
+
+        [Fact]
+        public void FullColorWheel_HasNoLimitations()
+        {
+            Assert.Empty(LedColorLimitation.ForCapabilities(Caps(("revRgb", 9), ("flagRgb", 2))));
+        }
+
+        [Theory]
+        [InlineData("legacyRevOnOff", 9)]
+        [InlineData("legacyRevStripe", 1)]
+        [InlineData("legacyRev3Bit", 9)]
+        [InlineData("legacyFlag3Bit", 6)]
+        [InlineData("buttonAuxIntensity", 4)]
+        public void LimitedChannel_ProducesANotice(string channel, int count)
+        {
+            var limitations = LedColorLimitation.ForCapabilities(Caps((channel, count)));
+
+            Assert.Single(limitations);
+            Assert.False(string.IsNullOrWhiteSpace(limitations[0].Text));
+        }
+
+        [Fact]
+        public void MultipleLimitedChannels_ProduceOneNoticeEach()
+        {
+            // A wheel can mix them — each limitation is a different thing to explain.
+            var limitations = LedColorLimitation.ForCapabilities(
+                Caps(("legacyRevOnOff", 9), ("buttonAuxIntensity", 2)));
+
+            Assert.Equal(2, limitations.Count);
+            Assert.Equal(limitations.Count, limitations.Select(l => l.Text).Distinct().Count());
+        }
+
+        [Fact]
+        public void ThreeBitRevAndFlag_ShareASingleNotice()
+        {
+            // Same limitation, same explanation — saying it twice would be noise.
+            Assert.Single(LedColorLimitation.ForCapabilities(
+                Caps(("legacyRev3Bit", 9), ("legacyFlag3Bit", 6))));
+        }
+
+        [Theory]
+        // The notice has to name the LEDs the user is looking at, not say "these LEDs".
+        [InlineData("legacyRev3Bit", "Rev LEDs")]
+        [InlineData("legacyFlag3Bit", "Flag LEDs")]
+        public void ThreeBitNotice_NamesTheRoleInvolved(string channel, string expected)
+        {
+            var limitation = Assert.Single(LedColorLimitation.ForCapabilities(Caps((channel, 6))));
+            Assert.Contains(expected, limitation.Text);
+        }
+
+        [Fact]
+        public void ThreeBitNotice_NamesBothRolesWhenBothArePresent()
+        {
+            var limitation = Assert.Single(LedColorLimitation.ForCapabilities(
+                Caps(("legacyRev3Bit", 9), ("legacyFlag3Bit", 6))));
+            // Shares the noun rather than repeating it as "rev LEDs and flag LEDs".
+            Assert.Contains("Rev and Flag LEDs", limitation.Text);
+        }
+
+        [Fact]
+        public void Notice_NamesWhateverRoleTheProfileAssigned()
+        {
+            // Nothing ties a channel to a role — a custom profile can drive flag
+            // LEDs through the on/off channel, and the notice must follow it.
+            var json = JsonConvert.SerializeObject(new
+            {
+                id = "TEST",
+                name = "Test",
+                leds = Enumerable.Range(0, 4).Select(i => new
+                {
+                    channel = "legacyRevOnOff",
+                    hwIndex = i,
+                    role = "flag",
+                    label = "Flag " + i,
+                }),
+            });
+            var caps = new WheelCapabilities(JsonConvert.DeserializeObject<WheelProfile>(json));
+
+            var limitation = Assert.Single(LedColorLimitation.ForCapabilities(caps));
+            Assert.Contains("Flag LEDs", limitation.Text);
+            Assert.DoesNotContain("Rev LEDs", limitation.Text);
+        }
+
+        [Theory]
+        // A hub has no LEDs of its own — they belong to the module attached to it.
+        [InlineData("", "This wheel's")]
+        [InlineData("PBME", "This module's")]
+        public void Notice_NamesWheelOrModuleFromTheProfile(string moduleType, string expected)
+        {
+            var json = JsonConvert.SerializeObject(new
+            {
+                id = "TEST",
+                name = "Test",
+                match = new { wheelType = "PHUB", moduleType },
+                leds = Enumerable.Range(0, 9).Select(i => new
+                {
+                    channel = "legacyRev3Bit",
+                    hwIndex = i,
+                    role = "rev",
+                    label = "Rev " + i,
+                }),
+            });
+            var caps = new WheelCapabilities(JsonConvert.DeserializeObject<WheelProfile>(json));
+
+            var limitation = Assert.Single(LedColorLimitation.ForCapabilities(caps));
+            Assert.StartsWith(expected, limitation.Text);
+        }
+
+        [Fact]
+        public void Notice_NamesEachGroupSeparately_WhenLimitationsDiffer()
+        {
+            // Two unrelated limitations on one device, each naming its own LEDs.
+            var limitations = LedColorLimitation.ForCapabilities(
+                Caps(("legacyRevOnOff", 9), ("buttonAuxIntensity", 3)));
+
+            Assert.Equal(2, limitations.Count);
+            Assert.Contains(limitations, l => l.Text.Contains("Rev LEDs"));
+            Assert.Contains(limitations, l => l.Text.Contains("Encoder LEDs"));
+        }
+
+        [Fact]
+        public void NullCapabilities_AreHandled()
+        {
+            Assert.Empty(LedColorLimitation.ForCapabilities(null));
+        }
+    }
+}

--- a/tests/FanaBridge.Tests/LegacyLedEncoderTests.cs
+++ b/tests/FanaBridge.Tests/LegacyLedEncoderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FanaBridge.Protocol;
 using FanaBridge.Transport;
 using Xunit;
@@ -53,17 +54,13 @@ namespace FanaBridge.Tests
 
             encoder.SetLegacyRevOnOff(new bool[9]);
 
-            // Should have: 1 global enable + 1 LED data
-            Assert.Equal(2, transport.Col01Reports.Count);
-
-            // Global enable: subcmd 0x02, enable=0x01
-            Assert.Equal(0x02, transport.Col01Reports[0][3]);
-            Assert.Equal(0x01, transport.Col01Reports[0][4]);
+            // LED data only — bitmask writes carry no enable sequence.
+            Assert.Single(transport.Col01Reports);
 
             // LED data: subcmd 0x08, bitmask=0x00
-            Assert.Equal(0x08, transport.Col01Reports[1][3]);
-            Assert.Equal(0x00, transport.Col01Reports[1][4]);
-            Assert.Equal(0x00, transport.Col01Reports[1][5]);
+            Assert.Equal(0x08, transport.Col01Reports[0][3]);
+            Assert.Equal(0x00, transport.Col01Reports[0][4]);
+            Assert.Equal(0x00, transport.Col01Reports[0][5]);
         }
 
         [Fact]
@@ -78,7 +75,7 @@ namespace FanaBridge.Tests
             // LED data report — bitmask in RGB333 bit order:
             //   byte[4] = LED0 (bit 0) = 0x01
             //   byte[5] = LED1(bit7)..LED8(bit0) = 0xFF
-            var report = transport.Col01Reports[1];
+            var report = transport.Col01Reports[0];
             Assert.Equal(0x08, report[3]);
             Assert.Equal(0x01, report[4]); // LED0
             Assert.Equal(0xFF, report[5]); // LEDs 1-8
@@ -95,7 +92,7 @@ namespace FanaBridge.Tests
             encoder.SetLegacyRevOnOff(pattern);
 
             // LEDs 0, 1, 2 on → byte[4]=LED0=0x01, byte[5]=LED1(bit7)|LED2(bit6)=0xC0
-            var report = transport.Col01Reports[1];
+            var report = transport.Col01Reports[0];
             Assert.Equal(0x01, report[4]); // LED0
             Assert.Equal(0xC0, report[5]); // LED1(bit7) + LED2(bit6)
         }
@@ -132,7 +129,7 @@ namespace FanaBridge.Tests
         // ── RevStripe tests ────────────────────────────────────────────
 
         [Fact]
-        public void SetRevStripeColor_SendsEnableSequenceThenColor()
+        public void SetRevStripeColor_AssertsColorModeThenColor()
         {
             var transport = new StubTransport();
             var encoder = new LegacyLedEncoder(transport);
@@ -140,21 +137,144 @@ namespace FanaBridge.Tests
             // Red in RGB333: data_hi=0x38, data_lo=0x00 → packed 0x3800
             encoder.SetRevStripeColor(0x3800);
 
-            // Should have: RevStripe enable + global enable + LED data = 3 reports
+            // Stripe enable + color-mode assert + LED data. No 0x02 — the rim white
+            // LED has no business in an LED write path.
             Assert.Equal(3, transport.Col01Reports.Count);
 
-            // RevStripe enable: subcmd 0x06, inverted 0x00 = ON
+            // Stripe enable: subcmd 0x06, inverted so 0x00 = on
             Assert.Equal(0x06, transport.Col01Reports[0][3]);
             Assert.Equal(0x00, transport.Col01Reports[0][4]);
 
-            // Global enable: subcmd 0x02, enable=0x01
-            Assert.Equal(0x02, transport.Col01Reports[1][3]);
-            Assert.Equal(0x01, transport.Col01Reports[1][4]);
+            // Mode select: subcmd 0x07, 0x00 = interpret 0x08 payloads as color
+            Assert.Equal(0x07, transport.Col01Reports[1][3]);
+            Assert.Equal(0x00, transport.Col01Reports[1][4]);
 
             // Color data: subcmd 0x08, data_lo=0x00, data_hi=0x38
             Assert.Equal(0x08, transport.Col01Reports[2][3]);
             Assert.Equal(0x00, transport.Col01Reports[2][4]); // data_lo
             Assert.Equal(0x38, transport.Col01Reports[2][5]); // data_hi
+        }
+
+        [Fact]
+        public void SetRevStripeColor_AssertsColorModeOnlyOnce()
+        {
+            var transport = new StubTransport();
+            var encoder = new LegacyLedEncoder(transport);
+
+            encoder.SetRevStripeColor(0x3800); // red
+            encoder.SetRevStripeColor(0x0700); // blue
+
+            Assert.Single(transport.Col01Reports, r => r[3] == 0x07);
+            Assert.Single(transport.Col01Reports, r => r[3] == 0x06);
+        }
+
+        [Fact]
+        public void SetRevStripeColor_NeverSendsWhiteLed()
+        {
+            var transport = new StubTransport();
+            var encoder = new LegacyLedEncoder(transport);
+
+            encoder.SetRevStripeColor(0x3800);
+            encoder.SetRevStripeColor(0x0700);
+            encoder.Clear();
+
+            Assert.DoesNotContain(transport.Col01Reports, r => r[3] == 0x02);
+        }
+
+        [Fact]
+        public void SetRevStripeColor_EnablesStripeOnceAndNeverDisablesIt()
+        {
+            var transport = new StubTransport();
+            var encoder = new LegacyLedEncoder(transport);
+
+            encoder.SetRevStripeColor(0x3800);
+            encoder.SetRevStripeColor(0x0700);
+            encoder.Clear();
+
+            // 0x06 is stored state: set it on once, never write the disable value.
+            // Clearing LEDs is not a reason to turn the user's stripe off.
+            var stripeEnables = transport.Col01Reports.Where(r => r[3] == 0x06).ToList();
+            Assert.Single(stripeEnables);
+            Assert.Equal(0x00, stripeEnables[0][4]);
+        }
+
+        [Fact]
+        public void SetRevStripeColor_UnsafeRawValue_IsSnappedAtTheWireBoundary()
+        {
+            var transport = new StubTransport();
+            var encoder = new LegacyLedEncoder(transport);
+
+            // 0x0001 is the payload that switches the rim out of color mode. The
+            // guarantee has to hold here, not only in whichever caller is wired up.
+            encoder.SetRevStripeColor(ColorHelper.RgbToRgb333(0, 128, 0));
+
+            var data = transport.Col01Reports.Single(r => r[3] == 0x08);
+            Assert.False(data[4] == 0x01 && data[5] == 0x00);
+            Assert.Equal(0x01, data[4]); // snapped to full green
+            Assert.Equal(0xC0, data[5]);
+        }
+
+        [Fact]
+        public void SetLegacyRevOnOff_InvalidatesAssertedColorMode()
+        {
+            var transport = new StubTransport();
+            var encoder = new LegacyLedEncoder(transport);
+
+            encoder.SetRevStripeColor(0x3800);
+            // A bitmask write can itself flip the rim into pattern mode.
+            encoder.SetLegacyRevOnOff(new bool[] { true, false, false, false, false, false, false, false, false });
+            encoder.SetRevStripeColor(0x0700);
+
+            // Color mode must be re-asserted rather than assumed still held.
+            Assert.Equal(2, transport.Col01Reports.Count(r => r[3] == 0x07));
+        }
+
+        [Fact]
+        public void ForceDirty_ReAssertsColorMode()
+        {
+            var transport = new StubTransport();
+            var encoder = new LegacyLedEncoder(transport);
+
+            encoder.SetRevStripeColor(0x3800);
+            encoder.ForceDirty();
+            encoder.SetRevStripeColor(0x3800);
+
+            Assert.Equal(2, transport.Col01Reports.Count(r => r[3] == 0x07));
+        }
+
+        [Fact]
+        public void Clear_ZeroesEachDrivenChannelOnItsOwnSubcommand()
+        {
+            var transport = new StubTransport();
+            var encoder = new LegacyLedEncoder(transport);
+
+            // A 0x08 frame does nothing for LEDs addressed via 0x0A.
+            var red = new byte[27];
+            for (int i = 0; i < 9; i++) red[i * 3] = 1;
+            encoder.SetLegacyRev3Bit(red);
+            int before = transport.Col01Reports.Count;
+
+            encoder.Clear();
+
+            var cleared = transport.Col01Reports.Skip(before).ToList();
+            var rgb = Assert.Single(cleared, r => r[3] == 0x0A);
+            Assert.Equal(new byte[] { 0, 0, 0, 0 }, new[] { rgb[4], rgb[5], rgb[6], rgb[7] });
+        }
+
+        [Fact]
+        public void Clear_DoesNotWriteChannelsThatWereNeverDriven()
+        {
+            var transport = new StubTransport();
+            var encoder = new LegacyLedEncoder(transport);
+
+            encoder.SetLegacyRevOnOff(new bool[] { true, false, false, false, false, false, false, false, false });
+            int before = transport.Col01Reports.Count;
+
+            encoder.Clear();
+
+            var cleared = transport.Col01Reports.Skip(before).ToList();
+            Assert.DoesNotContain(cleared, r => r[3] == 0x0A);
+            Assert.DoesNotContain(cleared, r => r[3] == 0x0B);
         }
 
         [Fact]
@@ -189,15 +309,11 @@ namespace FanaBridge.Tests
 
             encoder.SetLegacyRev3Bit(buf);
 
-            // Global enable + RGB data = 2 reports
-            Assert.Equal(2, transport.Col01Reports.Count);
-
-            // Global enable
-            Assert.Equal(0x02, transport.Col01Reports[0][3]);
-            Assert.Equal(0x01, transport.Col01Reports[0][4]);
+            // RGB data only — no enable sequence.
+            Assert.Single(transport.Col01Reports);
 
             // RGB data: subcmd 0x0A
-            var report = transport.Col01Reports[1];
+            var report = transport.Col01Reports[0];
             Assert.Equal(0x0A, report[3]);
 
             // All red: bit pattern per LED is 001 (R=1,G=0,B=0)
@@ -234,7 +350,7 @@ namespace FanaBridge.Tests
 
             encoder.SetLegacyRev3Bit(buf);
 
-            var report = transport.Col01Reports[1];
+            var report = transport.Col01Reports[0];
             Assert.Equal(0x0A, report[3]);
 
             // LED0: R=1,G=1,B=0 → bits 0,1,2 = 011 = 0x03
@@ -277,7 +393,7 @@ namespace FanaBridge.Tests
 
             encoder.SetLegacyRev3Bit(new byte[27]);
 
-            var report = transport.Col01Reports[1];
+            var report = transport.Col01Reports[0];
             Assert.Equal(0x0A, report[3]);
             Assert.Equal(0x00, report[4]);
             Assert.Equal(0x00, report[5]);
@@ -320,15 +436,11 @@ namespace FanaBridge.Tests
 
             encoder.SetLegacyFlag3Bit(buf);
 
-            // Global enable + flag data = 2 reports
-            Assert.Equal(2, transport.Col01Reports.Count);
-
-            // Global enable
-            Assert.Equal(0x02, transport.Col01Reports[0][3]);
-            Assert.Equal(0x01, transport.Col01Reports[0][4]);
+            // Flag data only — no enable sequence.
+            Assert.Single(transport.Col01Reports);
 
             // Flag data: subcmd 0x0B
-            var report = transport.Col01Reports[1];
+            var report = transport.Col01Reports[0];
             Assert.Equal(0x0B, report[3]);
 
             // All red: bit pattern per LED is 001 (R=1,G=0,B=0)
@@ -351,7 +463,7 @@ namespace FanaBridge.Tests
 
             encoder.SetLegacyFlag3Bit(new byte[18]);
 
-            var report = transport.Col01Reports[1];
+            var report = transport.Col01Reports[0];
             Assert.Equal(0x0B, report[3]);
             Assert.Equal(0x00, report[4]);
             Assert.Equal(0x00, report[5]);
@@ -378,7 +490,7 @@ namespace FanaBridge.Tests
         // ── Clear tests ───────────────────────────────────────────────
 
         [Fact]
-        public void Clear_SendsZeroDataAndDisablesGlobal()
+        public void Clear_SendsZeroDataOnly()
         {
             var transport = new StubTransport();
             var encoder = new LegacyLedEncoder(transport);
@@ -389,19 +501,14 @@ namespace FanaBridge.Tests
 
             encoder.Clear();
 
-            // Clear should send: LED data (all off) + global disable = 2 reports
-            Assert.True(transport.Col01Reports.Count > countBeforeClear);
+            // Clear sends exactly one report: all-off LED data. Turning LEDs off is
+            // not a reason to touch the rim white LED or the stored stripe preference.
+            Assert.Equal(countBeforeClear + 1, transport.Col01Reports.Count);
 
-            // Last LED data report should be all zeros (subcmd 0x08)
             var dataReport = transport.Col01Reports[countBeforeClear];
             Assert.Equal(0x08, dataReport[3]);
             Assert.Equal(0x00, dataReport[4]);
             Assert.Equal(0x00, dataReport[5]);
-
-            // Global disable: subcmd 0x02, enable=0x00
-            var disableReport = transport.Col01Reports[countBeforeClear + 1];
-            Assert.Equal(0x02, disableReport[3]);
-            Assert.Equal(0x00, disableReport[4]);
         }
 
         [Fact]

--- a/tests/FanaBridge.Tests/LegacyLedEncoderTests.cs
+++ b/tests/FanaBridge.Tests/LegacyLedEncoderTests.cs
@@ -230,6 +230,45 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
+        public void SetLegacyRevOnOff_SameStripeColor_ReassertsModeAndRewritesColor()
+        {
+            var transport = new StubTransport();
+            var encoder = new LegacyLedEncoder(transport);
+
+            encoder.SetRevStripeColor(0x3800); // red
+            encoder.SetLegacyRevOnOff(
+                new bool[] { true, false, false, false, false, false, false, false, false });
+            int beforeRestore = transport.Col01Reports.Count;
+
+            encoder.SetRevStripeColor(0x3800); // same color as before the bitmask write
+
+            var restore = transport.Col01Reports.Skip(beforeRestore).ToList();
+            Assert.Equal(new byte[] { 0x07, 0x08 }, restore.Select(r => r[3]).ToArray());
+            Assert.Equal(0x00, restore[1][4]);
+            Assert.Equal(0x38, restore[1][5]);
+            Assert.Single(transport.Col01Reports, r => r[3] == 0x06);
+        }
+
+        [Fact]
+        public void SetRevStripeColor_InvalidatesCachedBitmaskPayload()
+        {
+            var transport = new StubTransport();
+            var encoder = new LegacyLedEncoder(transport);
+            var pattern = new bool[] { true, false, false, false, false, false, false, false, false };
+
+            encoder.SetLegacyRevOnOff(pattern);
+            encoder.SetRevStripeColor(0x3800);
+            int beforeRestore = transport.Col01Reports.Count;
+
+            encoder.SetLegacyRevOnOff(pattern);
+
+            var restore = Assert.Single(transport.Col01Reports.Skip(beforeRestore));
+            Assert.Equal(0x08, restore[3]);
+            Assert.Equal(0x01, restore[4]);
+            Assert.Equal(0x00, restore[5]);
+        }
+
+        [Fact]
         public void ForceDirty_ReAssertsColorMode()
         {
             var transport = new StubTransport();


### PR DESCRIPTION
Fixes the rev stripe color bug on CSL Elite P1 (Xbox/PS4) and CSL Elite WRC, along with the legacy LED command and protocol issues found while tracing it.

Closes #76, closes #82, closes #78.

## Problem

The col01 `0x08` command carries either a per-LED on/off pattern or one RGB333 color for the whole RevStripe. Some RGB333 colors share the same payload as bitmask patterns; the driver stack can interpret those payloads as a mode switch, leaving later colors treated as LED patterns instead of colors.

Brightness and gradients made the bad payload reachable even when the selected color was not dark green.

The legacy write path also treated `0x02` as a rev-LED enable even though it addresses a separate white LED, and treated stored `0x06` state as a per-frame control that `Clear()` disabled repeatedly.

## Changes

- Match RevStripe output to the seven rendered colors plus off used by official software, with a second safety snap at the encoder boundary.
- Choose palette channels relative to the brightest channel so dimming cannot change hue; legacy 3-bit rev and flag LEDs use the same rule.
- Stop writing `0x02` from LED paths.
- Send `0x06` only while preparing a RevStripe and never send its disable value.
- Assert `0x07` color mode when needed, and invalidate the shared `0x08` caches in both directions when switching between stripe colors and bitmasks.
- Clear each driven legacy channel through its own subcommand without touching unused channels or stored preferences.
- Add capability-derived notices to the LEDs tab for limited-palette, on/off-only, and intensity-only hardware.
- Correct the col01 command, bit-packing, and color-encoding reference documentation.

## Validation

- 602 tests pass in Debug and Release.
- Release merged-plugin build succeeds with zero warnings.
- Regression coverage includes unsafe RGB333 payloads, same-color restoration after a bitmask write, symmetric shared-payload cache invalidation, per-channel clearing, palette behavior, limitation notices, and plugin-generation changes before the LEDs tab opens.
