### PR TITLE
Contain device settings loss when the runtime plugin is unavailable

### DIFF
--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -45,6 +45,12 @@ namespace FanaBridge.Adapters
         private JObject _pendingLedSettings;
         private bool _pendingLedSettingsIsDefault;
         private bool _pendingLedDefaults;
+        // Whether the pending payload has already been retried since it was
+        // stashed. A payload the module rejects blocks saving (see GetSettings),
+        // so it gets one more chance on the next call that touches the module —
+        // enough to clear a transient failure without retrying a permanently
+        // malformed payload on every frame.
+        private bool _pendingLedRetried;
 
         // Display manager — null when the wheel has no display.
         private FanatecDisplayDriver _displayManager;
@@ -158,7 +164,10 @@ namespace FanaBridge.Adapters
         private void EnsureLedModuleInitialized()
         {
             if (_ledModuleInitialized)
+            {
+                RetryPendingLedSettings();
                 return;
+            }
 
             // Without the shared encoders we can't build a module at all. Leave
             // the initialized flag unset so the next call retries — latching it
@@ -229,6 +238,40 @@ namespace FanaBridge.Adapters
                 _ledModule.LoadDefaults();
             }
             _pendingLedDefaults = false;
+        }
+
+        /// <summary>
+        /// Gives a payload the module previously rejected one more chance.
+        /// </summary>
+        /// <remarks>
+        /// While a payload is pending against an existing module the device
+        /// cannot save at all, so a failure that was only transient must not
+        /// strand it for the rest of the session. One retry is enough for that
+        /// without re-parsing a permanently malformed payload on every frame —
+        /// this runs from the per-frame update path.
+        /// </remarks>
+        private void RetryPendingLedSettings()
+        {
+            if (_ledModule == null || _pendingLedSettings == null || _pendingLedRetried)
+                return;
+
+            _pendingLedRetried = true;
+
+            if (ApplyLedSettings(_pendingLedSettings, _pendingLedSettingsIsDefault))
+            {
+                _pendingLedSettings = null;
+                SimHub.Logging.Current.Info(
+                    "FanatecWheelDeviceInstance[" + _config.Capabilities.Name +
+                    "]: pending LED settings applied on retry — saving is enabled again");
+            }
+            else
+            {
+                SimHub.Logging.Current.Warn(
+                    "FanatecWheelDeviceInstance[" + _config.Capabilities.Name +
+                    "]: pending LED settings were rejected again — this device will not " +
+                    "save until its settings are reloaded or reset, so the stored file " +
+                    "keeps the last complete copy");
+            }
         }
 
         /// <summary>
@@ -464,6 +507,7 @@ namespace FanaBridge.Adapters
                 {
                     _pendingLedSettings = (JObject)obj.DeepClone();
                     _pendingLedSettingsIsDefault = isDefault;
+                    _pendingLedRetried = false;
                 }
                 _pendingLedDefaults = false;
             }
@@ -473,6 +517,7 @@ namespace FanaBridge.Adapters
                 // payload so EnsureLedModuleInitialized can apply it on creation.
                 _pendingLedSettings = (JObject)obj.DeepClone();
                 _pendingLedSettingsIsDefault = isDefault;
+                _pendingLedRetried = false;
                 _pendingLedDefaults = false;
             }
 

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -429,6 +429,13 @@ namespace FanaBridge.Adapters
         {
             var result = new JObject();
 
+            // A device that never becomes connected reaches no other path that
+            // would retry, so spend the budget here rather than refuse every
+            // save for the rest of the session over a failure that may have
+            // been momentary. Bounded by the same flag, so this stays one
+            // attempt per loaded payload.
+            RetryPendingLedSettings();
+
             if (_ledModule != null)
             {
                 if (_pendingLedSettings != null)

--- a/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
+++ b/src/FanaBridge/Adapters/FanatecWheelDeviceInstance.cs
@@ -91,6 +91,13 @@ namespace FanaBridge.Adapters
         // drive the null→A, A→A, A→B, and connected→scanning transitions.
         internal Func<FanatecPlugin> PluginResolver = () => FanatecPlugin.Instance;
 
+        // Test seams for the two LED-module operations that can fail. SimHub's
+        // LED profile subsystem reads the running host, so it cannot run in a
+        // unit test — these let tests drive the success/failure outcomes the
+        // persistence logic branches on. Null in production.
+        internal Func<JObject, bool, bool> LedApplyForTest;
+        internal Action LedDefaultsForTest;
+
         /// <summary>Test hook: the generation the cached drivers were built against.</summary>
         internal FanatecPlugin BoundPluginForTest => _boundPlugin;
 
@@ -208,11 +215,14 @@ namespace FanaBridge.Adapters
                 ", buttonRgb=" + caps.ButtonRgbCount + ", buttonAuxIntensity=" + caps.ButtonAuxIntensityCount +
                 ", total=" + allLeds + ")");
 
-            // Apply anything SimHub delivered before the module existed.
+            // Apply anything SimHub delivered before the module existed. The stash
+            // is dropped only once the payload is fully applied — a failed apply
+            // leaves a half-populated module, and the stash is then the only
+            // complete copy of the user's settings (see GetSettings).
             if (_pendingLedSettings != null)
             {
-                ApplyLedSettings(_pendingLedSettings, _pendingLedSettingsIsDefault);
-                _pendingLedSettings = null;
+                if (ApplyLedSettings(_pendingLedSettings, _pendingLedSettingsIsDefault))
+                    _pendingLedSettings = null;
             }
             else if (_pendingLedDefaults)
             {
@@ -224,9 +234,14 @@ namespace FanaBridge.Adapters
         /// <summary>
         /// Applies a saved settings payload to the LED module (module-level
         /// state such as brightness first, then per-channel profile data).
+        /// Returns false when the payload was not fully applied, so callers can
+        /// keep the pending copy rather than trusting a half-populated module.
         /// </summary>
-        private void ApplyLedSettings(JObject obj, bool isDefault)
+        private bool ApplyLedSettings(JObject obj, bool isDefault)
         {
+            if (LedApplyForTest != null)
+                return LedApplyForTest(obj, isDefault);
+
             try
             {
                 // Restore module-level state (brightness, IndividualLEDsMode, etc.)
@@ -240,11 +255,13 @@ namespace FanaBridge.Adapters
                 foreach (var prop in obj.Properties())
                     dict[prop.Name] = prop.Value;
                 _ledModule.SetSettings(dict, isDefault);
+                return true;
             }
             catch (Exception ex)
             {
                 SimHub.Logging.Current.Warn(
                     "FanatecWheelDeviceInstance: SetSettings(LED) failed: " + ex.Message);
+                return false;
             }
         }
 
@@ -304,7 +321,13 @@ namespace FanaBridge.Adapters
 
             if (_ledModule != null)
             {
-                _ledModule.LoadDefaults();
+                if (LedDefaultsForTest != null)
+                    LedDefaultsForTest();
+                else
+                    _ledModule.LoadDefaults();
+                // An explicit reset makes the module authoritative again: any
+                // payload left over from a failed apply is now obsolete.
+                _pendingLedSettings = null;
             }
             else
             {
@@ -342,32 +365,61 @@ namespace FanaBridge.Adapters
             return DeviceState.Connected;
         }
 
+        /// <summary>
+        /// Produces this device's persisted settings document.
+        /// </summary>
+        /// <remarks>
+        /// SimHub rewrites every device's settings file from this method on each
+        /// save, with no merge against what is already on disk — so anything
+        /// missing here is erased. The plugin can be disabled or still starting
+        /// while SimHub loads and saves devices, in which case the LED module
+        /// does not exist and the loaded payload lives in
+        /// <see cref="_pendingLedSettings"/>; it is echoed back verbatim rather
+        /// than emitting a document without LED data.
+        ///
+        /// A module coexisting with a pending payload means hydration failed, so
+        /// the module holds partial state. That case throws: SimHub catches
+        /// per-device save failures and leaves the existing file (and its index
+        /// entry) untouched, which is the safe outcome.
+        /// </remarks>
         public override JToken GetSettings(bool forTemplate, bool forDefaultSettings)
         {
             var result = new JObject();
 
             if (_ledModule != null)
             {
-                try
+                if (_pendingLedSettings != null)
                 {
-                    // Serialize the module object itself (brightness, IndividualLEDsMode, etc.)
-                    // under "ledModuleSettings" — matches how LedModuleDevice does it.
-                    result["ledModuleSettings"] = JToken.FromObject(_ledModule);
+                    throw new InvalidOperationException(
+                        "FanatecWheelDeviceInstance[" + _config.Capabilities.Name + "]: refusing to " +
+                        "save — the loaded LED settings were not applied to the module, so the " +
+                        "document would be incomplete.");
+                }
 
-                    // Per-channel profile data (leds, buttons, raw, …)
-                    var ledDict = _ledModule.GetSettings(forTemplate, forDefaultSettings);
-                    if (ledDict != null)
+                // Serialize the module object itself (brightness, IndividualLEDsMode, etc.)
+                // under "ledModuleSettings" — matches how LedModuleDevice does it.
+                // Failures propagate: a partial document here would overwrite a
+                // complete file on disk.
+                result["ledModuleSettings"] = JToken.FromObject(_ledModule);
+
+                // Per-channel profile data (leds, buttons, raw, …)
+                var ledDict = _ledModule.GetSettings(forTemplate, forDefaultSettings);
+                if (ledDict != null)
+                {
+                    foreach (var kvp in ledDict)
                     {
-                        foreach (var kvp in ledDict)
-                        {
-                            result[kvp.Key] = kvp.Value ?? JValue.CreateNull();
-                        }
+                        result[kvp.Key] = kvp.Value ?? JValue.CreateNull();
                     }
                 }
-                catch (Exception ex)
+            }
+            else if (_pendingLedSettings != null)
+            {
+                // Module not buildable (plugin disabled or still starting). Echo the
+                // document SimHub gave us — no edit path exists while the module is
+                // absent, so this is still the user's complete, current payload.
+                foreach (var prop in _pendingLedSettings.Properties())
                 {
-                    SimHub.Logging.Current.Warn(
-                        "FanatecWheelDeviceInstance: GetSettings(LED) failed: " + ex.Message);
+                    result[prop.Name] = prop.Value.DeepClone();
                 }
             }
 
@@ -401,8 +453,18 @@ namespace FanaBridge.Adapters
 
             if (_ledModule != null)
             {
-                ApplyLedSettings(obj, isDefault);
-                _pendingLedSettings = null;
+                // Keep the payload when the module refuses it: the module is then
+                // partially populated and this copy is the only complete one.
+                // GetSettings refuses to save while both exist.
+                if (ApplyLedSettings(obj, isDefault))
+                {
+                    _pendingLedSettings = null;
+                }
+                else
+                {
+                    _pendingLedSettings = (JObject)obj.DeepClone();
+                    _pendingLedSettingsIsDefault = isDefault;
+                }
                 _pendingLedDefaults = false;
             }
             else

--- a/tests/FanaBridge.Tests/FanaBridge.Tests.csproj
+++ b/tests/FanaBridge.Tests/FanaBridge.Tests.csproj
@@ -49,6 +49,7 @@
       <_Parameter2>$(SimHubDir)</_Parameter2>
     </AssemblyAttribute>
     <None Include="Snapshots\SimHub.FanatecManaged.enums.txt" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
@@ -465,7 +465,7 @@ namespace FanaBridge.Tests
         }
 
         [Fact]
-        public void FailedHydration_IsRetriedOnce_AndSavingRecovers()
+        public void FailedHydration_IsRetriedWhenTheDeviceIsNextTouched()
         {
             // A transient refusal must not strand the device for the session.
             var inst = InstanceFor("PSWBMW");
@@ -476,13 +476,44 @@ namespace FanaBridge.Tests
             inst.LedApplyForTest = (_, __) => ++attempts > 1;   // fails once, then succeeds
 
             inst.SetSettings(FullDocument(), isDefault: false);
-            Assert.Throws<InvalidOperationException>(() => inst.GetSettings(false, false));
-
-            inst.GetDynamicButtonActions();   // next touch retries the payload
+            inst.GetDynamicButtonActions();   // any module-touching call retries
 
             var saved = (JObject)inst.GetSettings(false, false)!;
             Assert.Equal(2, attempts);
             Assert.Equal(3, (int?)saved["itmDefaultPage"]);
+        }
+
+        [Fact]
+        public void FailedHydration_IsRetriedOnSave_ForANeverConnectedDevice()
+        {
+            // A device that never becomes connected reaches no other path that
+            // would retry, so the save itself has to spend the budget.
+            var inst = InstanceFor("PSWBMW");
+            var plugin = PluginWithWheel("PSWBMW", out _);
+            inst.PluginResolver = () => plugin;
+
+            var attempts = 0;
+            inst.LedApplyForTest = (_, __) => ++attempts > 1;   // fails once, then succeeds
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+
+            var saved = (JObject)inst.GetSettings(false, false)!;
+            Assert.Equal(2, attempts);
+            Assert.Equal(3, (int?)saved["itmDefaultPage"]);
+        }
+
+        [Fact]
+        public void RepeatedlyRejectedPayload_StillRefusesToSave()
+        {
+            var inst = InstanceFor("PSWBMW");
+            var plugin = PluginWithWheel("PSWBMW", out _);
+            inst.PluginResolver = () => plugin;
+            inst.LedApplyForTest = (_, __) => false;
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+
+            Assert.Throws<InvalidOperationException>(() => inst.GetSettings(false, false));
+            Assert.Throws<InvalidOperationException>(() => inst.GetSettings(false, false));
         }
 
         [Fact]

--- a/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
@@ -32,20 +32,6 @@ namespace FanaBridge.Tests
             // for the whole process.
             System.IO.Directory.CreateDirectory(System.IO.Path.Combine(
                 AppDomain.CurrentDomain.BaseDirectory, "JavascriptExtensions"));
-
-            // Applying LED settings reaches SimHub's profile subsystem, which
-            // reads the running host (game name, car id) off PluginManager.
-            // Tests have no host, so stand up a bare instance — the fields it
-            // touches read as null/default, which is all these paths need.
-            var field = typeof(SimHub.Plugins.PluginManager)
-                .GetField("Instance", System.Reflection.BindingFlags.Static
-                                    | System.Reflection.BindingFlags.NonPublic
-                                    | System.Reflection.BindingFlags.Public);
-            if (field != null && field.GetValue(null) == null)
-            {
-                field.SetValue(null, System.Runtime.Serialization.FormatterServices
-                    .GetUninitializedObject(typeof(SimHub.Plugins.PluginManager)));
-            }
         }
 
         // ── Wheelbase harness (same fakes as FanatecWheelbaseTests) ───────

--- a/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
@@ -300,8 +300,10 @@ namespace FanaBridge.Tests
         //
         // SimHub rewrites each device's settings file from GetSettings() on every
         // save, with no merge — and it does so even while the plugin is disabled,
-        // when the LED module cannot be built. These pin that a save can never
-        // emit less than it was given.
+        // when the LED module cannot be built. These pin that such a save either
+        // reproduces the loaded document or fails outright, never writing a
+        // partial one. (Once the module owns the settings, roots this build does
+        // not recognise are still dropped; carrying them across is PR 2's job.)
 
         /// <summary>A complete on-disk settings payload, shaped like a real one.</summary>
         private static JObject FullDocument() => new JObject
@@ -460,6 +462,67 @@ namespace FanaBridge.Tests
             // The stashed document — including its unknown roots — reached the module.
             Assert.NotNull(applied);
             Assert.Equal("keep-me", (string?)applied?["futureExtension"]?["nested"]);
+        }
+
+        [Fact]
+        public void FailedHydration_IsRetriedOnce_AndSavingRecovers()
+        {
+            // A transient refusal must not strand the device for the session.
+            var inst = InstanceFor("PSWBMW");
+            var plugin = PluginWithWheel("PSWBMW", out _);
+            inst.PluginResolver = () => plugin;
+
+            var attempts = 0;
+            inst.LedApplyForTest = (_, __) => ++attempts > 1;   // fails once, then succeeds
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+            Assert.Throws<InvalidOperationException>(() => inst.GetSettings(false, false));
+
+            inst.GetDynamicButtonActions();   // next touch retries the payload
+
+            var saved = (JObject)inst.GetSettings(false, false)!;
+            Assert.Equal(2, attempts);
+            Assert.Equal(3, (int?)saved["itmDefaultPage"]);
+        }
+
+        [Fact]
+        public void RepeatedlyRejectedPayload_IsNotRetriedEveryFrame()
+        {
+            // A permanently malformed payload must not be re-parsed per frame.
+            var inst = InstanceFor("PSWBMW");
+            var plugin = PluginWithWheel("PSWBMW", out _);
+            inst.PluginResolver = () => plugin;
+
+            var attempts = 0;
+            inst.LedApplyForTest = (_, __) => { attempts++; return false; };
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+            for (int i = 0; i < 5; i++)
+                inst.GetDynamicButtonActions();
+
+            Assert.Equal(2, attempts);   // the initial apply plus one retry
+            Assert.Throws<InvalidOperationException>(() => inst.GetSettings(false, false));
+        }
+
+        [Fact]
+        public void NewPayloadAfterRejection_GetsAFreshRetry()
+        {
+            var inst = InstanceFor("PSWBMW");
+            var plugin = PluginWithWheel("PSWBMW", out _);
+            inst.PluginResolver = () => plugin;
+
+            var accept = false;
+            inst.LedApplyForTest = (_, __) => accept;
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+            inst.GetDynamicButtonActions();                     // retry budget spent
+            Assert.Throws<InvalidOperationException>(() => inst.GetSettings(false, false));
+
+            accept = true;
+            inst.SetSettings(FullDocument(), isDefault: false); // a new load succeeds
+
+            var saved = (JObject)inst.GetSettings(false, false)!;
+            Assert.Equal(3, (int?)saved["itmDefaultPage"]);
         }
 
         [Fact]

--- a/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
@@ -529,17 +529,48 @@ namespace FanaBridge.Tests
             inst.PluginResolver = () => plugin;
 
             var accept = false;
-            inst.LedApplyForTest = (_, __) => accept;
+            var attempts = 0;
+            inst.LedApplyForTest = (_, __) => { attempts++; return accept; };
 
-            inst.SetSettings(FullDocument(), isDefault: false);
-            inst.GetDynamicButtonActions();                     // retry budget spent
+            inst.SetSettings(FullDocument(), isDefault: false);  // 1: rejected
+            inst.GetDynamicButtonActions();                      // 2: retry, rejected
             Assert.Throws<InvalidOperationException>(() => inst.GetSettings(false, false));
+            Assert.Equal(2, attempts);                           // budget spent
+
+            // A newly loaded payload is a fresh start: it is rejected once and
+            // still gets its own retry, rather than inheriting the exhausted
+            // budget of the payload it replaced.
+            inst.SetSettings(FullDocument(), isDefault: false);  // 3: rejected
+            Assert.Equal(3, attempts);
 
             accept = true;
-            inst.SetSettings(FullDocument(), isDefault: false); // a new load succeeds
+            inst.GetDynamicButtonActions();                      // 4: retry, accepted
 
             var saved = (JObject)inst.GetSettings(false, false)!;
+            Assert.Equal(4, attempts);
             Assert.Equal(3, (int?)saved["itmDefaultPage"]);
+        }
+
+        [Fact]
+        public void PluginArrivingBetweenLoadAndSave_StillSavesEverything()
+        {
+            // The module cannot be built while the plugin is away, so the
+            // loaded payload is held rather than applied. A save taken after
+            // the plugin returns but before anything has rebuilt the module
+            // must still describe the whole document.
+            var inst = InstanceFor("PSWBMW");
+            FanatecPlugin? plugin = null;
+            inst.PluginResolver = () => plugin;
+            inst.LedApplyForTest = (_, __) => true;
+            var doc = FullDocument();
+
+            inst.SetSettings(doc, isDefault: false);
+            plugin = PluginWithWheel("PSWBMW", out _);
+
+            var saved = inst.GetSettings(false, false);
+
+            Assert.True(JToken.DeepEquals(doc, saved),
+                "a save in this order must still reproduce the document, got: " + saved);
         }
 
         [Fact]

--- a/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
+++ b/tests/FanaBridge.Tests/FanatecWheelDeviceInstanceTests.cs
@@ -7,6 +7,7 @@ using FanaBridge.Profiles;
 using FanaBridge.Protocol;
 using FanaBridge.Transport;
 using GameReaderCommon;
+using Newtonsoft.Json.Linq;
 using SimHub.Plugins.Devices;
 using Xunit;
 
@@ -23,6 +24,30 @@ namespace FanaBridge.Tests
     /// </summary>
     public class FanatecWheelDeviceInstanceTests
     {
+        static FanatecWheelDeviceInstanceTests()
+        {
+            // SimHub's Profile static initializer wants a JavascriptExtensions
+            // directory next to the binary (present in every SimHub install,
+            // absent in the test bin) — and a failed type initializer is sticky
+            // for the whole process.
+            System.IO.Directory.CreateDirectory(System.IO.Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory, "JavascriptExtensions"));
+
+            // Applying LED settings reaches SimHub's profile subsystem, which
+            // reads the running host (game name, car id) off PluginManager.
+            // Tests have no host, so stand up a bare instance — the fields it
+            // touches read as null/default, which is all these paths need.
+            var field = typeof(SimHub.Plugins.PluginManager)
+                .GetField("Instance", System.Reflection.BindingFlags.Static
+                                    | System.Reflection.BindingFlags.NonPublic
+                                    | System.Reflection.BindingFlags.Public);
+            if (field != null && field.GetValue(null) == null)
+            {
+                field.SetValue(null, System.Runtime.Serialization.FormatterServices
+                    .GetUninitializedObject(typeof(SimHub.Plugins.PluginManager)));
+            }
+        }
+
         // ── Wheelbase harness (same fakes as FanatecWheelbaseTests) ───────
 
         private sealed class FakeTransport : IConnectableTransport
@@ -269,6 +294,236 @@ namespace FanaBridge.Tests
             inst.DataUpdate(null, ref data);
 
             Assert.Same(pluginA, inst.BoundPluginForTest);
+        }
+
+        // ── Settings persistence (device settings wipe) ────────────────────
+        //
+        // SimHub rewrites each device's settings file from GetSettings() on every
+        // save, with no merge — and it does so even while the plugin is disabled,
+        // when the LED module cannot be built. These pin that a save can never
+        // emit less than it was given.
+
+        /// <summary>A complete on-disk settings payload, shaped like a real one.</summary>
+        private static JObject FullDocument() => new JObject
+        {
+            ["ledModuleSettings"] = new JObject
+            {
+                ["Brightness"] = 80.0,
+                ["IndividualLEDsMode"] = false,
+            },
+            ["leds"] = new JObject
+            {
+                ["activeProfileId"] = "profile-abc",
+                ["profiles"] = new JArray { new JObject { ["Id"] = "profile-abc" } },
+            },
+            ["buttons"] = new JObject { ["activeProfileId"] = "buttons-1" },
+            // Channels SimHub emits as null when no driver exists for them.
+            ["encoders"] = JValue.CreateNull(),
+            ["matrix"] = JValue.CreateNull(),
+            ["raw"] = new JObject { ["activeProfileId"] = "raw-1" },
+            ["wheelType"] = "PSWBMW",
+            ["moduleType"] = "",
+            ["displayMode"] = "speed",
+            ["itmEnabled"] = true,
+            ["itmShowLapTotal"] = false,
+            ["itmShowPositionTotal"] = true,
+            ["itmDefaultPage"] = 3,
+            // A root this build does not know about (a newer/older FanaBridge, or
+            // an unmerged feature branch). It must survive a round trip.
+            ["futureExtension"] = new JObject { ["nested"] = "keep-me" },
+        };
+
+        [Fact]
+        public void PluginUnavailable_GetSettings_ReturnsTheWholeDocument()
+        {
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+            var doc = FullDocument();
+
+            inst.SetSettings(doc, isDefault: false);
+            var saved = inst.GetSettings(false, false);
+
+            Assert.True(JToken.DeepEquals(doc, saved),
+                "Saving with the plugin disabled must reproduce the loaded document, got: " + saved);
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public void PluginUnavailable_EveryFlagCombination_ReturnsTheWholeDocument(
+            bool forTemplate, bool forDefaultSettings)
+        {
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+            var doc = FullDocument();
+
+            inst.SetSettings(doc, isDefault: false);
+            var saved = inst.GetSettings(forTemplate, forDefaultSettings);
+
+            Assert.True(JToken.DeepEquals(doc, saved),
+                $"flags({forTemplate},{forDefaultSettings}) must not drop settings, got: " + saved);
+        }
+
+        [Fact]
+        public void PluginUnavailable_UnknownRootsSurvive()
+        {
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+            var saved = (JObject)inst.GetSettings(false, false)!;
+
+            Assert.Equal("keep-me", (string?)saved["futureExtension"]?["nested"]);
+        }
+
+        [Fact]
+        public void PluginUnavailable_NullChannelsAreNotDropped()
+        {
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+            var saved = (JObject)inst.GetSettings(false, false)!;
+
+            Assert.Equal(JTokenType.Null, saved["encoders"]?.Type);
+            Assert.Equal(JTokenType.Null, saved["matrix"]?.Type);
+        }
+
+        [Fact]
+        public void FailedHydration_RefusesToSave()
+        {
+            // A payload the module cannot consume leaves it partially populated;
+            // saving it would overwrite a complete file with an incomplete one.
+            var inst = InstanceFor("PSWBMW");
+            var plugin = PluginWithWheel("PSWBMW", out _);
+            inst.PluginResolver = () => plugin;
+            inst.LedApplyForTest = (_, __) => false;   // module refuses the payload
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+
+            Assert.Throws<InvalidOperationException>(() => inst.GetSettings(false, false));
+        }
+
+        [Fact]
+        public void FailedHydration_ThenDefaults_SavesAgain()
+        {
+            // An explicit reset makes the module authoritative again.
+            var inst = InstanceFor("PSWBMW");
+            var plugin = PluginWithWheel("PSWBMW", out _);
+            inst.PluginResolver = () => plugin;
+            inst.LedApplyForTest = (_, __) => false;
+            inst.LedDefaultsForTest = () => { };
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+            Assert.Throws<InvalidOperationException>(() => inst.GetSettings(false, false));
+
+            inst.LoadDefaultSettings();
+
+            // No longer refuses; the reset cleared the unapplied payload.
+            var saved = (JObject)inst.GetSettings(false, false)!;
+            Assert.Equal("PSWBMW", (string?)saved["wheelType"]);
+        }
+
+        [Fact]
+        public void SuccessfulHydration_DoesNotRefuseToSave()
+        {
+            var inst = InstanceFor("PSWBMW");
+            var plugin = PluginWithWheel("PSWBMW", out _);
+            inst.PluginResolver = () => plugin;
+            inst.LedApplyForTest = (_, __) => true;    // module accepts the payload
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+
+            var saved = (JObject)inst.GetSettings(false, false)!;
+            Assert.Equal(3, (int?)saved["itmDefaultPage"]);
+        }
+
+        [Fact]
+        public void PluginArrivesAfterLoad_TheStashHydratesTheModule()
+        {
+            var inst = InstanceFor("PSWBMW");
+            FanatecPlugin? plugin = null;
+            inst.PluginResolver = () => plugin;
+            JObject? applied = null;
+            inst.LedApplyForTest = (doc, __) => { applied = doc; return true; };
+
+            // Loaded while disabled — nothing to apply to yet …
+            inst.SetSettings(FullDocument(), isDefault: false);
+            Assert.Null(applied);
+
+            // … then the plugin comes up and SimHub asks for the settings tab.
+            plugin = PluginWithWheel("PSWBMW", out _);
+            inst.GetDynamicButtonActions();   // any module-touching call builds it
+
+            // The stashed document — including its unknown roots — reached the module.
+            Assert.NotNull(applied);
+            Assert.Equal("keep-me", (string?)applied?["futureExtension"]?["nested"]);
+        }
+
+        [Fact]
+        public void PluginArrivesAfterLoad_FailedHydrationKeepsTheStash()
+        {
+            var inst = InstanceFor("PSWBMW");
+            FanatecPlugin? plugin = null;
+            inst.PluginResolver = () => plugin;
+            inst.LedApplyForTest = (_, __) => false;
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+            plugin = PluginWithWheel("PSWBMW", out _);
+            inst.GetDynamicButtonActions();   // any module-touching call builds it
+
+            // Hydration failed, so the module must not become authoritative.
+            Assert.Throws<InvalidOperationException>(() => inst.GetSettings(false, false));
+        }
+
+        [Fact]
+        public void FreshDeviceWhileDisabled_SavesDefaultsWithoutThrowing()
+        {
+            // No prior document exists: emitting just the custom defaults is
+            // correct, and throwing would leave the new device without a file.
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+
+            inst.LoadDefaultSettings();
+            var saved = (JObject)inst.GetSettings(false, false)!;
+
+            Assert.Equal("PSWBMW", (string?)saved["wheelType"]);
+            Assert.Null(saved["ledModuleSettings"]);
+        }
+
+        [Fact]
+        public void ResetWhileDisabled_DropsTheStashedLedPayload()
+        {
+            var inst = InstanceFor("PSWBMW");
+            inst.PluginResolver = () => null;
+
+            inst.SetSettings(FullDocument(), isDefault: false);
+            inst.LoadDefaultSettings();
+
+            var saved = (JObject)inst.GetSettings(false, false)!;
+            Assert.Null(saved["leds"]);
+            Assert.Null(saved["futureExtension"]);
+        }
+
+        [Fact]
+        public void DisplayOnlyDevice_SerializesWithoutLedModule()
+        {
+            var inst = InstanceFor("CSLSWGT3");
+            var plugin = PluginWithWheel("CSLSWGT3", out _);
+            inst.PluginResolver = () => plugin;
+
+            inst.SetSettings(new JObject
+            {
+                ["wheelType"] = "CSLSWGT3",
+                ["displayMode"] = "speed",
+                ["itmDefaultPage"] = 2,
+            }, isDefault: false);
+
+            var saved = (JObject)inst.GetSettings(false, false)!;
+            Assert.Equal("speed", (string?)saved["displayMode"]);
+            Assert.Equal(2, (int?)saved["itmDefaultPage"]);
         }
     }
 }

--- a/tests/FanaBridge.Tests/xunit.runner.json
+++ b/tests/FanaBridge.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Fixes #91.

## The problem

SimHub rewrites each device's settings file from `GetSettings()` on every save — wholesale, with no merge against what is on disk. It does this whether or not FanaBridge is running, because it finds device types by scanning assemblies rather than consulting the list of enabled plugins.

FanaBridge only built its LED settings module once `FanatecPlugin.Instance` existed. A save taken before that — most obviously with the plugin disabled — returned a document with no LED data, which replaced a 10–16 KB settings file with a ~450-byte stub. Hand-built LED profiles were lost.

## What this does

Containment only. The lifecycle change that makes this structurally impossible is #90, stacked on top of this branch.

- While the module cannot exist, `GetSettings()` echoes the loaded document verbatim. Nothing can edit LED settings in that state and an explicit reset drops the payload, so what is echoed is always the user's current settings.
- Hydration failures were silent: the apply result was discarded while both callers cleared the pending payload, leaving a partly populated module authoritative. It now reports failure and the payload is kept.
- A save while a payload is pending throws instead of persisting an incomplete document. Verified against SimHub 9.11.21: the per-device save is wrapped in `try`/`catch` and the device's index entry is written *before* serialization, so a throw leaves both the existing file and its index entry intact — the settings directory is not cleaned up as an orphan.
- A rejected payload gets one more attempt on the next call that touches the module, including the save itself. Without that, a device that never became connected stayed unable to save for the rest of the session over a failure that may have been momentary.

## Scope

This does **not** fix the losses that happen once the module *is* the owner — unrecognised settings being dropped on reload, and LED data for channels the current wheel cannot drive being deleted. Those are addressed in the follow-up.

## Testing

602 → 622 tests, 0 warnings. New coverage: full-document round trip with the plugin unavailable across all four flag combinations, unknown roots surviving, null channels not dropped, failed hydration blocking the save, the retry being spent exactly once per payload, a fresh device saving defaults without throwing, and reset clearing the stash.