### PR TITLE
Drive GTSWPRO rev LEDs as on/off, not per-LED colour

### DIFF
--- a/src/FanaBridge.Core/Resources/Profiles/GTSWPRO.json
+++ b/src/FanaBridge.Core/Resources/Profiles/GTSWPRO.json
@@ -10,14 +10,14 @@
   "display": "basic",
   "verified": false,
   "leds": [
-    { "channel": "legacyRev3Bit", "hwIndex": 0, "role": "rev", "label": "Rev LED 1" },
-    { "channel": "legacyRev3Bit", "hwIndex": 1, "role": "rev", "label": "Rev LED 2" },
-    { "channel": "legacyRev3Bit", "hwIndex": 2, "role": "rev", "label": "Rev LED 3" },
-    { "channel": "legacyRev3Bit", "hwIndex": 3, "role": "rev", "label": "Rev LED 4" },
-    { "channel": "legacyRev3Bit", "hwIndex": 4, "role": "rev", "label": "Rev LED 5" },
-    { "channel": "legacyRev3Bit", "hwIndex": 5, "role": "rev", "label": "Rev LED 6" },
-    { "channel": "legacyRev3Bit", "hwIndex": 6, "role": "rev", "label": "Rev LED 7" },
-    { "channel": "legacyRev3Bit", "hwIndex": 7, "role": "rev", "label": "Rev LED 8" },
-    { "channel": "legacyRev3Bit", "hwIndex": 8, "role": "rev", "label": "Rev LED 9" }
+    { "channel": "legacyRevOnOff", "hwIndex": 0, "role": "rev", "label": "Rev LED 1" },
+    { "channel": "legacyRevOnOff", "hwIndex": 1, "role": "rev", "label": "Rev LED 2" },
+    { "channel": "legacyRevOnOff", "hwIndex": 2, "role": "rev", "label": "Rev LED 3" },
+    { "channel": "legacyRevOnOff", "hwIndex": 3, "role": "rev", "label": "Rev LED 4" },
+    { "channel": "legacyRevOnOff", "hwIndex": 4, "role": "rev", "label": "Rev LED 5" },
+    { "channel": "legacyRevOnOff", "hwIndex": 5, "role": "rev", "label": "Rev LED 6" },
+    { "channel": "legacyRevOnOff", "hwIndex": 6, "role": "rev", "label": "Rev LED 7" },
+    { "channel": "legacyRevOnOff", "hwIndex": 7, "role": "rev", "label": "Rev LED 8" },
+    { "channel": "legacyRevOnOff", "hwIndex": 8, "role": "rev", "label": "Rev LED 9" }
   ]
 }


### PR DESCRIPTION
Closes #77.

## What was wrong

`GTSWPRO.json` declared its nine rev LEDs as `legacyRev3Bit` (per-LED colour). The GT DD PRO rev strip is fixed-colour hardware, so that colour data cannot do anything useful.

This was a silent regression, not an original mistake. The profile shipped **correct** in `72d2c21` (2026-03-27), then one day later `ea97718` — *"Add supported devices doc and simplify README device list"* — flipped all nine channels while otherwise touching only docs. That is why it never appeared as a reviewable diff.

The docs half of that commit stayed right, which is why `docs/reference/devices.md` already disagrees with the profile and needs no change here:

- line 200 — `GTSWPRO | 9 | Non-RGB | Legacy (col01)`
- line 324 — listed under `Legacy Non-RGB (bitmask)`

## The change

Nine channels `legacyRev3Bit` → `legacyRevOnOff`, `hwIndex` 0-8 unchanged. Colours then come from the hardware and SimHub's colour choice correctly reduces to lit/unlit.

This is a byte-for-byte restore of the pre-regression file — git reports the blob moving `ce5e7a8..3eae09f`, the exact inverse of what `ea97718` recorded.

## `legacyRev3Bit` is now unused, deliberately

No shipped profile references it any more; the only remaining hit under `Resources/Profiles/` is the `wheel-profile.schema.json` enum, which is correct to keep as a valid channel.

Per the issue's explicit note, **the encoding stays implemented** — the subcmd 0x0A path, buffers, caps flags and `SettingsControl` UI branch in `FanatecLedDriver.cs` are all untouched. It is a real, tested encoding that no wheel we can currently talk to needs.

## Verification

Full suite green — **623 passed, 0 failed**.

Not verified on hardware — `"verified": false` still stands in the profile.