### PR TITLE
Fix device settings wipe: document-first persistence

### DIFF
--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -30,7 +30,12 @@ namespace FanaBridge.Adapters
     public class FanatecWheelDeviceInstance : DeviceInstance
     {
         private readonly DeviceConfig _config;
-        private JObject _customSettings = new JObject();
+
+        // One stable object for the instance's lifetime: UI panels hold this
+        // reference (GetSettingsControls hands it out), so a reload must
+        // repopulate it in place — replacing it would orphan the panels'
+        // copy and silently drop their subsequent edits.
+        private readonly JObject _customSettings = new JObject();
 
         // ── Settings persistence state ───────────────────────────────────
         //
@@ -51,21 +56,42 @@ namespace FanaBridge.Adapters
         // reset — deferring it beats fabricating an empty payload.
         private bool _pendingDefaultsReset;
 
-        // Top-level keys owned by the LED module. A module refresh replaces
+        // The published module diverged from the canonical document (an
+        // apply/defaults call into it failed partway). While set, saves
+        // serve the document and never refresh it from the module — a
+        // half-mutated module must not be serialized over good data. The
+        // next fully-successful application clears it.
+        private bool _moduleOutOfSync;
+
+        // Top-level keys owned by the LED module ("extra" is emitted by
+        // SimHub when ExtraSettings is used). A module refresh replaces
         // these subtrees whole (recursive merges would resurrect deleted
         // profiles); every other key round-trips untouched, so keys this
         // class doesn't know about (e.g. panel-written ones) survive.
         private static readonly string[] ModuleOwnedKeys =
-            { "ledModuleSettings", "leds", "buttons", "encoders", "matrix", "raw" };
+            { "ledModuleSettings", "leds", "buttons", "encoders", "matrix", "raw", "extra" };
 
         // LED module — null when the wheel has no LEDs or it can't be built
-        // yet. Published only after full hydration from the canonical
-        // document, so a concurrent save serializes either the old document
-        // or a complete module — never a half-populated one.
+        // yet. Hydrated from the canonical document before the volatile
+        // publish; if hydration fails the module is published anyway (the
+        // LEDs tab must stay available to repair a bad payload) and
+        // _moduleOutOfSync keeps the document authoritative.
         private volatile LedModuleSettings<FanatecLedManager> _ledModule;
         private FanatecLedManager _manager;
 
         private volatile bool _ledModuleInitialized;
+
+        // Environment.TickCount of the last zero-LED capability resolution.
+        // DataUpdate retries EnsureLedModuleInitialized per frame; this
+        // bounds the lock + ResolveCapsFor cost for display-only wheels to
+        // ~1/s. 0 = no throttle active.
+        private volatile int _lastZeroCapsTick;
+
+        // The plugin generation the manager/module were built against, for
+        // the issue-#37 guard: DataUpdate owns _boundPlugin, but a module
+        // built from another call site (settings page, SetSettings) between
+        // a generation swap and the next frame must still trigger a rebind.
+        private volatile FanatecPlugin _moduleSourcePlugin;
 
         // Display manager — null when the wheel has no display.
         private FanatecDisplayDriver _displayManager;
@@ -114,6 +140,11 @@ namespace FanaBridge.Adapters
 
         /// <summary>Test hook: the generation the cached drivers were built against.</summary>
         internal FanatecPlugin BoundPluginForTest => _boundPlugin;
+
+        /// <summary>Test hooks: which persistence branch is active.</summary>
+        internal bool LedModuleBuiltForTest => _ledModule != null;
+        internal bool ModuleOutOfSyncForTest { get { lock (_settingsGate) return _moduleOutOfSync; } }
+        internal JObject CustomSettingsForTest => _customSettings;
 
         // ITM status snapshot for the Device Status panel / diagnostics. Composed on the
         // DataUpdate thread (the only thread that mutates the lifecycle) and read from the
@@ -174,6 +205,15 @@ namespace FanaBridge.Adapters
             if (_ledModuleInitialized)
                 return;
 
+            // DataUpdate retries this per frame while unbuilt; for wheels whose
+            // caps genuinely resolve to zero LEDs (display-only profiles) that
+            // would mean a lock + ResolveCapsFor per frame forever. Bound the
+            // retry to ~1/s. Wrap-safe unsigned delta (see PublishItmStatusSnapshot).
+            int tick = Environment.TickCount;
+            int lastZero = _lastZeroCapsTick;
+            if (lastZero != 0 && unchecked((uint)(tick - lastZero)) < 1000)
+                return;
+
             lock (_settingsGate)
             {
                 if (_ledModuleInitialized)
@@ -196,60 +236,74 @@ namespace FanaBridge.Adapters
                 // LED-less" — don't latch, so a later resolution still builds.
                 var caps = plugin.ResolveCapsFor(_config);
                 int allLeds = caps.AllLedCount;
-                if (allLeds == 0) return;
-
-                var manager = new FanatecLedManager(_config, plugin.Leds, plugin.LegacyLeds);
-                var options = new LedModuleOptions
+                if (allLeds == 0)
                 {
-                    DeviceName = caps.ShortName ?? caps.Name,
-                    LedCount = caps.RevFlagCount,
-                    ButtonsCount = caps.ButtonLedCount,
-                    EncodersCount = 0,  // all non-rev/flag LEDs are "buttons" in SimHub
-                    RawLedCount = allLeds,
-                    LedDriver = manager,
-                    EnableBrightnessSection = true,
-                    ShowConnectionStatus = true,
-                    VID = FanatecWheelbase.FANATEC_VENDOR_ID,
-                };
+                    _lastZeroCapsTick = tick == 0 ? 1 : tick;
+                    return;
+                }
 
-                // Wheels whose LEDs can't render the picker's range get a note in the
-                // LEDs tab. The picker stays stock — constraining it would break
-                // gradients and imported profiles without fixing anything, since those
-                // never pass through it.
-                //
-                // The factory is installed unconditionally and the notice resolves
-                // capabilities itself when the tab is opened. This method runs once, and
-                // usually before identity has settled or a user profile override has
-                // been applied — deciding here would miss wheels whose real profile
-                // arrives later, and could never correct itself.
-                options.ExtraSettingsControlFactory =
-                    _ => new UI.LedColorLimitationNotice(() => ResolveCurrentCapabilities());
+                FanatecLedManager manager;
+                LedModuleSettings<FanatecLedManager> module;
+                try
+                {
+                    manager = new FanatecLedManager(_config, plugin.Leds, plugin.LegacyLeds);
+                    var options = new LedModuleOptions
+                    {
+                        DeviceName = caps.ShortName ?? caps.Name,
+                        LedCount = caps.RevFlagCount,
+                        ButtonsCount = caps.ButtonLedCount,
+                        EncodersCount = 0,  // all non-rev/flag LEDs are "buttons" in SimHub
+                        RawLedCount = allLeds,
+                        LedDriver = manager,
+                        EnableBrightnessSection = true,
+                        ShowConnectionStatus = true,
+                        VID = FanatecWheelbase.FANATEC_VENDOR_ID,
+                    };
 
-                var module = new LedModuleSettings<FanatecLedManager>(options);
-                module.IsEmbedded = true;
-                module.IsEnabled = true;
+                    // Wheels whose LEDs can't render the picker's range get a note in the
+                    // LEDs tab. The picker stays stock — constraining it would break
+                    // gradients and imported profiles without fixing anything, since those
+                    // never pass through it.
+                    //
+                    // The factory is installed unconditionally and the notice resolves
+                    // capabilities itself when the tab is opened. This method runs once, and
+                    // usually before identity has settled or a user profile override has
+                    // been applied — deciding here would miss wheels whose real profile
+                    // arrives later, and could never correct itself.
+                    options.ExtraSettingsControlFactory =
+                        _ => new UI.LedColorLimitationNotice(() => ResolveCurrentCapabilities());
+
+                    module = new LedModuleSettings<FanatecLedManager>(options);
+                    module.IsEmbedded = true;
+                    module.IsEnabled = true;
+                }
+                catch (Exception ex)
+                {
+                    // Construction failed — latch so DataUpdate doesn't rebuild
+                    // per frame. A new SetSettings payload unlatches for one
+                    // fresh attempt; the canonical document keeps round-tripping
+                    // meanwhile.
+                    _ledModuleInitialized = true;
+                    SimHub.Logging.Current.Warn(
+                        "FanatecWheelDeviceInstance[" + caps.Name + "]: LED module construction " +
+                        "failed — stored settings still round-trip: " + ex.Message);
+                    return;
+                }
 
                 // Hydrate BEFORE publishing: a save running concurrently must see
                 // either the canonical document or a fully populated module —
-                // never a fresh one still carrying defaults.
+                // never a fresh one still carrying defaults. Hydration failure
+                // still publishes (the LEDs tab must stay available to repair a
+                // bad payload); _moduleOutOfSync keeps saves on the document
+                // until an application fully succeeds.
                 bool hydrated = _pendingDefaultsReset
                     ? TryLoadModuleDefaults(module)
                     : _settingsDocument == null
                         || ApplyLedSettings(module, _settingsDocument, _settingsDocumentIsDefault);
-                if (!hydrated)
-                {
-                    // Hydration failed. Publishing this module would let the next
-                    // save replace the good document with its default state, and
-                    // retrying would rebuild a module per DataUpdate frame — so
-                    // latch unbuilt; the canonical document keeps round-tripping.
-                    _ledModuleInitialized = true;
-                    SimHub.Logging.Current.Warn(
-                        "FanatecWheelDeviceInstance[" + caps.Name + "]: LED module hydration " +
-                        "failed — keeping the stored settings as-is for this session");
-                    return;
-                }
+                _moduleOutOfSync = !hydrated;
 
                 _manager = manager;
+                _moduleSourcePlugin = plugin;
                 _ledModule = module;
                 _ledModuleInitialized = true;
 
@@ -257,13 +311,16 @@ namespace FanaBridge.Adapters
                     "FanatecWheelDeviceInstance[" + caps.Name + "]: LED module created (" +
                     "revRgb=" + caps.RevRgbCount + ", flagRgb=" + caps.FlagRgbCount +
                     ", buttonRgb=" + caps.ButtonRgbCount + ", buttonAuxIntensity=" + caps.ButtonAuxIntensityCount +
-                    ", total=" + allLeds + ")");
+                    ", total=" + allLeds + ", hydrated=" + hydrated + ")");
 
                 if (_pendingDefaultsReset)
                 {
                     // Materialize the deferred reset now that a module exists to
-                    // define what "defaults" means for the LED subtrees.
-                    TryRefreshDocumentFromModule(module);
+                    // define what "defaults" means for the LED subtrees. If the
+                    // reset itself failed the document keeps the old subtrees —
+                    // out-of-sync already blocks refreshes.
+                    if (hydrated)
+                        TryRefreshDocumentFromModule(module);
                     _pendingDefaultsReset = false;
                 }
             }
@@ -334,13 +391,19 @@ namespace FanaBridge.Adapters
                 var channels = module.GetSettings(false, false);
 
                 var doc = (JObject)(_settingsDocument?.DeepClone() ?? new JObject());
-                foreach (var key in ModuleOwnedKeys)
-                    doc.Remove(key);
                 doc["ledModuleSettings"] = moduleState;
                 if (channels != null)
                 {
                     foreach (var kvp in channels)
-                        doc[kvp.Key] = kvp.Value != null ? kvp.Value.DeepClone() : JValue.CreateNull();
+                    {
+                        // SimHub emits every channel key and nulls the ones it
+                        // has no driver for right now (e.g. a profile override
+                        // without button LEDs). Null means "can't emit", not
+                        // "deleted" — keep the stored subtree so reverting the
+                        // override gets it back.
+                        if (kvp.Value != null && kvp.Value.Type != JTokenType.Null)
+                            doc[kvp.Key] = kvp.Value.DeepClone();
+                    }
                 }
 
                 _settingsDocument = doc;
@@ -455,23 +518,45 @@ namespace FanaBridge.Adapters
             {
                 EnsureLedModuleInitialized();
 
-                _customSettings = new JObject
-                {
-                    ["wheelType"] = _config.WheelCode ?? "",
-                    ["moduleType"] = _config.ModuleCode ?? "",
-                    ["displayMode"] = DisplaySettings.DefaultMode,
-                    ["itmEnabled"] = DisplaySettings.DefaultItmEnabled,
-                    ["itmShowLapTotal"] = DisplaySettings.DefaultShowLapTotal,
-                    ["itmShowPositionTotal"] = DisplaySettings.DefaultShowPositionTotal,
-                    ["itmDefaultPage"] = DisplaySettings.DefaultItmDefaultPage,
-                };
+                _customSettings.RemoveAll();
+                _customSettings["wheelType"] = _config.WheelCode ?? "";
+                _customSettings["moduleType"] = _config.ModuleCode ?? "";
+                _customSettings["displayMode"] = DisplaySettings.DefaultMode;
+                _customSettings["itmEnabled"] = DisplaySettings.DefaultItmEnabled;
+                _customSettings["itmShowLapTotal"] = DisplaySettings.DefaultShowLapTotal;
+                _customSettings["itmShowPositionTotal"] = DisplaySettings.DefaultShowPositionTotal;
+                _customSettings["itmDefaultPage"] = DisplaySettings.DefaultItmDefaultPage;
                 _displaySettings = new DisplaySettings();
+
+                // A reset must also purge non-module keys from the document or
+                // panel-written keys resurrect on the next save (the overlay
+                // can add and overwrite but never remove). Only the LED
+                // subtrees stay — they reset via the module or the deferral.
+                if (_settingsDocument != null)
+                {
+                    var doc = (JObject)_settingsDocument.DeepClone();
+                    foreach (var prop in doc.Properties().ToList())
+                    {
+                        if (!ModuleOwnedKeys.Contains(prop.Name))
+                            doc.Remove(prop.Name);
+                    }
+                    _settingsDocument = doc;
+                }
 
                 var module = _ledModule;
                 if (module != null)
                 {
                     if (TryLoadModuleDefaults(module))
+                    {
+                        _moduleOutOfSync = false;
                         TryRefreshDocumentFromModule(module);
+                    }
+                    else
+                    {
+                        // A half-reset module must not be serialized over the
+                        // document.
+                        _moduleOutOfSync = true;
+                    }
                 }
                 else
                 {
@@ -516,23 +601,26 @@ namespace FanaBridge.Adapters
             lock (_settingsGate)
             {
                 var module = _ledModule;
+                bool trusted = module != null && !_moduleOutOfSync;
                 JObject result;
 
                 if (forTemplate || forDefaultSettings)
                 {
-                    // Special serialization flavors. With a module, delegate the
-                    // filtering to it with the exact flags and do NOT fold the
-                    // filtered output back into the canonical document. Without
-                    // one, SimHub's contract for where this output lands is
-                    // unverified — the complete document is the safe answer
-                    // (never a stub that could land in the per-device file).
-                    result = module != null
+                    // Special serialization flavors — these land in shared files
+                    // (forTemplate: device template export; forDefaultSettings:
+                    // the per-type DevicesDefaults payload applied to newly added
+                    // devices), never in this device's own settings file. With a
+                    // trusted module, delegate the filtering to it with the exact
+                    // flags and do NOT fold the output back into the canonical
+                    // document. Otherwise the full document matches the user's
+                    // intent for both actions.
+                    result = trusted
                         ? BuildModuleProjection(module, forTemplate, forDefaultSettings)
                         : BuildPersistedSettings();
                 }
                 else
                 {
-                    if (module != null)
+                    if (trusted)
                         TryRefreshDocumentFromModule(module);
                     result = BuildPersistedSettings();
                 }
@@ -542,7 +630,8 @@ namespace FanaBridge.Adapters
                     "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: GetSettings(" +
                     "forTemplate=" + forTemplate + ", forDefaultSettings=" + forDefaultSettings +
                     ") thread " + System.Threading.Thread.CurrentThread.ManagedThreadId +
-                    ", module=" + (module != null) + " -> " + result.Count + " keys");
+                    ", module=" + (module != null) + ", sync=" + !_moduleOutOfSync +
+                    " -> " + result.Count + " keys");
 
                 return result;
             }
@@ -564,24 +653,34 @@ namespace FanaBridge.Adapters
                 // The complete payload becomes the canonical document, replaced
                 // whole — a later SetSettings simply wins. Custom keys are
                 // everything the module doesn't own, so keys this class doesn't
-                // know about (e.g. the tuning panel's) survive a reload.
+                // know about (e.g. the tuning panel's) survive a reload; the
+                // object is repopulated in place because panels hold it.
                 _settingsDocument = (JObject)obj.DeepClone();
                 _settingsDocumentIsDefault = isDefault;
                 _pendingDefaultsReset = false;
 
-                _customSettings = new JObject();
+                _customSettings.RemoveAll();
                 foreach (var prop in obj.Properties())
                 {
                     if (!ModuleOwnedKeys.Contains(prop.Name))
                         _customSettings[prop.Name] = prop.Value.DeepClone();
                 }
 
+                // A fresh payload earns one new build attempt after a failed
+                // construction, and resets the zero-cap retry throttle.
+                if (_ledModule == null)
+                    _ledModuleInitialized = false;
+                _lastZeroCapsTick = 0;
+
                 // If the module already exists, apply the payload to it; if this
-                // call builds it, hydration consumes the document set above.
+                // call builds it, hydration consumes the document set above. A
+                // fully-successful apply re-trusts the module; a failed one
+                // keeps saves on the document (never serialize a half-mutated
+                // module over good data).
                 var hadModule = _ledModule != null;
                 EnsureLedModuleInitialized();
                 if (hadModule)
-                    ApplyLedSettings(_ledModule, obj, isDefault);
+                    _moduleOutOfSync = !ApplyLedSettings(_ledModule, obj, isDefault);
 
                 _displaySettings = new DisplaySettings
                 {
@@ -602,10 +701,12 @@ namespace FanaBridge.Adapters
             // built, drop them so they rebuild against the current hardware core
             // (see _boundPlugin). Must run before anything below touches them.
             var currentPlugin = PluginResolver();
-            if (currentPlugin != null && _boundPlugin != null
-                && !ReferenceEquals(_boundPlugin, currentPlugin))
+            if (currentPlugin != null
+                && ((_boundPlugin != null && !ReferenceEquals(_boundPlugin, currentPlugin))
+                    || (_moduleSourcePlugin != null && !ReferenceEquals(_moduleSourcePlugin, currentPlugin))))
             {
                 RebindToCurrentGeneration();
+                _moduleSourcePlugin = currentPlugin;
             }
             if (currentPlugin != null)
                 _boundPlugin = currentPlugin;
@@ -875,12 +976,16 @@ namespace FanaBridge.Adapters
                     _displaySettings, _config.Capabilities.Display, _config.Capabilities.ItmDeviceId,
                     settingsChanged: () =>
                     {
-                        // Sync back to JObject for persistence.
-                        _customSettings["displayMode"] = _displaySettings.DisplayMode;
-                        _customSettings["itmEnabled"] = _displaySettings.ItmEnabled;
-                        _customSettings["itmShowLapTotal"] = _displaySettings.ItmShowLapTotal;
-                        _customSettings["itmShowPositionTotal"] = _displaySettings.ItmShowPositionTotal;
-                        _customSettings["itmDefaultPage"] = _displaySettings.ItmDefaultPage;
+                        // Sync back to JObject for persistence — under the gate,
+                        // since a save may be enumerating _customSettings.
+                        lock (_settingsGate)
+                        {
+                            _customSettings["displayMode"] = _displaySettings.DisplayMode;
+                            _customSettings["itmEnabled"] = _displaySettings.ItmEnabled;
+                            _customSettings["itmShowLapTotal"] = _displaySettings.ItmShowLapTotal;
+                            _customSettings["itmShowPositionTotal"] = _displaySettings.ItmShowPositionTotal;
+                            _customSettings["itmDefaultPage"] = _displaySettings.ItmDefaultPage;
+                        }
                         _displayManager?.UpdateSettings(_displaySettings);
                         // ITM driver reads _displaySettings live each frame.
                     });

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -56,6 +56,14 @@ namespace FanaBridge.Adapters
         // reset — deferring it beats fabricating an empty payload.
         private bool _pendingDefaultsReset;
 
+        // A defaults reset was requested and the document refresh that
+        // materializes it hasn't succeeded yet. While set, the refresh uses
+        // reset semantics (all module-owned keys removed before writing what
+        // the module emits) — otherwise a single failed refresh would let
+        // pre-reset subtrees survive and resurrect later. Cleared by the
+        // first successful refresh, or by a new SetSettings payload.
+        private bool _channelResetPending;
+
         // The published module diverged from the canonical document (an
         // apply/defaults call into it failed partway). While set, saves
         // serve the document and never refresh it from the module — a
@@ -288,8 +296,12 @@ namespace FanaBridge.Adapters
                     // Construction failed — latch so DataUpdate doesn't rebuild
                     // per frame. A new SetSettings payload unlatches for one
                     // fresh attempt; the canonical document keeps round-tripping
-                    // meanwhile.
+                    // meanwhile. Record the generation the failure belongs to,
+                    // or a plugin swap before the first DataUpdate would leave
+                    // both generation markers null and the rebind that unlatches
+                    // would never fire.
                     _ledModuleInitialized = true;
+                    _moduleSourcePlugin = plugin;
                     SimHub.Logging.Current.Warn(
                         "FanatecWheelDeviceInstance[" + caps.Name + "]: LED module construction " +
                         "failed — stored settings still round-trip: " + ex.Message);
@@ -326,7 +338,7 @@ namespace FanaBridge.Adapters
                     // reset itself failed the document keeps the old subtrees —
                     // out-of-sync already blocks refreshes.
                     if (hydrated)
-                        TryRefreshDocumentFromModule(module, channelReset: true);
+                        TryRefreshDocumentFromModule(module);
                     _pendingDefaultsReset = false;
                 }
             }
@@ -389,8 +401,7 @@ namespace FanaBridge.Adapters
         /// is left untouched so a save still returns the last good payload.
         /// Callers hold _settingsGate.
         /// </summary>
-        private bool TryRefreshDocumentFromModule(
-            LedModuleSettings<FanatecLedManager> module, bool channelReset = false)
+        private bool TryRefreshDocumentFromModule(LedModuleSettings<FanatecLedManager> module)
         {
             try
             {
@@ -398,6 +409,17 @@ namespace FanaBridge.Adapters
                 var channels = module.GetSettings(false, false);
 
                 var doc = (JObject)(_settingsDocument?.DeepClone() ?? new JObject());
+
+                // While a defaults reset is pending, drop every module-owned
+                // key first: emitted-null channels AND keys the module omits
+                // entirely (e.g. "extra" when ExtraSettings is unused) must
+                // not survive an explicit reset.
+                if (_channelResetPending)
+                {
+                    foreach (var key in ModuleOwnedKeys)
+                        doc.Remove(key);
+                }
+
                 doc["ledModuleSettings"] = moduleState;
                 if (channels != null)
                 {
@@ -407,18 +429,15 @@ namespace FanaBridge.Adapters
                         // has no driver for right now (e.g. a profile override
                         // without button LEDs). On an ordinary save null means
                         // "can't emit", not "deleted" — keep the stored subtree
-                        // so reverting the override gets it back. On an explicit
-                        // defaults reset the stored subtree must go too, or it
-                        // resurrects after the override is reverted.
+                        // so reverting the override gets it back.
                         if (kvp.Value != null && kvp.Value.Type != JTokenType.Null)
                             doc[kvp.Key] = kvp.Value.DeepClone();
-                        else if (channelReset)
-                            doc.Remove(kvp.Key);
                     }
                 }
 
                 _settingsDocument = doc;
                 _settingsDocumentIsDefault = false;
+                _channelResetPending = false;
                 return true;
             }
             catch (Exception ex)
@@ -517,11 +536,18 @@ namespace FanaBridge.Adapters
 
             // A new generation also earns a fresh module-build attempt if a
             // previous construction failed or caps resolved to zero — the
-            // latch and throttle are per-generation, not per-session.
-            if (_ledModule == null)
+            // latch and throttle are per-generation, not per-session. Under
+            // the gate: a lock-free null-check here could interleave with a
+            // concurrent build publishing a module and then unlatch anyway,
+            // making the next call construct a SECOND module while SimHub's
+            // cached LEDs control stays bound to the orphaned first one.
+            lock (_settingsGate)
             {
-                _ledModuleInitialized = false;
-                _lastZeroCapsTick = 0;
+                if (_ledModule == null)
+                {
+                    _ledModuleInitialized = false;
+                    _lastZeroCapsTick = 0;
+                }
             }
         }
 
@@ -548,6 +574,11 @@ namespace FanaBridge.Adapters
                 _customSettings["itmDefaultPage"] = DisplaySettings.DefaultItmDefaultPage;
                 _displaySettings = new DisplaySettings();
 
+                // Reset semantics stay pending until a document refresh
+                // actually succeeds — a single failed refresh must not let
+                // pre-reset subtrees survive into later ordinary saves.
+                _channelResetPending = true;
+
                 // A reset must also purge non-module keys from the document or
                 // panel-written keys resurrect on the next save (the overlay
                 // can add and overwrite but never remove). Only the LED
@@ -569,7 +600,7 @@ namespace FanaBridge.Adapters
                     if (TryLoadModuleDefaults(module))
                     {
                         _moduleOutOfSync = false;
-                        TryRefreshDocumentFromModule(module, channelReset: true);
+                        TryRefreshDocumentFromModule(module);
                     }
                     else
                     {
@@ -623,14 +654,17 @@ namespace FanaBridge.Adapters
                 var module = _ledModule;
 
                 // While out-of-sync, retry applying the canonical document once
-                // per save: transient apply failures heal here (module returns
+                // per ordinary save (template/defaults calls never write the
+                // per-device file — no reason to mutate the live module for
+                // them): transient apply failures heal here (module returns
                 // to exactly the stored state, so no user data moves). If the
                 // payload itself is unappliable the document stays
                 // authoritative — reset-defaults is the repair path, and it
                 // re-trusts the module. Trade-off: a late-healing resync
                 // reverts LEDs-tab edits made while broken, visibly — better
                 // than silently excluding them from saves forever.
-                if (module != null && _moduleOutOfSync && _settingsDocument != null
+                if (!forTemplate && !forDefaultSettings
+                    && module != null && _moduleOutOfSync && _settingsDocument != null
                     && ApplyLedSettings(module, _settingsDocument, _settingsDocumentIsDefault))
                 {
                     _moduleOutOfSync = false;
@@ -693,6 +727,7 @@ namespace FanaBridge.Adapters
                 _settingsDocument = (JObject)obj.DeepClone();
                 _settingsDocumentIsDefault = isDefault;
                 _pendingDefaultsReset = false;
+                _channelResetPending = false;   // a full payload supersedes a reset
 
                 _customSettings.RemoveAll();
                 foreach (var prop in obj.Properties())

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -32,19 +32,40 @@ namespace FanaBridge.Adapters
         private readonly DeviceConfig _config;
         private JObject _customSettings = new JObject();
 
-        // LED module — null when wheel has no LEDs.
-        private LedModuleSettings<FanatecLedManager> _ledModule;
+        // ── Settings persistence state ───────────────────────────────────
+        //
+        // SimHub rewrites this device's settings file from GetSettings on
+        // every save-all, so GetSettings must always be able to produce a
+        // complete payload — including sessions where the LED module can
+        // never be built (plugin deactivated in SimHub's plugin list: the
+        // DLL still loads and instances still receive SetSettings, but the
+        // singleton never appears). The canonical document below is the
+        // lossless fallback: the last complete payload, only ever replaced
+        // whole under _settingsGate, never mutated in place or handed out.
+        private readonly object _settingsGate = new object();
+        private JObject _settingsDocument;
+        private bool _settingsDocumentIsDefault;
+
+        // LoadDefaultSettings arrived while no module existed. The old LED
+        // subtree stays in the document until a module can materialize the
+        // reset — deferring it beats fabricating an empty payload.
+        private bool _pendingDefaultsReset;
+
+        // Top-level keys owned by the LED module. A module refresh replaces
+        // these subtrees whole (recursive merges would resurrect deleted
+        // profiles); every other key round-trips untouched, so keys this
+        // class doesn't know about (e.g. panel-written ones) survive.
+        private static readonly string[] ModuleOwnedKeys =
+            { "ledModuleSettings", "leds", "buttons", "encoders", "matrix", "raw" };
+
+        // LED module — null when the wheel has no LEDs or it can't be built
+        // yet. Published only after full hydration from the canonical
+        // document, so a concurrent save serializes either the old document
+        // or a complete module — never a half-populated one.
+        private volatile LedModuleSettings<FanatecLedManager> _ledModule;
         private FanatecLedManager _manager;
 
-        private bool _ledModuleInitialized;
-
-        // LED settings/defaults that arrived while the module didn't exist yet
-        // (SimHub can deliver SetSettings/LoadDefaultSettings before FanatecPlugin
-        // finishes Init). Applied by EnsureLedModuleInitialized right after the
-        // module is built, so an early payload is deferred instead of dropped.
-        private JObject _pendingLedSettings;
-        private bool _pendingLedSettingsIsDefault;
-        private bool _pendingLedDefaults;
+        private volatile bool _ledModuleInitialized;
 
         // Display manager — null when the wheel has no display.
         private FanatecDisplayDriver _displayManager;
@@ -153,79 +174,109 @@ namespace FanaBridge.Adapters
             if (_ledModuleInitialized)
                 return;
 
-            // Without the shared encoders we can't build a module at all. Leave
-            // the initialized flag unset so the next call retries — latching it
-            // here would permanently kill this instance's LED module just
-            // because it raced ahead of plugin Init.
-            var plugin = PluginResolver();
-            if (plugin == null) return;
-
-            _ledModuleInitialized = true;
-            _boundPlugin = plugin;
-
-            // Resolve the caps for THIS descriptor (live caps only when the
-            // connected wheel matches us; otherwise our registration caps).
-            var caps = plugin.ResolveCapsFor(_config);
-            int allLeds = caps.AllLedCount;
-
-            if (allLeds == 0) return;
-
-            _manager = new FanatecLedManager(_config, plugin.Leds, plugin.LegacyLeds);
-            var manager = _manager;
-            var options = new LedModuleOptions
+            lock (_settingsGate)
             {
-                DeviceName = caps.ShortName ?? caps.Name,
-                LedCount = caps.RevFlagCount,
-                ButtonsCount = caps.ButtonLedCount,
-                EncodersCount = 0,  // all non-rev/flag LEDs are "buttons" in SimHub
-                RawLedCount = allLeds,
-                LedDriver = manager,
-                EnableBrightnessSection = true,
-                ShowConnectionStatus = true,
-                VID = FanatecWheelbase.FANATEC_VENDOR_ID,
-            };
+                if (_ledModuleInitialized)
+                    return;
 
-            // Wheels whose LEDs can't render the picker's range get a note in the
-            // LEDs tab. The picker stays stock — constraining it would break
-            // gradients and imported profiles without fixing anything, since those
-            // never pass through it.
-            //
-            // The factory is installed unconditionally and the notice resolves
-            // capabilities itself when the tab is opened. This method runs once, and
-            // usually before identity has settled or a user profile override has
-            // been applied — deciding here would miss wheels whose real profile
-            // arrives later, and could never correct itself.
-            options.ExtraSettingsControlFactory =
-                _ => new UI.LedColorLimitationNotice(() => ResolveCurrentCapabilities());
+                // Without the shared encoders we can't build a module at all.
+                // Leave the initialized flag unset so the next call retries —
+                // latching it here would permanently kill this instance's LED
+                // module just because it raced ahead of plugin Init. Generation
+                // tracking (_boundPlugin) stays with DataUpdate: claiming the
+                // generation here would let a build landing between a plugin
+                // swap and the next DataUpdate bypass the issue-#37 rebind.
+                var plugin = PluginResolver();
+                if (plugin == null) return;
 
-            _ledModule = new LedModuleSettings<FanatecLedManager>(options);
-            _ledModule.IsEmbedded = true;
-            _ledModule.IsEnabled = true;
+                // Resolve the caps for THIS descriptor (live caps only when the
+                // connected wheel matches us; otherwise our registration caps).
+                // Zero LEDs can mean "caps not resolved yet" (identity still
+                // settling, profile override not applied) as much as "genuinely
+                // LED-less" — don't latch, so a later resolution still builds.
+                var caps = plugin.ResolveCapsFor(_config);
+                int allLeds = caps.AllLedCount;
+                if (allLeds == 0) return;
 
-            SimHub.Logging.Current.Info(
-                "FanatecWheelDeviceInstance[" + caps.Name + "]: LED module created (" +
-                "revRgb=" + caps.RevRgbCount + ", flagRgb=" + caps.FlagRgbCount +
-                ", buttonRgb=" + caps.ButtonRgbCount + ", buttonAuxIntensity=" + caps.ButtonAuxIntensityCount +
-                ", total=" + allLeds + ")");
+                var manager = new FanatecLedManager(_config, plugin.Leds, plugin.LegacyLeds);
+                var options = new LedModuleOptions
+                {
+                    DeviceName = caps.ShortName ?? caps.Name,
+                    LedCount = caps.RevFlagCount,
+                    ButtonsCount = caps.ButtonLedCount,
+                    EncodersCount = 0,  // all non-rev/flag LEDs are "buttons" in SimHub
+                    RawLedCount = allLeds,
+                    LedDriver = manager,
+                    EnableBrightnessSection = true,
+                    ShowConnectionStatus = true,
+                    VID = FanatecWheelbase.FANATEC_VENDOR_ID,
+                };
 
-            // Apply anything SimHub delivered before the module existed.
-            if (_pendingLedSettings != null)
-            {
-                ApplyLedSettings(_pendingLedSettings, _pendingLedSettingsIsDefault);
-                _pendingLedSettings = null;
+                // Wheels whose LEDs can't render the picker's range get a note in the
+                // LEDs tab. The picker stays stock — constraining it would break
+                // gradients and imported profiles without fixing anything, since those
+                // never pass through it.
+                //
+                // The factory is installed unconditionally and the notice resolves
+                // capabilities itself when the tab is opened. This method runs once, and
+                // usually before identity has settled or a user profile override has
+                // been applied — deciding here would miss wheels whose real profile
+                // arrives later, and could never correct itself.
+                options.ExtraSettingsControlFactory =
+                    _ => new UI.LedColorLimitationNotice(() => ResolveCurrentCapabilities());
+
+                var module = new LedModuleSettings<FanatecLedManager>(options);
+                module.IsEmbedded = true;
+                module.IsEnabled = true;
+
+                // Hydrate BEFORE publishing: a save running concurrently must see
+                // either the canonical document or a fully populated module —
+                // never a fresh one still carrying defaults.
+                bool hydrated = _pendingDefaultsReset
+                    ? TryLoadModuleDefaults(module)
+                    : _settingsDocument == null
+                        || ApplyLedSettings(module, _settingsDocument, _settingsDocumentIsDefault);
+                if (!hydrated)
+                {
+                    // Hydration failed. Publishing this module would let the next
+                    // save replace the good document with its default state, and
+                    // retrying would rebuild a module per DataUpdate frame — so
+                    // latch unbuilt; the canonical document keeps round-tripping.
+                    _ledModuleInitialized = true;
+                    SimHub.Logging.Current.Warn(
+                        "FanatecWheelDeviceInstance[" + caps.Name + "]: LED module hydration " +
+                        "failed — keeping the stored settings as-is for this session");
+                    return;
+                }
+
+                _manager = manager;
+                _ledModule = module;
+                _ledModuleInitialized = true;
+
+                SimHub.Logging.Current.Info(
+                    "FanatecWheelDeviceInstance[" + caps.Name + "]: LED module created (" +
+                    "revRgb=" + caps.RevRgbCount + ", flagRgb=" + caps.FlagRgbCount +
+                    ", buttonRgb=" + caps.ButtonRgbCount + ", buttonAuxIntensity=" + caps.ButtonAuxIntensityCount +
+                    ", total=" + allLeds + ")");
+
+                if (_pendingDefaultsReset)
+                {
+                    // Materialize the deferred reset now that a module exists to
+                    // define what "defaults" means for the LED subtrees.
+                    TryRefreshDocumentFromModule(module);
+                    _pendingDefaultsReset = false;
+                }
             }
-            else if (_pendingLedDefaults)
-            {
-                _ledModule.LoadDefaults();
-            }
-            _pendingLedDefaults = false;
         }
 
         /// <summary>
-        /// Applies a saved settings payload to the LED module (module-level
+        /// Applies a saved settings payload to a LED module (module-level
         /// state such as brightness first, then per-channel profile data).
+        /// False on failure so callers can refuse to publish a module that
+        /// didn't fully consume the payload.
         /// </summary>
-        private void ApplyLedSettings(JObject obj, bool isDefault)
+        private static bool ApplyLedSettings(
+            LedModuleSettings<FanatecLedManager> module, JObject obj, bool isDefault)
         {
             try
             {
@@ -233,18 +284,128 @@ namespace FanaBridge.Adapters
                 // before passing channel profiles, matching LedModuleDevice.SetSettings.
                 var moduleToken = obj["ledModuleSettings"];
                 if (moduleToken != null)
-                    Newtonsoft.Json.JsonConvert.PopulateObject(moduleToken.ToString(), _ledModule);
+                    Newtonsoft.Json.JsonConvert.PopulateObject(moduleToken.ToString(), module);
 
                 // Per-channel profile data (leds, buttons, raw, …)
                 var dict = new Dictionary<string, JToken>();
                 foreach (var prop in obj.Properties())
                     dict[prop.Name] = prop.Value;
-                _ledModule.SetSettings(dict, isDefault);
+                module.SetSettings(dict, isDefault);
+                return true;
             }
             catch (Exception ex)
             {
                 SimHub.Logging.Current.Warn(
                     "FanatecWheelDeviceInstance: SetSettings(LED) failed: " + ex.Message);
+                return false;
+            }
+        }
+
+        // LoadDefaults reaches into SimHub internals that can throw; a failed
+        // reset must not tear down the caller or let a half-reset module be
+        // trusted (the canonical document is only refreshed on success).
+        private static bool TryLoadModuleDefaults(LedModuleSettings<FanatecLedManager> module)
+        {
+            try
+            {
+                module.LoadDefaults();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                SimHub.Logging.Current.Warn(
+                    "FanatecWheelDeviceInstance: LoadDefaults(LED) failed: " + ex.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Serializes the module and replaces the module-owned subtrees of the
+        /// canonical document — whole-subtree replacement, every other key
+        /// preserved. All-or-nothing: on any serialization failure the document
+        /// is left untouched so a save still returns the last good payload.
+        /// Callers hold _settingsGate.
+        /// </summary>
+        private bool TryRefreshDocumentFromModule(LedModuleSettings<FanatecLedManager> module)
+        {
+            try
+            {
+                var moduleState = JToken.FromObject(module);
+                var channels = module.GetSettings(false, false);
+
+                var doc = (JObject)(_settingsDocument?.DeepClone() ?? new JObject());
+                foreach (var key in ModuleOwnedKeys)
+                    doc.Remove(key);
+                doc["ledModuleSettings"] = moduleState;
+                if (channels != null)
+                {
+                    foreach (var kvp in channels)
+                        doc[kvp.Key] = kvp.Value != null ? kvp.Value.DeepClone() : JValue.CreateNull();
+                }
+
+                _settingsDocument = doc;
+                _settingsDocumentIsDefault = false;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                SimHub.Logging.Current.Warn(
+                    "FanatecWheelDeviceInstance: LED settings serialization failed — " +
+                    "keeping the previous settings document: " + ex.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// The canonical document plus the live custom keys (settings panels
+        /// mutate _customSettings between saves). Always a fresh object so
+        /// SimHub never receives a reference into our state. Callers hold
+        /// _settingsGate.
+        /// </summary>
+        private JObject BuildPersistedSettings()
+        {
+            var result = (JObject)(_settingsDocument?.DeepClone() ?? new JObject());
+            if (_customSettings != null)
+            {
+                foreach (var prop in _customSettings.Properties())
+                    result[prop.Name] = prop.Value.DeepClone();
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// A template/defaults projection built by the module with the exact
+        /// flags SimHub passed. Never stored: filtered output must not replace
+        /// the canonical document. Falls back to the full document if module
+        /// serialization fails. Callers hold _settingsGate.
+        /// </summary>
+        private JObject BuildModuleProjection(
+            LedModuleSettings<FanatecLedManager> module, bool forTemplate, bool forDefaultSettings)
+        {
+            try
+            {
+                var result = new JObject
+                {
+                    ["ledModuleSettings"] = JToken.FromObject(module),
+                };
+                var channels = module.GetSettings(forTemplate, forDefaultSettings);
+                if (channels != null)
+                {
+                    foreach (var kvp in channels)
+                        result[kvp.Key] = kvp.Value != null ? kvp.Value.DeepClone() : JValue.CreateNull();
+                }
+                if (_customSettings != null)
+                {
+                    foreach (var prop in _customSettings.Properties())
+                        result[prop.Name] = prop.Value.DeepClone();
+                }
+                return result;
+            }
+            catch (Exception ex)
+            {
+                SimHub.Logging.Current.Warn(
+                    "FanatecWheelDeviceInstance: GetSettings(LED) failed: " + ex.Message);
+                return BuildPersistedSettings();
             }
         }
 
@@ -285,33 +446,41 @@ namespace FanaBridge.Adapters
 
         public override void LoadDefaultSettings()
         {
+            // Settings trace (see docs: call-order/flag semantics verification).
             SimHub.Logging.Current.Info(
-                "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: LoadDefaultSettings");
+                "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: LoadDefaultSettings" +
+                " (thread " + System.Threading.Thread.CurrentThread.ManagedThreadId + ")");
 
-            EnsureLedModuleInitialized();
+            lock (_settingsGate)
+            {
+                EnsureLedModuleInitialized();
 
-            _customSettings = new JObject
-            {
-                ["wheelType"] = _config.WheelCode ?? "",
-                ["moduleType"] = _config.ModuleCode ?? "",
-                ["displayMode"] = DisplaySettings.DefaultMode,
-                ["itmEnabled"] = DisplaySettings.DefaultItmEnabled,
-                ["itmShowLapTotal"] = DisplaySettings.DefaultShowLapTotal,
-                ["itmShowPositionTotal"] = DisplaySettings.DefaultShowPositionTotal,
-                ["itmDefaultPage"] = DisplaySettings.DefaultItmDefaultPage,
-            };
-            _displaySettings = new DisplaySettings();
+                _customSettings = new JObject
+                {
+                    ["wheelType"] = _config.WheelCode ?? "",
+                    ["moduleType"] = _config.ModuleCode ?? "",
+                    ["displayMode"] = DisplaySettings.DefaultMode,
+                    ["itmEnabled"] = DisplaySettings.DefaultItmEnabled,
+                    ["itmShowLapTotal"] = DisplaySettings.DefaultShowLapTotal,
+                    ["itmShowPositionTotal"] = DisplaySettings.DefaultShowPositionTotal,
+                    ["itmDefaultPage"] = DisplaySettings.DefaultItmDefaultPage,
+                };
+                _displaySettings = new DisplaySettings();
 
-            if (_ledModule != null)
-            {
-                _ledModule.LoadDefaults();
-            }
-            else
-            {
-                // Module not buildable yet — remember that defaults were requested
-                // so EnsureLedModuleInitialized applies them on creation.
-                _pendingLedDefaults = true;
-                _pendingLedSettings = null;
+                var module = _ledModule;
+                if (module != null)
+                {
+                    if (TryLoadModuleDefaults(module))
+                        TryRefreshDocumentFromModule(module);
+                }
+                else
+                {
+                    // No module to define what LED defaults are. Keep the old LED
+                    // subtrees in the document and defer the reset to module
+                    // creation — fabricating an empty payload here would destroy
+                    // stored profiles on the next save.
+                    _pendingDefaultsReset = true;
+                }
             }
         }
 
@@ -344,43 +513,39 @@ namespace FanaBridge.Adapters
 
         public override JToken GetSettings(bool forTemplate, bool forDefaultSettings)
         {
-            var result = new JObject();
-
-            if (_ledModule != null)
+            lock (_settingsGate)
             {
-                try
-                {
-                    // Serialize the module object itself (brightness, IndividualLEDsMode, etc.)
-                    // under "ledModuleSettings" — matches how LedModuleDevice does it.
-                    result["ledModuleSettings"] = JToken.FromObject(_ledModule);
+                var module = _ledModule;
+                JObject result;
 
-                    // Per-channel profile data (leds, buttons, raw, …)
-                    var ledDict = _ledModule.GetSettings(forTemplate, forDefaultSettings);
-                    if (ledDict != null)
-                    {
-                        foreach (var kvp in ledDict)
-                        {
-                            result[kvp.Key] = kvp.Value ?? JValue.CreateNull();
-                        }
-                    }
-                }
-                catch (Exception ex)
+                if (forTemplate || forDefaultSettings)
                 {
-                    SimHub.Logging.Current.Warn(
-                        "FanatecWheelDeviceInstance: GetSettings(LED) failed: " + ex.Message);
+                    // Special serialization flavors. With a module, delegate the
+                    // filtering to it with the exact flags and do NOT fold the
+                    // filtered output back into the canonical document. Without
+                    // one, SimHub's contract for where this output lands is
+                    // unverified — the complete document is the safe answer
+                    // (never a stub that could land in the per-device file).
+                    result = module != null
+                        ? BuildModuleProjection(module, forTemplate, forDefaultSettings)
+                        : BuildPersistedSettings();
                 }
+                else
+                {
+                    if (module != null)
+                        TryRefreshDocumentFromModule(module);
+                    result = BuildPersistedSettings();
+                }
+
+                // Settings trace (call-order/flag semantics verification).
+                SimHub.Logging.Current.Info(
+                    "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: GetSettings(" +
+                    "forTemplate=" + forTemplate + ", forDefaultSettings=" + forDefaultSettings +
+                    ") thread " + System.Threading.Thread.CurrentThread.ManagedThreadId +
+                    ", module=" + (module != null) + " -> " + result.Count + " keys");
+
+                return result;
             }
-
-            // Custom settings (display mode, wheel/module identity)
-            if (_customSettings != null)
-            {
-                foreach (var prop in _customSettings.Properties())
-                {
-                    result[prop.Name] = prop.Value.DeepClone();
-                }
-            }
-
-            return result;
         }
 
         public override void SetSettings(JToken settings, bool isDefault)
@@ -388,42 +553,47 @@ namespace FanaBridge.Adapters
             if (!(settings is JObject obj))
                 return;
 
-            EnsureLedModuleInitialized();
+            // Settings trace (call-order/flag semantics verification).
+            SimHub.Logging.Current.Info(
+                "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: SetSettings(" +
+                "isDefault=" + isDefault + ") thread " +
+                System.Threading.Thread.CurrentThread.ManagedThreadId + ", " + obj.Count + " keys");
 
-            // Extract custom settings
-            _customSettings = new JObject();
-            foreach (var key in new[] { "wheelType", "moduleType", "displayMode", "itmEnabled",
-                                        "itmShowLapTotal", "itmShowPositionTotal", "itmDefaultPage" })
+            lock (_settingsGate)
             {
-                if (obj[key] != null)
-                    _customSettings[key] = obj[key].DeepClone();
+                // The complete payload becomes the canonical document, replaced
+                // whole — a later SetSettings simply wins. Custom keys are
+                // everything the module doesn't own, so keys this class doesn't
+                // know about (e.g. the tuning panel's) survive a reload.
+                _settingsDocument = (JObject)obj.DeepClone();
+                _settingsDocumentIsDefault = isDefault;
+                _pendingDefaultsReset = false;
+
+                _customSettings = new JObject();
+                foreach (var prop in obj.Properties())
+                {
+                    if (!ModuleOwnedKeys.Contains(prop.Name))
+                        _customSettings[prop.Name] = prop.Value.DeepClone();
+                }
+
+                // If the module already exists, apply the payload to it; if this
+                // call builds it, hydration consumes the document set above.
+                var hadModule = _ledModule != null;
+                EnsureLedModuleInitialized();
+                if (hadModule)
+                    ApplyLedSettings(_ledModule, obj, isDefault);
+
+                _displaySettings = new DisplaySettings
+                {
+                    DisplayMode = (string)_customSettings["displayMode"] ?? DisplaySettings.DefaultMode,
+                    ItmEnabled = (bool?)_customSettings["itmEnabled"] ?? DisplaySettings.DefaultItmEnabled,
+                    ItmShowLapTotal = (bool?)_customSettings["itmShowLapTotal"] ?? DisplaySettings.DefaultShowLapTotal,
+                    ItmShowPositionTotal = (bool?)_customSettings["itmShowPositionTotal"] ?? DisplaySettings.DefaultShowPositionTotal,
+                    ItmDefaultPage = (byte?)_customSettings["itmDefaultPage"] ?? DisplaySettings.DefaultItmDefaultPage,
+                };
+
+                _displayManager?.UpdateSettings(_displaySettings);
             }
-
-            if (_ledModule != null)
-            {
-                ApplyLedSettings(obj, isDefault);
-                _pendingLedSettings = null;
-                _pendingLedDefaults = false;
-            }
-            else
-            {
-                // Module not buildable yet (plugin still initializing) — keep the
-                // payload so EnsureLedModuleInitialized can apply it on creation.
-                _pendingLedSettings = (JObject)obj.DeepClone();
-                _pendingLedSettingsIsDefault = isDefault;
-                _pendingLedDefaults = false;
-            }
-
-            _displaySettings = new DisplaySettings
-            {
-                DisplayMode = (string)_customSettings["displayMode"] ?? DisplaySettings.DefaultMode,
-                ItmEnabled = (bool?)_customSettings["itmEnabled"] ?? DisplaySettings.DefaultItmEnabled,
-                ItmShowLapTotal = (bool?)_customSettings["itmShowLapTotal"] ?? DisplaySettings.DefaultShowLapTotal,
-                ItmShowPositionTotal = (bool?)_customSettings["itmShowPositionTotal"] ?? DisplaySettings.DefaultShowPositionTotal,
-                ItmDefaultPage = (byte?)_customSettings["itmDefaultPage"] ?? DisplaySettings.DefaultItmDefaultPage,
-            };
-
-            _displayManager?.UpdateSettings(_displaySettings);
         }
 
         public override void DataUpdate(PluginManager pluginManager, ref GameData data)

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -200,19 +200,25 @@ namespace FanaBridge.Adapters
         /// A single module handles all LED types (Rev, Flag, Button/Encoder)
         /// through the unified <see cref="FanatecLedDriver"/>.
         /// </summary>
-        private void EnsureLedModuleInitialized()
+        private void EnsureLedModuleInitialized(bool throttled = false)
         {
             if (_ledModuleInitialized)
                 return;
 
             // DataUpdate retries this per frame while unbuilt; for wheels whose
             // caps genuinely resolve to zero LEDs (display-only profiles) that
-            // would mean a lock + ResolveCapsFor per frame forever. Bound the
-            // retry to ~1/s. Wrap-safe unsigned delta (see PublishItmStatusSnapshot).
+            // would mean a lock + ResolveCapsFor per frame forever. Bound that
+            // retry to ~1/s — but ONLY the DataUpdate path: GetSettingsControls
+            // runs once and SimHub caches its result, so a throttled return
+            // there would cost the LEDs tab for the whole session. Wrap-safe
+            // unsigned delta (see PublishItmStatusSnapshot).
             int tick = Environment.TickCount;
-            int lastZero = _lastZeroCapsTick;
-            if (lastZero != 0 && unchecked((uint)(tick - lastZero)) < 1000)
-                return;
+            if (throttled)
+            {
+                int lastZero = _lastZeroCapsTick;
+                if (lastZero != 0 && unchecked((uint)(tick - lastZero)) < 1000)
+                    return;
+            }
 
             lock (_settingsGate)
             {
@@ -320,7 +326,7 @@ namespace FanaBridge.Adapters
                     // reset itself failed the document keeps the old subtrees —
                     // out-of-sync already blocks refreshes.
                     if (hydrated)
-                        TryRefreshDocumentFromModule(module);
+                        TryRefreshDocumentFromModule(module, channelReset: true);
                     _pendingDefaultsReset = false;
                 }
             }
@@ -383,7 +389,8 @@ namespace FanaBridge.Adapters
         /// is left untouched so a save still returns the last good payload.
         /// Callers hold _settingsGate.
         /// </summary>
-        private bool TryRefreshDocumentFromModule(LedModuleSettings<FanatecLedManager> module)
+        private bool TryRefreshDocumentFromModule(
+            LedModuleSettings<FanatecLedManager> module, bool channelReset = false)
         {
             try
             {
@@ -398,11 +405,15 @@ namespace FanaBridge.Adapters
                     {
                         // SimHub emits every channel key and nulls the ones it
                         // has no driver for right now (e.g. a profile override
-                        // without button LEDs). Null means "can't emit", not
-                        // "deleted" — keep the stored subtree so reverting the
-                        // override gets it back.
+                        // without button LEDs). On an ordinary save null means
+                        // "can't emit", not "deleted" — keep the stored subtree
+                        // so reverting the override gets it back. On an explicit
+                        // defaults reset the stored subtree must go too, or it
+                        // resurrects after the override is reverted.
                         if (kvp.Value != null && kvp.Value.Type != JTokenType.Null)
                             doc[kvp.Key] = kvp.Value.DeepClone();
+                        else if (channelReset)
+                            doc.Remove(kvp.Key);
                     }
                 }
 
@@ -503,6 +514,15 @@ namespace FanaBridge.Adapters
             // Re-register with the new plugin's instance list (used by the
             // Control Mapper integration to read display names).
             _registeredWithPlugin = false;
+
+            // A new generation also earns a fresh module-build attempt if a
+            // previous construction failed or caps resolved to zero — the
+            // latch and throttle are per-generation, not per-session.
+            if (_ledModule == null)
+            {
+                _ledModuleInitialized = false;
+                _lastZeroCapsTick = 0;
+            }
         }
 
         // ── DeviceInstance overrides ─────────────────────────────────────
@@ -549,7 +569,7 @@ namespace FanaBridge.Adapters
                     if (TryLoadModuleDefaults(module))
                     {
                         _moduleOutOfSync = false;
-                        TryRefreshDocumentFromModule(module);
+                        TryRefreshDocumentFromModule(module, channelReset: true);
                     }
                     else
                     {
@@ -601,6 +621,21 @@ namespace FanaBridge.Adapters
             lock (_settingsGate)
             {
                 var module = _ledModule;
+
+                // While out-of-sync, retry applying the canonical document once
+                // per save: transient apply failures heal here (module returns
+                // to exactly the stored state, so no user data moves). If the
+                // payload itself is unappliable the document stays
+                // authoritative — reset-defaults is the repair path, and it
+                // re-trusts the module. Trade-off: a late-healing resync
+                // reverts LEDs-tab edits made while broken, visibly — better
+                // than silently excluding them from saves forever.
+                if (module != null && _moduleOutOfSync && _settingsDocument != null
+                    && ApplyLedSettings(module, _settingsDocument, _settingsDocumentIsDefault))
+                {
+                    _moduleOutOfSync = false;
+                }
+
                 bool trusted = module != null && !_moduleOutOfSync;
                 JObject result;
 
@@ -741,7 +776,7 @@ namespace FanaBridge.Adapters
             if (!isConnected)
                 return;
 
-            EnsureLedModuleInitialized();
+            EnsureLedModuleInitialized(throttled: true);
 
             var plugin = PluginResolver();
             var device = plugin?.Transport;
@@ -1002,7 +1037,7 @@ namespace FanaBridge.Adapters
             if (panels != null && _config.Capabilities.HasEncoders)
             {
                 yield return new DeviceSettingControl(
-                    panels.CreateTuningPanel(_customSettings),
+                    panels.CreateTuningPanel(_customSettings, _settingsGate),
                     2,
                     "Tuning",
                     DeviceSettingControlKind.None,

--- a/src/FanaBridge/Adapters/IDevicePanelFactory.cs
+++ b/src/FanaBridge/Adapters/IDevicePanelFactory.cs
@@ -18,7 +18,11 @@ namespace FanaBridge.Adapters
         /// <summary>A bound Screen settings panel; <paramref name="settingsChanged"/> fires on any user change.</summary>
         Control CreateScreenPanel(DisplaySettings settings, DisplayType display, byte itmDeviceId, Action settingsChanged);
 
-        /// <summary>A bound Tuning settings panel.</summary>
-        Control CreateTuningPanel(JObject customSettings);
+        /// <summary>
+        /// A bound Tuning settings panel. Writes into <paramref name="customSettings"/>
+        /// must hold <paramref name="settingsGate"/> — the device instance
+        /// enumerates the same object during saves on another thread.
+        /// </summary>
+        Control CreateTuningPanel(JObject customSettings, object settingsGate);
     }
 }

--- a/src/FanaBridge/UI/DevicePanelFactory.cs
+++ b/src/FanaBridge/UI/DevicePanelFactory.cs
@@ -18,10 +18,10 @@ namespace FanaBridge.UI
             return panel;
         }
 
-        public Control CreateTuningPanel(JObject customSettings)
+        public Control CreateTuningPanel(JObject customSettings, object settingsGate)
         {
             var panel = new TuningSettingsPanel();
-            panel.Bind(customSettings);
+            panel.Bind(customSettings, settingsGate);
             return panel;
         }
     }

--- a/src/FanaBridge/UI/TuningSettingsPanel.xaml.cs
+++ b/src/FanaBridge/UI/TuningSettingsPanel.xaml.cs
@@ -11,6 +11,9 @@ namespace FanaBridge.UI
     public partial class TuningSettingsPanel : UserControl
     {
         private JObject _settings;
+        // Guards every _settings access: the device instance enumerates the
+        // same JObject during saves on another thread.
+        private object _settingsGate = new object();
         private bool _suppressEvents;
 
         /// <summary>Fired when the user changes a setting. The parent should persist.</summary>
@@ -26,9 +29,10 @@ namespace FanaBridge.UI
         /// Binds the panel to a device-instance settings JObject.
         /// Call once after construction, before the panel is displayed.
         /// </summary>
-        public void Bind(JObject settings)
+        public void Bind(JObject settings, object settingsGate = null)
         {
             _settings = settings ?? new JObject();
+            _settingsGate = settingsGate ?? new object();
             UpdateEnabledState();
         }
 
@@ -77,14 +81,20 @@ namespace FanaBridge.UI
                         {
                             modeTag = ((EncoderMode)raw).ToString();
                             if (_settings != null)
-                                _settings["encoderMode"] = modeTag;
+                            {
+                                lock (_settingsGate)
+                                    _settings["encoderMode"] = modeTag;
+                            }
                         }
                     }
                 }
 
                 // Fall back to persisted setting
                 if (modeTag == null && _settings != null)
-                    modeTag = (string)_settings["encoderMode"];
+                {
+                    lock (_settingsGate)
+                        modeTag = (string)_settings["encoderMode"];
+                }
 
                 modeTag = modeTag ?? "Encoder";
 
@@ -139,7 +149,8 @@ namespace FanaBridge.UI
             if (selected == null) return;
 
             string modeTag = (string)selected.Tag;
-            _settings["encoderMode"] = modeTag;
+            lock (_settingsGate)
+                _settings["encoderMode"] = modeTag;
             SettingsChanged?.Invoke();
 
             // Send to hardware immediately

--- a/src/FanaBridge/UI/TuningSettingsPanel.xaml.cs
+++ b/src/FanaBridge/UI/TuningSettingsPanel.xaml.cs
@@ -26,10 +26,11 @@ namespace FanaBridge.UI
         }
 
         /// <summary>
-        /// Binds the panel to a device-instance settings JObject.
-        /// Call once after construction, before the panel is displayed.
+        /// Binds the panel to a device-instance settings JObject. The gate is
+        /// required: the device instance enumerates the same object during
+        /// saves on another thread, so every caller must share its lock.
         /// </summary>
-        public void Bind(JObject settings, object settingsGate = null)
+        public void Bind(JObject settings, object settingsGate)
         {
             _settings = settings ?? new JObject();
             _settingsGate = settingsGate ?? new object();

--- a/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
@@ -345,6 +345,10 @@ namespace FanaBridge.Tests
             inst.PluginResolver = () => plugin;
             inst.GetDynamicButtonActions();   // any EnsureLedModuleInitialized site
 
+            // Publish-anyway: the module must exist even if hydration failed
+            // (the LEDs tab is the only way to repair a bad payload) — and the
+            // payload survives either way (module state or document fallback).
+            Assert.True(inst.LedModuleBuiltForTest);
             var result = (JObject)inst.GetSettings(false, false);
             Assert.Equal(80.0, (double)result["ledModuleSettings"]!["_LEDsBrightness"]!);
         }
@@ -415,9 +419,51 @@ namespace FanaBridge.Tests
             inst.PluginResolver = () => plugin;
             inst.GetDynamicButtonActions();   // builds the module → LoadDefaults path
 
+            Assert.True(inst.LedModuleBuiltForTest);
             var result = (JObject)inst.GetSettings(false, false);
             Assert.NotNull(result["ledModuleSettings"]);
             Assert.NotNull(result["leds"]);
+        }
+
+        [Fact]
+        public void LoadDefaults_PurgesPanelKeysFromTheDocument()
+        {
+            // The overlay can add and overwrite keys but never remove them, so
+            // a defaults reset must strip non-module keys from the document or
+            // panel-written keys resurrect on the next save.
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+
+            var payload = LedSettingsPayload();
+            payload["encoderMode"] = "fine";
+            inst.SetSettings(payload, false);
+            inst.LoadDefaultSettings();
+
+            var result = (JObject)inst.GetSettings(false, false);
+            Assert.Null(result["encoderMode"]);                                  // purged
+            Assert.Equal(80.0, (double)result["ledModuleSettings"]!["_LEDsBrightness"]!); // LED subtrees deferred
+        }
+
+        [Fact]
+        public void CustomSettingsObject_IsStableAcrossReloads()
+        {
+            // UI panels hold the custom-settings JObject for their lifetime;
+            // a reload must repopulate it in place, not replace it, or panel
+            // edits land in an orphaned object and are never persisted.
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+
+            var bound = inst.CustomSettingsForTest;
+            inst.SetSettings(LedSettingsPayload(), false);
+            var second = LedSettingsPayload();
+            second["itmDefaultPage"] = 5;
+            inst.SetSettings(second, false);
+
+            Assert.Same(bound, inst.CustomSettingsForTest);
+            Assert.Equal(5, (int)bound["itmDefaultPage"]!);
+
+            inst.LoadDefaultSettings();
+            Assert.Same(bound, inst.CustomSettingsForTest);
         }
     }
 }

--- a/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
@@ -7,6 +7,7 @@ using FanaBridge.Profiles;
 using FanaBridge.Protocol;
 using FanaBridge.Transport;
 using GameReaderCommon;
+using Newtonsoft.Json.Linq;
 using SimHub.Plugins.Devices;
 using Xunit;
 
@@ -23,6 +24,16 @@ namespace FanaBridge.Tests
     /// </summary>
     public class FanatecWheelDeviceInstanceTests
     {
+        static FanatecWheelDeviceInstanceTests()
+        {
+            // SimHub's Profile static initializer wants a JavascriptExtensions
+            // directory next to the binary (present in every SimHub install,
+            // absent in the test bin) — and a failed type initializer is sticky
+            // for the whole process.
+            System.IO.Directory.CreateDirectory(System.IO.Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory, "JavascriptExtensions"));
+        }
+
         // ── Wheelbase harness (same fakes as FanatecWheelbaseTests) ───────
 
         private sealed class FakeTransport : IConnectableTransport
@@ -269,6 +280,144 @@ namespace FanaBridge.Tests
             inst.DataUpdate(null, ref data);
 
             Assert.Same(pluginA, inst.BoundPluginForTest);
+        }
+
+        // ── Settings persistence (document-first) ──────────────────────────
+        //
+        // SimHub loads the DLL and creates DeviceInstances even when the
+        // plugin is deactivated in its plugin list, then rewrites each
+        // device's settings file from GetSettings on every save-all. The
+        // canonical document must round-trip losslessly in every state where
+        // the LED module can't be built — one save-all writing a stub is
+        // permanent loss of the stored LED profiles.
+
+        private static JObject LedSettingsPayload() => new JObject
+        {
+            ["ledModuleSettings"] = new JObject { ["_LEDsBrightness"] = 80.0 },
+            ["leds"] = new JObject { ["activeProfileId"] = "3795069f-fb17-46f8-a89e-b432d812283d" },
+            ["buttons"] = new JObject(),
+            ["wheelType"] = "PSWBMW",
+            ["itmDefaultPage"] = 3,
+        };
+
+        [Fact]
+        public void PluginUnavailable_GetSettings_RoundTripsTheDocument()
+        {
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+
+            inst.SetSettings(LedSettingsPayload(), false);
+            var result = (JObject)inst.GetSettings(false, false);
+
+            Assert.Equal(80.0, (double)result["ledModuleSettings"]!["_LEDsBrightness"]!);
+            Assert.Equal("3795069f-fb17-46f8-a89e-b432d812283d", (string?)result["leds"]!["activeProfileId"]);
+            Assert.NotNull(result["buttons"]);
+            Assert.Equal(3, (int)result["itmDefaultPage"]!);
+        }
+
+        [Fact]
+        public void PluginUnavailable_SpecialFlavors_StillReturnTheFullDocument()
+        {
+            // Interim policy pending SimHub-contract verification: with no
+            // module to do the template/defaults filtering, returning the
+            // complete document is the only answer that can't wipe the
+            // per-device file if SimHub writes this output there.
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+            inst.SetSettings(LedSettingsPayload(), false);
+
+            foreach (var (forTemplate, forDefaults) in new[] { (true, false), (false, true), (true, true) })
+            {
+                var result = (JObject)inst.GetSettings(forTemplate, forDefaults);
+                Assert.NotNull(result["leds"]);
+                Assert.Equal(3, (int)result["itmDefaultPage"]!);
+            }
+        }
+
+        [Fact]
+        public void PluginArrivesLater_DocumentHydratesTheBuiltModule()
+        {
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+            inst.SetSettings(LedSettingsPayload(), false);
+
+            var plugin = PluginWithWheel(null, out _);
+            inst.PluginResolver = () => plugin;
+            inst.GetDynamicButtonActions();   // any EnsureLedModuleInitialized site
+
+            var result = (JObject)inst.GetSettings(false, false);
+            Assert.Equal(80.0, (double)result["ledModuleSettings"]!["_LEDsBrightness"]!);
+        }
+
+        [Fact]
+        public void UnknownCustomKeys_SurviveTheReloadRoundTrip()
+        {
+            // The tuning panel writes keys (e.g. encoderMode) this class doesn't
+            // enumerate; a whitelist would silently drop them on the next load.
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+
+            var payload = LedSettingsPayload();
+            payload["encoderMode"] = "fine";
+            inst.SetSettings(payload, false);
+
+            var result = (JObject)inst.GetSettings(false, false);
+            Assert.Equal("fine", (string?)result["encoderMode"]);
+        }
+
+        [Fact]
+        public void SetSettingsTwice_TheLaterPayloadWins()
+        {
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+
+            inst.SetSettings(LedSettingsPayload(), false);
+            var second = LedSettingsPayload();
+            second["ledModuleSettings"] = new JObject { ["_LEDsBrightness"] = 55.0 };
+            inst.SetSettings(second, false);
+
+            var result = (JObject)inst.GetSettings(false, false);
+            Assert.Equal(55.0, (double)result["ledModuleSettings"]!["_LEDsBrightness"]!);
+        }
+
+        [Fact]
+        public void LoadDefaults_WithoutModule_DefersTheLedReset()
+        {
+            // With no module to define LED defaults, the stored LED subtrees
+            // must survive (deferred reset) while custom keys reset now —
+            // destroying profiles to fake a reset is the wipe again.
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+            inst.SetSettings(LedSettingsPayload(), false);
+
+            inst.LoadDefaultSettings();
+            var result = (JObject)inst.GetSettings(false, false);
+
+            Assert.Equal(80.0, (double)result["ledModuleSettings"]!["_LEDsBrightness"]!);   // retained
+            Assert.Equal(
+                (int)DisplaySettings.DefaultItmDefaultPage, (int)result["itmDefaultPage"]!); // reset
+        }
+
+        [Fact]
+        public void DeferredLedReset_ModuleBuildAttempt_NeverProducesAStub()
+        {
+            // Headless, LoadDefaults on the fresh module fails inside SimHub
+            // internals (app context is absent), taking the hydration-failure
+            // path; in-app it succeeds and materializes the reset. Either way
+            // the invariant this pins is the same: the LED subtrees survive —
+            // a save after the build attempt must never emit a stub.
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+            inst.SetSettings(LedSettingsPayload(), false);
+            inst.LoadDefaultSettings();
+
+            var plugin = PluginWithWheel(null, out _);
+            inst.PluginResolver = () => plugin;
+            inst.GetDynamicButtonActions();   // builds the module → LoadDefaults path
+
+            var result = (JObject)inst.GetSettings(false, false);
+            Assert.NotNull(result["ledModuleSettings"]);
+            Assert.NotNull(result["leds"]);
         }
     }
 }


### PR DESCRIPTION
## What broke

Disabling FanaBridge via the per-plugin checkbox in SimHub's plugin list could permanently wipe per-device settings — LED profiles, brightness, button colors — replacing 10–16 KB settings files with ~450-byte stubs. Confirmed by a real incident on 2026-08-02 (settings recovered from SimHub's rolling backups).

Mechanism: even with the plugin deactivated, SimHub still loads `FanaBridge.dll`, still registers the device types, still creates `DeviceInstance`s and delivers their stored settings — but the plugin singleton never initializes, so the LED module can never be built. SimHub rewrites every device's settings file from `GetSettings()` on each save-all (activation toggles, plugin-manager restarts, clean exit), and the old `GetSettings` emitted LED data only when the module existed. One save-all in that half-loaded state destroyed the stored payload. The same window existed transiently during normal startup and plugin-activation toggles.

(SimHub's *master* "disable 3rd-party plugins" switch is unaffected — it skips the DLL entirely and leaves settings files untouched.)

## The fix: document-first persistence

Instead of patching the emit path, persistence now keeps a **lossless canonical document** as the source of truth, with the LED module as a projection of it:

- `SetSettings` stores the complete payload as the document (replaced whole, never cleared). `GetSettings` always has something complete to return, in every lifecycle state — the wipe becomes impossible by construction.
- The module hydrates from the document before being published; ordinary saves refresh the document from the module by replacing only the module-owned subtrees, preserving every other key.
- A failed apply into the module marks it out-of-sync: saves serve the document until an apply fully succeeds (each ordinary save retries). A half-mutated module can never be serialized over good data.
- Defaults resets are durable and complete: deferred when no module exists, and pending until a refresh actually materializes them — including dropping channels the current module can't emit.
- All settings state sits behind one lock, module publication is ordered and volatile, and the settings panels share the same gate.

Fixed along the way:

- `encoderMode` (Tuning panel) was silently dropped on every reload by a custom-key whitelist; unknown keys now round-trip.
- The zero-LED capability latch could permanently disable a module that raced plugin init; retries are now bounded (~1/s, `DataUpdate` path only) instead of forbidden.
- The issue-#37 generation guard now also covers modules built outside `DataUpdate`.
- Settings calls log method, flags, thread, and key count for field verification of SimHub's call ordering.

## Review process

Four adversarial review rounds across three independent reviewers, including two comparative rounds over this branch and a minimal-fix alternative. All confirmed findings are addressed; one deliberately deferred item (a cached settings-tab edge case after a module construction failure at first enumeration — rare, pre-existing behavior class) will get a follow-up issue.

## Testing

- 611/611 tests passing; 9 new/updated regression tests covering the wipe scenario, round-trips while the plugin is unavailable, special-flavor policies, deferred resets, reload stability of panel bindings, and unknown-key survival.
- Reviewer note: the settings-trace logging is Info-level and intentionally verbose for the first field deployment; can be dialed down before release.
